### PR TITLE
Observaciones a Team review

### DIFF
--- a/docs/guides/platform/team-review.md
+++ b/docs/guides/platform/team-review.md
@@ -33,7 +33,7 @@ Si bien la aprobación se encuentra limitada, cualquier usuario con permisos pue
 - **Forzar revisión**: Esta opción permite seleccionar una lista de usuarios, de los cuales se requiere al menos una aprobación para que el elemento pueda pasar al estado "Aprobado". Esto es independiente del número de aprobaciones configurado anteriormente, es decir, aunque un elemento tenga la cantidad de aprobaciones necesarias, seguirá en estado "Esperando aprobación" si ningún usuario de la lista lo ha aprobado.
 - **Requerir todos**: Esta opción extiende la restricción anterior a todos los usuarios seleccionados.
 
-:::warning
+:::warning Atención
 Cuando haces cambios en la configuración de revisión en equipo, los elementos que ya estaban esperando revisión seguirán rigiéndose por las reglas anteriores a los cambios. Para que esos elementos tomen en cuenta la nueva configuración, es necesario que sean rechazados y enviados a revisión nuevamente.
 :::
 

--- a/docs/guides/platform/team-review.md
+++ b/docs/guides/platform/team-review.md
@@ -6,58 +6,52 @@ search: true
 
 ## Introducción
 
-La revisión en equipo (o Team Review) es una herramienta que te permite controlar de forma colaborativa los elementos que son publicados en Modyo. Esta herramienta se puede activar tanto a nivel de sitio, como a nivel de espacio, permitiéndote usar distintas configuraciones y niveles de restricción, dependiendo de lo estricto que quieras ser en cada caso.
+La revisión en equipo (o Team review) es una herramienta que permite controlar el proceso de publicación de elementos en Modyo. Al activarla, cada elemento debe pasar por etapas de revisión antes de habilitar su publicación. De esta manera, se agrega un nivel de supervisión y colaboración entre el editor de contenidos y un equipo de revisores.
 
-Para activar la herramienta, debes dirigirte a la configuración del sitio o espacio, y hacer click en la opción "Revisión en equipo", seleccionar la primera opción "Habilitar revisión en equipo" y luego guardar los cambios.
+Cuando un editor o un desarrollador considera que el elemento en el que está trabajando se encuentra listo, puede enviarlo a revisión, tarea que será realizada por usuarios habilitados para ello o por un equipo escogido por él mismo. Ellos serán los responsables de aprobar (o rechazar) el elemento, lo que determinará finalmente si el elemento está en condiciones de ser publicado.
 
-Una vez activada la revisión en equipo, notarás que cuando guardas los cambios en un elemento, en vez de aparecer el botón **Publicar**, cambiará al botón **Enviar a revisión**. Al enviar a revisión un elemento, quedará en un estado en el que se puede seguir modificando, pero además, podrás asignar revisores, quienes podrán aprobar, rechazar y hacer comentarios en el elemento.
+Cada paso de este proceso lleva al elemento por distintos estados (imagen), los cuales quedan registrados en un historial para su posterior auditoría.
 
-Bajo el estado "En revisión", cada acción que se haga sobre el elemento, gatillará una notificación a todos los involucrados en el proceso de revisión (quién lo envió a revisión y todos los revisores asignados), de tal forma de mantener a tu equipo al tanto sobre los cambios y comentarios del elemento.
-
-Una vez que se cumplen los requisitos para que el elemento sea publicado, automáticamente cambia al estado "Aprobado", y quienes tengan los permisos necesarios, podrán publicar el elemento.
+[Imagen de etapas de revisión]
+ 
+Esta herramienta está disponible tanto para sitios (páginas, navegación, widgets y templates) como para espacios (entries). La configuración de reglas de revisión se realiza de manera independiente para cada sitio o espacio.
 
 ### Configuración
 
+Para configurar la herramienta, debes dirigirte a `Configuración del sitio/espacio > Revisión en equipo`.
+
 <img src="/assets/img/platform/teamreviewsettings.jpg" width="500px" style="margin-top: 40px; border: 1px solid #EEE;" />
 
-Dentro de la configuración de la revisión en equipo, encontrarás distintas opciones:
+Las opciones disponibles son:
 
