### PR TITLE
Remove broken project template from examples

### DIFF
--- a/docs/es/platform/channels/widgets.md
+++ b/docs/es/platform/channels/widgets.md
@@ -200,7 +200,6 @@ EXAMPLE
 ```bash
   EJEMPLOS
     $ modyo-cli get modyo-widgets-template-vue [DIRECTORY] #to initialize a widget
-    $ modyo-cli get modyo-widgets-project-vue [DIRECTORY] #to initialize a base project library
 ```
 
 >Desde este comando y en adelante, puede continuar utilizando el widget como cualquier otro widget vue-cli.

--- a/docs/platform/channels/widgets.md
+++ b/docs/platform/channels/widgets.md
@@ -204,12 +204,11 @@ EXAMPLE
   $ modyo-cli get name [directory]
 ```
 
->there are some public widget names that can be accessed via this command
+>There are some public widget names that can be accessed via this command
 
 ```bash
   EXAMPLE
     $ modyo-cli get modyo-widgets-template-vue [DIRECTORY] #to initialize a widget
-    $ modyo-cli get modyo-widgets-project-vue [DIRECTORY] #to initialize a base project library
 ```
 
 >From this command and on you can continue using the widget like any other vue-cli widget.


### PR DESCRIPTION
Remove code samples that include `-project-` templates