### PR TITLE
Actualizar enlaces muertos en home

### DIFF
--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -203,8 +203,8 @@
           <h3 class="m-0 mb-1 w-100 text-white text-center" style="h3-xl">{{data.communityTitle}}</h3>
           <h5 class="text-white text-center mt-0 mb-2">{{data.communityText}}</h5>
           <div class="d-flex flex-wrap justify-content-center">
-            <a :href="'https://support.modyo.com/hc/'+data.communityLang" target="_blank" class="btn btn-lg btn-primary m-3">Modyo Support</a>
-            <a :href="'https://support.modyo.com/hc/'+data.communityLang+'/community/topics/'" target="_blank" class="btn btn-lg btn-outline-primary m-3">Modyo Community</a>
+            <a :href="'https://support.modyo.com/hc/'+data.communityLang.toLowerCase()" target="_blank" class="btn btn-lg btn-primary m-3">Modyo Support</a>
+            <a :href="data.communityURL.toLowerCase()" target="_blank" class="btn btn-lg btn-outline-primary m-3">Modyo Community</a>
           </div>
         </div>
       </div>

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -3,7 +3,7 @@ home: true
 
 title: Modyo Docs
 heroImage: https://cloud.modyocdn.com/uploads/cec0beb2-6695-495d-9306-f6ea1098b020/original/MP-Channels-and-Content.png
-footer: Copyright © 2008-2021 Modyo SpA
+footer: Copyright © 2008-2022 Modyo SpA
 
 platformText: The technological base in which the applications operate
 
@@ -73,10 +73,11 @@ releaseText: Release notes
 releaseUrl: /en/platform/release-notes.html
 
 roadmapText: Modyo Roadmap
-roadmapUrl: https://en.modyo.com/roadmap
+roadmapUrl: https://modyo.com/roadmap
 
 communityTitle: Need more help?
 communityText: Use our help channels
+communityURL: https://www.modyo.com/community
 
 communityLang: en-US
 ---

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -3,7 +3,7 @@ home: true
 
 title: Modyo Docs
 heroImage: https://cloud.modyocdn.com/uploads/cec0beb2-6695-495d-9306-f6ea1098b020/original/MP-Channels-and-Content.png
-footer: Copyright © 2008-2021 Modyo SpA
+footer: Copyright © 2008-2022 Modyo SpA
 
 platformText: La base tecnológica sobre la cual operan las aplicaciones
 
@@ -77,6 +77,7 @@ roadmapUrl: https://es.modyo.com/roadmap
 
 communityTitle: ¿Necesitas más ayuda?
 communityText: Utiliza nuestros canales de ayuda
+communityURL: https://es.modyo.com/comunidad
 
 communityLang: es
 ---


### PR DESCRIPTION
FIX: este commit resuelve:
- remover enlaces con respuesta 404 en el home
- actualizar el año de copyright en el footer