-- **Habilitar revisión en equipo**: Es la opción que habilita o deshabilita por completo la revisión en equipo en ese contexto (sitio o espacio)
-- **Número de aprobaciones**: Determina cuántas son las aprobaciones (checks) necesarias para que un elemento pase automáticamente de "Esperando revisión" a "Aprobado". De esta forma, si seleccionas 3, se requerirá que 3 personas con permisos den su aprobación para que ese elemento pueda ser publicado.
+- **Habilitar revisión en equipo**: Activa o desactiva por completo la revisión en equipo en este contexto (sitio o espacio).
+- **Número de aprobaciones**: Determina cuántos usuarios deben aprobar el elemento para que esté en condiciones de ser publicado (cambiará su estado de "Esperando revisión" a "Aprobado").
+- **Restringir la selección de revisores**: Por defecto, cualquier usuario con los permisos necesarios podrá aprobar los elementos que están esperando revisión. Habilitando esta opción, sólo aquellos escogidos por el editor podrán hacerlo.
 :::tip Tip
- Por defecto, cualquier usuario que tenga los permisos necesarios, podrá aprobar y comentar en los elementos que están esperando revisión. Cuando un usuario que no está asignado como revisor aprueba un elemento, automáticamente se convierte en revisor del elemento. 
+Si bien la aprobación se encuentra limitada, cualquier usuario con permisos puede hacer comentarios sobre el elemento.
 :::
-- **Restringir la selección de revisores**: Esta opción evita que cualquier usuario con permisos pueda aprobar el elemento, limitando la selección y adición de revisores a quien envía el elemento a revisión.
-:::tip Tip
-Aunque la selección de revisores esté limitada a quien envía a revisión, todos los usuarios con permisos podrán seguir haciendo comentarios en el elemento que está en revisión, pero no podrán aprobar el elemento.
-:::
-- **Forzar revisión**: Esta opción habilita un selector de usuarios que permite forzar la adición de ciertos revisores a los elementos del contexto, de tal forma que en cada revisión, todos los usuarios asociados a la fuerza serán notificados de los comentarios y cambios del elemento.
-:::tip Tip
-Aunque se cumpla la primera restricción con la cantidad de aprobaciones, si ninguno de los usuarios forzados a revisar ha dado su aprobación, entonces el elemento no pasará a estado "Aprobado", por lo que no podrá ser publicado.
-:::
-- **Requerir todos**: Esta opción obliga a que, como mínimo, todos los usuarios que estén añadidos como revisores forzados tengan que dar su aprobación para que el elemento pase a estado "Aprobado" y luego pueda ser publicado.
+- **Forzar revisión**: Esta opción permite seleccionar una lista de usuarios, de los cuales se requiere al menos una aprobación para que el elemento pueda pasar al estado "Aprobado". Esto es independiente del número de aprobaciones configurado anteriormente, es decir, aunque un elemento tenga la cantidad de aprobaciones necesarias, seguirá en estado "Esperando aprobación" si ningún usuario de la lista lo ha aprobado.
+- **Requerir todos**: Esta opción extiende la restricción anterior a todos los usuarios seleccionados.
 
-::: warning Atención
-Recuerda hacer click en el botón **Guardar** arriba a la derecha cada vez que hagas cambios en la configuración de la revisión en equipo, de lo contrario, los cambios no surtirán efecto.
+:::warning
+Cuando haces cambios en la configuración de revisión en equipo, los elementos que ya estaban esperando revisión seguirán rigiéndose por las reglas anteriores a los cambios. Para que esos elementos tomen en cuenta la nueva configuración, es necesario que sean rechazados y enviados a revisión nuevamente.
 :::
 
-::: warning Atención
-Cuando haces cambios en la configuración de la revisión en equipo, los elementos que ya estaban esperando revisión seguirán rigiéndose por las reglas anteriores a los cambios. Para que esos elementos tomen en cuenta la nueva configuración de la revisión en equipo, es necesario que sean rechazados y se vuelvan a enviar a revisión.
-:::
+### Uso (ejemplo)
 
 ### Roles y permisos
 
-Existen tres niveles de permisos en los contextos en que se puede habilitar la revisión en equipo:
+Existen tres niveles de roles que permiten a los usuarios realizar distintas acciones en el proceso de revisión:
 
