### PR TITLE
Agregar guia "Liquid en Widgets Locales"

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -35,6 +35,7 @@ module.exports = {
     docsDir: "docs",
     sidebarDepth: 1,
     activeHeaderLinks: false,
+    smoothScroll: true,
     algolia: {
       apiKey: '99dcc8c4afd966e0e2f614f8498897d6',
       indexName: 'dev_docs',
@@ -206,6 +207,7 @@ module.exports = {
                 ["/en/widgets/guides/i18n", "Internationalization"],
                 ["/en/widgets/guides/share-state", "Shared state"],
                 "/en/widgets/guides/liquid-variables",
+                "/en/widgets/guides/local-liquid",
                 "/en/widgets/guides/ci-cd",
                 "/en/widgets/guides/repository-pattern",
                 "/en/widgets/guides/storybook",
@@ -488,6 +490,7 @@ module.exports = {
                 ["/es/widgets/guides/i18n", "Internacionalización"],
                 ["/es/widgets/guides/share-state", "Compartir estado"],
                 "/es/widgets/guides/liquid-variables",
+                "/es/widgets/guides/local-liquid",
                 "/es/widgets/guides/ci-cd",
                 "/es/widgets/guides/repository-pattern",
                 "/es/widgets/guides/storybook",

--- a/docs/en/widgets/guides/local-liquid.md
+++ b/docs/en/widgets/guides/local-liquid.md
@@ -1,0 +1,85 @@
+---
+search: true
+---
+
+# Liquid en Widgets Locales
+
+Utiliza la librería de liquidParser para poder hacer uso de Liquid dentro del desarrollo de tu Widget en tu ambiente local. Al momento de hacer push de tu Widget hacia Modyo Platform, la plataforma reemplazará tus variables liquid locales por las variables de la plataforma.
+
+Mantén un alto ritmo de desarrollo usando las mismas variables que se utilizan en Modyo Platform dentro de tu ambiente local con el propósito de verificar que el código Liquid sea el correcto sin la necesidad de probarlo directamente en Modyo Platform. 
+
+### Plantillas de widget
+
+En nuestro catálogo de widgets, ofrecemos plantillas que contienen lo mínimo para subir un widget a Modyo Platform. Las plantillas las puedes encontrar en los siguientes frameworks:
+
+- [Vue](https://github.com/modyo/modyo-widgets-template-vue)
+- [Angular](https://github.com/modyo/modyo-widgets-template-angular)
+- [React](https://github.com/modyo/modyo-widgets-template-react)
+
+>Todas las instrucciones de esta guía usan como base la plantilla de vue.
+
+Sigue estos pasos para agregar nuevas variables liquid a tu widget local:
+
+## Agregar nuevas variables
+
+En el archivo `local-liquid-variables.js` puedes encontrar algunas variables de prueba. 
+
+1. Para localizar este archivo abre la siguiente URL https://github.com/modyo/modyo-widgets-template-vue/blob/master/src/liquid/local-liquid-variables.js
+2. El archivo contiene algunas variables, para este ejemplo vamos a utilizar las variables de site.
+
+```js
+export default {
+  ...
+  site: {
+    url: 'https://fed-team.modyo.cloud/test',
+    name: 'my site',
+    lang: 'en',
+  },
+  ...
+}
+```
+
+## Importar y utilizar liquidParser
+
+En caso de usar nuestras plantillas de widgets, no es necesario estos pasos ya que la plantilla ya tiene todo listo para que empieces a desarrollar.
+
+1. En la vista App.vue, importamos la librería liquidParser para poder hacer uso del lenguaje liquid en el Widget usando: 
+
+```js
+import liquidParser from './liquid/liquidParser';
+```
+
+También debemos asegurar que estemos importando como dependencia `liquidjs`, el paquete de Shopify para el lenguaje Liquid en Javascript.
+
+2. Abre `package.json` y agrega la siguiente dependencia.
+
+`"liquidjs": "^10.4.0"`
+
+3. Al momento de exportar tu App (en nuestro caso en `App.vue`), puedes agregar tus variables liquid usando liquidParser.parse(). Dentro del método parse(), puedes hacer uso de cualquier expresión liquid.
+
+```js
+export default {
+  name: 'App',
+  components: {
+    ExampleComponent,
+  },
+  data() {
+    return {
+      siteName: liquidParser.parse('{{site.name | replace: "my", "your" | upcase }}')
+    };
+  }
+}
+```
+
+4. En tu código HTML, puedes empezar a hacer uso de tus variables usando Liquid. En la plantilla vue, desplegamos un `<h1>` de la siguiente manera:
+
+```html
+<h1
+  v-if="_i18n.asyncLoading"
+  class="mb-3"
+>
+  {{ $t('salutation', [siteName, basePath]) }}
+  {{ $t('Path') }}
+  {{ $t('Pathnew') }}
+</h1>
+```

--- a/docs/es/widgets/guides/first-steps.md
+++ b/docs/es/widgets/guides/first-steps.md
@@ -104,3 +104,10 @@ Si queremos que el Widget se publique automáticamente al terminar la carga, pod
 modyo-cli push --publish
 ```
 
+### Plantillas de widget
+
+En nuestro catálogo de widgets, ofrecemos plantillas que contienen lo mínimo para subir un widget a Modyo Platform. Las plantillas las puedes encontrar en los siguientes frameworks:
+
+- [Vue](https://github.com/modyo/modyo-widgets-template-vue)
+- [Angular](https://github.com/modyo/modyo-widgets-template-angular)
+- [React](https://github.com/modyo/modyo-widgets-template-react)

--- a/docs/es/widgets/guides/liquid-variables.md
+++ b/docs/es/widgets/guides/liquid-variables.md
@@ -8,7 +8,6 @@ Crea un objeto javascript en Snippets para poder hacer uso de Liquid en tus Widg
 
 Los Widgets, al estar desacoplados de la plataforma, tienen la desventaja de no poder usar Liquid directamente y no tenemos acceso a esos drops, para poder trabajar con ellos los tendremos que hacer disponibles mediante javascript desde la plataforma. [**Liquid Markup**](/es/platform/channels/liquid-markup.html) es una parte importante de la plataforma, de como construimos las vistas, y accedemos al contenido en ella. También nos da acceso a [**drops**](/es/platform/channels/drops) (variables) de contexto que nos permiten interactuar con nuestras vistas de manera más dinámica. Por ejemplo, se puede determinar que contenido mostrar al usuario según el segmento al que pertenece, ocultar un menú según la página que se este visitando, etc.
 
-
 Sigue estos pasos para crear un snippet con variables de Liquid:
 1. En el menú lateral en la plataforma, expande **Channels** y haz click en **Sitios**.
 2. Haz click en tu sitio.

--- a/docs/es/widgets/guides/local-liquid.md
+++ b/docs/es/widgets/guides/local-liquid.md
@@ -1,0 +1,85 @@
+---
+search: true
+---
+
+# Liquid en Widgets Locales
+
+Utiliza la librería de liquidParser para poder hacer uso de Liquid dentro del desarrollo de tu Widget en tu ambiente local. Al momento de hacer push de tu Widget hacia Modyo Platform, la plataforma reemplazará tus variables liquid locales por las variables de la plataforma.
+
+Mantén un alto ritmo de desarrollo usando las mismas variables que se utilizan en Modyo Platform dentro de tu ambiente local con el propósito de verificar que el código Liquid sea el correcto sin la necesidad de probarlo directamente en Modyo Platform. 
+
+### Plantillas de widget
+
+En nuestro catálogo de widgets, ofrecemos plantillas que contienen lo mínimo para subir un widget a Modyo Platform. Las plantillas las puedes encontrar en los siguientes frameworks:
+
+- [Vue](https://github.com/modyo/modyo-widgets-template-vue)
+- [Angular](https://github.com/modyo/modyo-widgets-template-angular)
+- [React](https://github.com/modyo/modyo-widgets-template-react)
+
+>Todas las instrucciones de esta guía usan como base la plantilla de vue.
+
+Sigue estos pasos para agregar nuevas variables liquid a tu widget local:
+
+## Agregar nuevas variables
+
+En el archivo `local-liquid-variables.js` puedes encontrar algunas variables de prueba. 
+
+1. Para localizar este archivo abre la siguiente URL https://github.com/modyo/modyo-widgets-template-vue/blob/master/src/liquid/local-liquid-variables.js
+2. El archivo contiene algunas variables, para este ejemplo vamos a utilizar las variables de site.
+
+```js
+export default {
+  ...
+  site: {
+    url: 'https://fed-team.modyo.cloud/test',
+    name: 'my site',
+    lang: 'en',
+  },
+  ...
+}
+```
+
+## Importar y utilizar liquidParser
+
+En caso de usar nuestras plantillas de widgets, no es necesario estos pasos ya que la plantilla ya tiene todo listo para que empieces a desarrollar.
+
+1. En la vista App.vue, importamos la librería liquidParser para poder hacer uso del lenguaje liquid en el Widget usando: 
+
+```js
+import liquidParser from './liquid/liquidParser';
+```
+
+También debemos asegurar que estemos importando como dependencia `liquidjs`, el paquete de Shopify para el lenguaje Liquid en Javascript.
+
+2. Abre `package.json` y agrega la siguiente dependencia.
+
+`"liquidjs": "^10.4.0"`
+
+3. Al momento de exportar tu App (en nuestro caso en `App.vue`), puedes agregar tus variables liquid usando liquidParser.parse(). Dentro del método parse(), puedes hacer uso de cualquier expresión liquid.
+
+```js
+export default {
+  name: 'App',
+  components: {
+    ExampleComponent,
+  },
+  data() {
+    return {
+      siteName: liquidParser.parse('{{site.name | replace: "my", "your" | upcase }}')
+    };
+  }
+}
+```
+
+4. En tu código HTML, puedes empezar a hacer uso de tus variables usando Liquid. En la plantilla vue, desplegamos un `<h1>` de la siguiente manera:
+
+```html
+<h1
+  v-if="_i18n.asyncLoading"
+  class="mb-3"
+>
+  {{ $t('salutation', [siteName, basePath]) }}
+  {{ $t('Path') }}
+  {{ $t('Pathnew') }}
+</h1>
+```


### PR DESCRIPTION
Se agregó una nueva guía llamada "Liquid en Widgets Locales"

Se habla a detalle acerca de que se tiene que hacer para empezar a utilizar Liquid en tus Widgets locales, antes de hacer un push hacia la plataforma.

Creo que me hace falta más información acerca de: 
- Cómo se reemplazan variables en la plataforma?
- Hay alguna nomenclatura o patrón para las variables?
- Agregar un último paso que sería el push con cli hacia la plataforma?

Espero sus comentarios, gracias!