### PR TITLE
Agregar ejemplos de Liquid y SEO

### DIFF
--- a/docs/es/platform/channels/templates.md
+++ b/docs/es/platform/channels/templates.md
@@ -237,6 +237,12 @@ Este snippet utiliza Liquid para agregar meta tags a nivel Sitio. También agreg
 
 Si es que lo requieres, puedes personalizar este snippet, definiendo qué meta tags quieres que aparezcan para URLs o tipos específicos. 
 
+## Ejemplos de SEO
+
+A continuación proveemos una serie de ejemplos para mejorar el SEO de diferentes casos.
+
+### Meta tags específicos para una Entrada
+
 Por ejemplo, si quieres usar meta tags específicas cuando un usuario visita una Entrada, puedes usar:
 
 ```html
@@ -261,6 +267,34 @@ Por ejemplo, si quieres usar meta tags específicas cuando un usuario visita una
 ...
 ```
 
-En este caso, los tipos `posts` y `place` comparten los atributos _title_, _excerpt_ y _covers_, y difieren en el objeto _locations_. Además, define un tipo de documento diferente para cada uno.
+En este caso, los tipos de Entrada `posts` y `place` comparten los atributos _title_, _excerpt_ y _covers_, y difieren en el objeto _locations_. Además, define un tipo de documento diferente para cada uno.
 
-Para conocer más información acerca de Liquid y como usar Liquid Drops para generar variables dinámicamente, visita [Liquid Markup](/es/platform/channels/liquid-markup).
+### Meta tags específicos para Categoría en Página de Contenido
+
+En caso de tener meta tags específicas cuando muestras Entradas que pertenecen a una Categoría, puedes copiar el siguiente código:
+
+```html
+{% assign category_name = category_path | split: '/' | last | capitalize %}
+ 
+{% case category_name %}
+  {% when 'Category 1' %}
+     {% assign category_description = 'This is the meta description for Category 1' %}
+  {% when 'Categoría 2' %}
+     {% assign category_description = 'This is the meta description for Category 2' %}
+{% endcase %}
+
+{% if category_path.size > 0 %}
+<!-- Content Page: Index con categoría -->
+<title> {{ category_name }} - {{ site.name }} </title>
+<meta name="description" content="{{ category_description }}"/>
+<meta property="og:title" content="{{ category_name }} - {{ site.name }}"/>
+<meta property="og:type" content="website"/>
+<meta property="og:url" content="{{ page.url }}/{{ category_path }}">
+<meta property="og:image" content="https://d1dzq2r60kxox4.cloudfront.net/uploads/c82bdfea-3622-4c11-9a20-bea227cbdc60/original/og_image.jpg"/>
+<meta property="og:site_name" content="{{ site.name }}"/>
+<meta property="og:description" content="{{ category_description }}"/>
+```
+
+En este código, se crea una variable `category_name` que contiene el nombre de la categoría tomado del URL, después se utiliza un `{% if category_path.size > 0 %}` para anexar meta data pertinente a la categoría.
+
+Liquid es la manera para crear contenido dinámico en todas las partes de tu Sitio. Para conocer más información acerca de Liquid y como usar Liquid Drops, visita [Liquid Markup](/es/platform/channels/liquid-markup).

--- a/docs/es/platform/content/public-api-reference.md
+++ b/docs/es/platform/content/public-api-reference.md
@@ -661,7 +661,7 @@ El objeto retornado por getEntries() incluye un campo meta que te ayudará a nav
 <template v-slot:curl>
     
 ```shell
-curl -X GET "https://test.modyo.com/api/admin/content/spaces/{my_space}/entries?category_id=25"
+curl -X GET "https://test.modyo.com/api/content/spaces/{my_space}/entries?category_id=25"
 ```
 
 La respuesta contiene el objeto `meta` que incluye un campo que te ayudará a navegarlo. La forma del objeto retornado será algo como esto:


### PR DESCRIPTION
Estos son los ejemplos que pude extraer del documento de mejoras de SEO.

Meta tags específicos para una Entrada
Meta tags específicos para Categoría en Página de Contenido

Voy a tener que hacer otra pasada al recibir el documento de variables de contexto.