-- Alto (Administrador de sitio y espacio)
-- Medio (Revisor en sitios y Editor en espacio)
-- Bajo (Developer en sitios y Escritor en espacios)
+- Alto: Administrador (sitio o espacio)
+- Medio: Revisor (sitio) o Editor (espacio)
+- Bajo: Desarrollador (sitio) o Escritor (espacio)
 
-Los usuarios con el rol más bajo, aparte de los permisos asociados al contexto, pueden enviar a revisión y comentar los elementos que se encuentran en este estado.
+Los usuarios con el rol más bajo, pueden enviar a revisión y comentar los elementos que se encuentran en ese estado.
 
 Los usuarios con el rol intermedio, además de lo anterior, pueden aprobar los elementos en revisión y una vez que estos estén aprobados, pueden publicarlos mediante el flujo de revisión en equipo.
 
-Los usuarios con el nivel de permisos alto, además de poder hacer el resto de las acciones, pueden saltarse el flujo de revisión y hacer uso de la acción "Forzar publicación" para publicar inmediatamente un elemento.
+Los usuarios con el nivel más alto, además de realizar todo lo anterior, pueden saltarse el flujo de revisión y hacer uso de la acción "Forzar publicación" para publicar inmediatamente un elemento.
 
 ::: warning Atención
 Los administradores de sitio o espacio siempre tienen la posibilidad de saltarse el flujo de revisión en equipo. Para ellos, los botones "Enviar a revisión" y "Revisar" tienen una opción dentro del dropdown para "Forzar publicación". Esta opción existe porque hay ocasiones en las que es necesario publicar rápidamente, por lo que debes ser cauteloso cuando asignas los roles para tus espacios o sitios.
@@ -73,47 +67,45 @@ Al momento de enviar a revisión la barra cambiará de estado:
 
 <img src="/assets/img/platform/missing-conditions-team-review.jpg" width="350px" style="border: 1px solid #EEE;" />
 
-Al hacer click, verás que sobre la sección lateral derecha del builder aparecerá una sección nueva, indicando los requerimientos necesarios para poder publicar el elemento. En caso de tener algún revisor requerido, aparecerá `(requerido)` junto a su nombre en el listado de revisores.
+Al hacer click, verás que en la sección lateral derecha se indicarán los requerimientos para publicar el elemento. En caso de existir algún revisor requerido, aparecerá `(requerido)` junto a su nombre en el listado de revisores.
 
 <img src="/assets/img/platform/box-reviewers.jpg" width="500px" style="border: 1px solid #EEE;" />
 
 A la derecha de cada revisor, aparecerá el estado de su revisión, mostrando un círculo amarillo si no ha hecho su revisión, y un check verde en caso de haber aprobado el elemento.
 
-Todos quienes puedan acceder a la vista de edición del elemento, verán un botón **Aprobar** bajo el listado de revisores, y quienes tengan permiso para hacerlo lo verán activo y podrán hacer click para aprobar el elemento. Además, los usuarios que no cuenten con dicho permiso verán el botón deshabilitado.
+Todos quienes puedan acceder a la vista de edición del elemento, verán un botón "Aprobar" bajo el listado de revisores. Quienes tengan el permiso necesario, lo verán activo y podrán hacerle click para aprobar el elemento, quienes no tengan permiso, verán el botón deshabilitado.
 
-Al aprobar el elemento, quedará registrada la aprobación por ese usuario, mostrando un check verde a la derecha de su nombre en el listado de revisores.
+Al aprobar el elemento, quedará registrada la aprobación de ese usuario, mostrando un check verde a la derecha de su nombre en el listado de revisores.
 
-Cuando se habilita la revisión en equipo, en la barra de acciones del elemento, a la izquierda del botón principal de color verde y a la derecha del botón de diferencias, aparecerá un ícono ( <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1em" height="1em" style="-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path d="M12 23a1 1 0 0 1-1-1v-3H7a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-4.1l-3.7 3.71c-.2.18-.44.29-.7.29H12m1-6v3.08L16.08 17H21V7H7v10h6M3 15H1V3a2 2 0 0 1 2-2h16v2H3v12m6-6h10v2H9V9m0 4h8v2H9v-2z" fill="#626262"/><rect x="0" y="0" width="24" height="24" fill="rgba(0, 0, 0, 0)" /></svg> ) para abrir la pestaña de actividad del elemento. Al abrirla, se desplegará un listado cronológico de las acciones que se han efectuado sobre el elemento, con la opción para ver el detalle de la acción, y al fondo de la pestaña, estará la opción para dejar un mensaje.
+Cuando se habilita la revisión en equipo, en la barra de acciones del elemento, a la izquierda del botón principal de color verde y a la derecha del botón de diferencias, aparecerá un ícono ( <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1em" height="1em" style="-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path d="M12 23a1 1 0 0 1-1-1v-3H7a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-4.1l-3.7 3.71c-.2.18-.44.29-.7.29H12m1-6v3.08L16.08 17H21V7H7v10h6M3 15H1V3a2 2 0 0 1 2-2h16v2H3v12m6-6h10v2H9V9m0 4h8v2H9v-2z" fill="#626262"/><rect x="0" y="0" width="24" height="24" fill="rgba(0, 0, 0, 0)" /></svg> ) para abrir la pestaña de actividad del elemento. Al abrirla, se desplegará un listado cronológico de las acciones que se han efectuado sobre el elemento, con la opción para ver el detalle de la acción, y al fondo de la pestaña, estará la opción para dejar un comentario.
 
-Cuando se deja un mensaje o comentario en un elemento, quien envió a revisión y todos los usuarios que están en el listado de revisores serán notificados sobre el comentario y/o modificación del elemento.
+Cuando se deja un comentario o se ejecuta alguna acción sobre el elemento, se envía una notificación tanto a quien envió a revisión como a los usuarios que están en la lista de revisores.
 
 ## Versionado
 
-El Versionado es una manera automática de Modyo de asegurarse el respaldo de los recursos ante cualquier cambio hecho desde la misma web.
+Como mecanismo de respaldo, al momento de publicar un elemento, Modyo genera y mantiene automáticamente un número de versiones que posteriormente pueden ser recuperadas en caso de ser necesario.
 
-En palabras simples, si por error se llega a hacer un cambio indebido, es posible revertirlo a través de la plataforma.
+Esto es útil cuando por alguna razón se realiza un cambio indebido, existe la posibilidad de revertirlo a través de la plataforma.
 
-Este sistema está disponible para ser usado en Widgets, Pages, Navegación, Templates y Contenido.
+Este sistema está disponible para Widgets, Pages, Navegación, Templates y Contenido.
 
 ### Versiones de los recursos
 
 #### Editable
 
-Cuando un recurso está en proceso de creación queda en estado de "Editable", y es posible realizar en él modificaciones hasta que no se confirme que se encuentra listo para su revisión y publicación.
-
-Además, es posible revisar vistas previas de los cambios realizados antes de ser publicado.
+Esta versión mantiene los cambios hechos en el elemento desde su última publicación o desde su creación si nunca ha sido publicado. Es esta la versión que pasa por el proceso de revisión en equipo cuando está activada, y justo en el momento de la publicación, las versiones "Editable" y "Publicada" poseen el mismo contenido.
 
 #### Publicado
 
-El recurso publicado es aquel que ya se encuentra visible en el sitio y es de libre disponibilidad para cualquier usuario. En este caso, recursos internos como Widgets y Templates ya se pueden usar dentro de la creación de cualquier sitio o página.
+Esta versión guarda el contenido visible en el sitio y es de libre disponibilidad para cualquier usuario. En este caso, recursos internos como Widgets y Templates ya se pueden usar en la creación de cualquier sitio o página.
 
-Los recursos publicados no necesariamente tienen el mismo código que los editables, ya que estos últimos pueden contener cambios que estén en proceso de prueba o de vista previa.
+La versión publicada no necesariamente tiene el mismo contenido que la editable (excepto en el momento justo de la publicación), ya que esta última puede contener cambios que estén en proceso de prueba o revisión.
 
 ### Respaldos
 
-Los respaldos son las versiones de los elementos que se han guardado anteriormente. Es decir, cada vez que publicamos un elemento, Modyo guarda la versión publicada anteriormente como un respaldo.
+Los respaldos son versiones previamente publicadas de los elementos. Es decir, cada vez que publicamos un elemento, Modyo guarda la versión publicada anteriormente como un respaldo.
 
-Si deseas revisar alguna versión en particular de algún recurso, puedes ir a las "Diferencias entre versiones" de cada elemento, y así poder ver los cambios que se han realizado y revertirlos cuando sea necesario.
+Si deseas revisar alguna versión en particular de un elemento, puedes ir a las "Diferencias entre versiones", y así poder ver los cambios que se han realizado y revertirlos cuando sea necesario.
 
 ::: warning Atención
 Por defecto, Modyo guarda las últimas 20 versiones (`MAX_BACKUPS`) publicadas de cada elemento, por lo que al hacer la vigésimoprimera publicación, estarás borrando el respaldo de la primera publicación del elemento. Este valor se puede modificar mediante variables de entorno y es común para todas la cuentas de ese entorno.
@@ -125,9 +117,9 @@ Dentro del versionado cuentas con dos acciones que te permiten interactuar con l
 
 ![Modal de diferencias](/assets/img/platform/differences.png)
 
-Por defecto el modal de diferencias muestra la versión publicada a la izquierda, y la versión editable a la derecha. Puedes cambiar que versiones comparar, cambiando los valores seleccionados en los selectores de versiones en la parte superior del modal. 
+Por defecto el modal de diferencias muestra la versión publicada a la izquierda, y la versión editable a la derecha. Puedes cambiar qué versiones comparar, cambiando los valores en los selectores de versiones en la parte superior del modal. 
 
-Cuando se aplica alguna de las acciones, siempre se toma la versión seleccionada a la izquierda, de tal forma que si se reestablece, se llevará la versión seleccionada a la izquierda a la versión editable, y si se hace rollback, se llevará la versión seleccionada a la izquierda de la versión publicada.
+Cuando se aplica alguna de las acciones, siempre se toma la versión seleccionada a la izquierda, de tal forma que si se reestablece, se llevará la versión de la izquierda a la versión editable, y si se hace rollback, se llevará la versión de la izquierda de la versión publicada.
 
 #### Reestablecer
 
@@ -138,7 +130,7 @@ En este caso, el respaldo se copiará a la versión editable, por lo que perdere
 En este caso, el respaldo se copiará directamente a la versión publicada del elemento, sin tocar la versión editable. Esto es especialmente útil cuando se publicó algo por error, y es necesario volver a alguna de las versiones estables rápidamente, mientras se sigue trabajando en resolver los problemas que la versión con errores pudo haber tenido.
 
 ::: danger Peligro
-Dado que esta es una acción potencialmente peligrosa, solo los administradores de Sitios o Espacios tienen el permiso para poder ejecutar esta acción.
+Dado que esta es una acción potencialmente peligrosa, sólo los administradores de sitios o espacios tienen el permiso para poder ejecutar esta acción.
 :::
 
 ## Locks
@@ -147,26 +139,26 @@ Locks es una funcionalidad de Modyo que permite modificar un recurso de manera s
 
 <img src="/assets/img/platform/locks.jpg" style="border: 1px solid #EEE;" />
 
-### ¿Qué usa Locks?
+### ¿Qué elementos usan Locks?
 
-Locks se usan mayoritariamente en [Contenidos](/guides/content/) y en [Channels](/guides/channels/), pero también puede ser usado en otras secciones donde se editan elementos como Configuraciones y [Customers](/guides/customers/).
+Locks se usa mayoritariamente en [Contenidos](/guides/content/) y en [Channels](/guides/channels/), pero también puede ser usado en otras secciones donde se editan elementos como Configuraciones y [Customers](/guides/customers/).
 
 ### ¿Cómo usar Locks?
 
-Locks se implementa de distintas maneras dentro de la plataforma. En [Contenidos](/guides/content/) y [Channels](/guides/channels/), múltiples usuarios pueden entrar a un recurso, siendo solo uno el que podrá editar y guardar esos cambios, mientras que los demás solo verán la última versión guardada en la plataforma. Si una segunda persona intenta hacer un cambio, le aparecerá un mensaje indicando que el elemento ya tiene cambios y que lo que está intentando modificar está obsoleto.
+Locks se implementa de distintas maneras dentro de la plataforma. En [Contenidos](/guides/content/) y [Channels](/guides/channels/), múltiples usuarios pueden entrar a un recurso, siendo sólo uno el que podrá editar y guardar esos cambios, mientras que los demás sólo verán la última versión guardada en la plataforma. Si una segunda persona intenta hacer un cambio, le aparecerá un mensaje indicando que el elemento ya tiene cambios y que lo que está intentando modificar está obsoleto.
 
-En otras secciones como [Customers](/guides/customers/) y Configuraciones, Locks no permitirán la visión simultánea del recurso, por lo que si este se encuentra en edición, otro usuario no podrá ingresar a la vista de trabajo.
+En otras secciones como [Customers](/guides/customers/) y Configuraciones, Locks no permitirá la visión simultánea del recurso, por lo que si éste se encuentra en edición, otro usuario no podrá ingresar a la vista de trabajo.
 
-En este caso, solo un Administrador podrá tomar el control, activando para sí mismo la edición y descartándose los avances no guardados del usuario que se encuentra trabajando en él.
+En este caso, sólo un Administrador podrá tomar el control, activando para sí mismo la edición y descartándose los avances no guardados del usuario que se encuentra trabajando en él.
 
 
 ::: warning Tomar el control
 
-Si un Administrador quiere tomar el control de una vista, deberá hacer click en el elemento en uso y en la pantalla siguiente, hacer click en el botón de **Tomar Control**.
+Si un Administrador quiere tomar el control de una vista, deberá hacer click en el elemento en uso y en la pantalla siguiente, hacer click en el botón **Tomar Control**.
 
 <img src="/assets/img/platform/lock-forms.jpg" style="border: 1px solid #EEE;" />
 
-Cuando el Administrador tome el control, el usuario que esté usando el recurso recibirá un mensaje en el que se le impedirá seguir haciendo más cambios, por lo que cualquier cambio que se esté realizando, deberá ser guardado y respaldado offline.
+Cuando el Administrador tome el control, el usuario que esté usando el recurso recibirá un mensaje en el que se le impedirá seguir haciendo cambios, por lo que cualquier cambio que se esté realizando, deberá ser guardado y respaldado offline.
 
-Tras tomar el control, el Administrador solo tendrá dos horas para hacer cambios sin guardar. Pasado ese tiempo, el recurso volverá a liberarse y podrá ser tomado por cualquier otro usuario.
+Tras tomar el control, el Administrador sólo tendrá dos horas para hacer cambios sin guardar. Pasado ese tiempo, el recurso volverá a liberarse y podrá ser tomado por cualquier otro usuario.
 :::

--- a/docs/guides/platform/team-review.md
+++ b/docs/guides/platform/team-review.md
@@ -119,7 +119,7 @@ Dentro del versionado cuentas con dos acciones que te permiten interactuar con l
 
 Por defecto el modal de diferencias muestra la versión publicada a la izquierda, y la versión editable a la derecha. Puedes cambiar qué versiones comparar, cambiando los valores en los selectores de versiones en la parte superior del modal. 
 
-Cuando se aplica alguna de las acciones, siempre se toma la versión seleccionada a la izquierda, de tal forma que si se reestablece, se llevará la versión de la izquierda a la versión editable, y si se hace rollback, se llevará la versión de la izquierda de la versión publicada.
+Cuando se aplica alguna de las acciones, siempre se toma la versión seleccionada a la izquierda, de tal forma que si se reestablece, se llevará la versión de la izquierda a la versión editable, y si se hace rollback, se llevará la versión de la izquierda a la versión publicada.
 
 #### Reestablecer
 


### PR DESCRIPTION
Observaciones a Team review:

* Dividí y reescribí la introducción con una explicación general del Team review pues me parecía que se mencionaban cosas muy específicas allí. Mi idea es que esas cosas se expliquen en una sección de "Ejemplo" con un caso concreto (por ejemplo que los botones van cambiando dependiendo del estado del elemento, cómo asignar revisores, etc.). Esa sección estaría faltando.
* Creo que es necesaria una imagen que muestre el flujo de estados (draft, en revisión, rechazado, aprobado).
* Eliminé o fusioné algunos "tips" que me parecieron innecesarios o que eran parte de la explicación de cada ítem.
* Corregí el concepto de "versión" pues se confundía con "estado".
* Creo que hay que uniformar qué cosas van entre comillas, negrita y código.