### PR TITLE
Reemplazar Snippets de codigo en espanol

### DIFF
--- a/docs/es/dynamic/README.md
+++ b/docs/es/dynamic/README.md
@@ -47,15 +47,15 @@ Para comenzar a utilizar Dynamic Framework [crea un ambiente de pruebas](https:/
 
 Inicia un nuevo proyecto con Dynamic Framework utilizando el comando NPX. Este comando configura automáticamente todo el entorno:
 
-``` shell
-npx @modyo/cli@latest get dynamic-react-base-template <nombre-de-tu-proyecto>
+```bash
+npx @modyo/cli@latest get dynamic-react-base-template <project-name>
 ```
 Si no tienes instalado el CLI de Modyo, el sistema solicitará instalarlo debido a que es un paquete requerido. Puedes encontrar las instrucciones de instalación del CLI en la [documentación oficial](/es/platform/channels/cli.html#modyo-cli)
 
 Este proceso descarga la plantilla dynamic-react-base-template, una vez que tengas la plantilla, ingresa a la carpeta del proyecto para instalar las dependencias y levantar el proyecto:
 
-```shell
-cd <nombre-de-tu-proyecto>
+```bash
+cd <project-name>
 npm i
 npm run start
 ```
@@ -63,7 +63,7 @@ Usa un editor de código para explorar el código y examinar cómo se utilizan l
 
 ### Instalación manual
 Para crear manualmente un nuevo proyecto con Dynamic Framework o agregarlo como dependencia a un proyecto React existente, instala los paquetes requeridos:
-```shell
+```bash
 npm i @modyo/cli@latest @dynamic-framework/ui-react@latest
 ```
 

--- a/docs/es/platform/channels/cli.md
+++ b/docs/es/platform/channels/cli.md
@@ -79,12 +79,12 @@ Para facilitar el proceso de subir tus widgets a la plataforma Modyo, puedes hac
 1. Crea un archivo `.env` en la raíz de tu proyecto.
 2. Agrega la siguiente información:
 
-```
-MODYO_ACCOUNT_URL=test.miModyo.com
+```bash
+MODYO_ACCOUNT_URL=test.myModyo.com
 MODYO_VERSION=9
 MODYO_TOKEN=ak9cb2....a53s
-MODYO_SITE_HOST=miSitio
-MODYO_WIDGET_NAME=miNuevoWidget
+MODYO_SITE_HOST=mySite
+MODYO_WIDGET_NAME=myNewWidget
 MODYO_BUILD_COMMAND=build
 MODYO_BUILD_DIRECTORY=dist
 ```
@@ -129,8 +129,8 @@ Después del comando, puedes correr `$ compaudit -D` para verificar que no hay c
 
 2. Prueba que funcione correctamente, e.g.:
 ```bash
-$ modyo-cli <TAB>           #Completar comando
-$ modyo-cli command --<TAB> #Completar opción
+$ modyo-cli <TAB>           #Complete command
+$ modyo-cli command --<TAB> #Complete option
 ```
 
 ### Obtenga una plantilla para un proyecto
@@ -162,7 +162,6 @@ EXAMPLE
 >Hay algunas plantillas de widgets públicos a los que se puede acceder a través de este comando
 
 ```bash
-  EJEMPLOS
     $ modyo-cli get modyo-widgets-template-vue [DIRECTORY] #to initialize a widget
 ```
 
@@ -210,23 +209,23 @@ Para hacer push hacia la plataforma, es necesario llenar las opciones requeridas
 
 En el directorio raíz del widget, crea un archivo `.env` que contenga los siguientes datos:
 
-```shell
-MODYO_ACCOUNT_URL=https://test.miModyo.com //URL de la cuenta dueña del sitio
-MODYO_VERSION=9                            //La versión de la plataforma Modyo
-MODYO_TOKEN=ax93...nm3                     //El token para accesar a la API administrativa
-MODYO_SITE_HOST=miHost                     //El nombre de Host, localizado dentro de la plataforma, en la sección de sitios
-MODYO_SITE_ID=miStage                      //(Opcional) Esta variable solo se utiliza en el caso de hacer push hacia un stage. Solo se utiliza una variable MODYO_SITE_HOST o MODYO_SITE_ID. El Id se obtiene utilizando nuestra API /api/admin/sites.    
-MODYO_WIDGET_NAME=miWidget                 //El nombre del widget
-MODYO_BUILD_COMMAND=build                  //El comando para package.json (default: build) 
-MODYO_BUILD_DIRECTORY=dist                 //La ruta del widget (default: dist) 
+```bash
+MODYO_ACCOUNT_URL=https://test.myModyo.com
+MODYO_VERSION=9
+MODYO_TOKEN=ax93...nm3
+MODYO_SITE_HOST=myHost
+MODYO_SITE_ID=myStage
+MODYO_WIDGET_NAME=myWidget
+MODYO_BUILD_COMMAND=build
+MODYO_BUILD_DIRECTORY=dist 
 ```
 
 #### Opciones
 
 En una terminal con modyo-cli instalado, es posible hacer push a través de la linea de comandos de la siguiente manera:
 
-```
-modyo-cli push miWidget -b build -d dist -n miHost -v 9 -u "https://test.miModyo.com" -t $TOKEN 
+```bash
+modyo-cli push myWidget -b build -d dist -n myHost -v 9 -u "https://test.myModyo.com" -t $TOKEN 
 ```
 
 #### Push hacia Stage
@@ -243,7 +242,7 @@ Recibirás un JSON con toda la información relacionada a sitios. Dentro de este
 "meta": [...],
 "sites": [
     ...,
-    "name": "miHost",
+    "name": "myHost",
     "stages": [
         {
           "id": 1044,
@@ -271,11 +270,11 @@ Recibirás un JSON con toda la información relacionada a sitios. Dentro de este
 
 2. Abre tu archivo de variables de entorno `.env`. Se debe borrar la variable MODYO_SITE_HOST ya que usaremos el Id del sitio. Para hacer push hacia un stage, solo se puede usar MODYO_SITE_ID. Agrega el MODYO_SITE_ID de la siguiente manera:
 
-```shell
-MODYO_ACCOUNT_URL=https://test.miModyo.com
+```bash
+MODYO_ACCOUNT_URL=https://test.myModyo.com
 MODYO_VERSION=9
 MODYO_TOKEN=ax93...nm3
-MODYO_WIDGET_NAME=miWidget
+MODYO_WIDGET_NAME=myWidget
 MODYO_BUILD_COMMAND=build
 MODYO_BUILD_DIRECTORY=dist
 MODYO_SITE_ID=2673
@@ -283,6 +282,6 @@ MODYO_SITE_ID=2673
 
 3. En tu terminal, haz push a tu stage utilizando Modyo CLI:
 
-``modyo-cli push miWidget``
+``modyo-cli push myWidget``
 
 En caso de querer hacer push a main, se tiene que modificar la variable MODYO_SITE_ID para main o borrar esta variable y usar MODYO_SITE_HOST.

--- a/docs/es/platform/channels/liquid-markup/README.md
+++ b/docs/es/platform/channels/liquid-markup/README.md
@@ -65,7 +65,7 @@ Para desplegar el nombre de la entrada en tu página usa:
 Con Tags se puede agregar control de flujo e iteración a tus páginas. Se necesita encapsular el lenguaje con corchete y porcentaje {% %} para hacer uso de Tags, por ejemplo:
 
 ```liquid
-{% if product.name == "Banca Electrónica" %}
- ¡Descarga nuestra banca electrónica en tu teléfono celular!
+{% if product.name == "Online Banking" %}
+Download our Online Banking App now!
 {% endif %}
 ```

--- a/docs/es/platform/channels/liquid-markup/examples.md
+++ b/docs/es/platform/channels/liquid-markup/examples.md
@@ -8,11 +8,11 @@ En cualquier parte de Channels (Sitios, Widgets, y Plantillas) puedes usar Liqui
 
 ## Desplegar listado de Entradas de un Tipo
 
-En [Páginas de Contenido](/es/platform/channels/pages.html#pagina-de-contenido) puedes generar un listado de todas las Entradas de un Tipo. En este caso, tomamos todas las Entradas del Tipo `producto` en el Espacio `Mi Banco`. La variable `entries`  de la línea 1 obtiene un arreglo del drop [Entrada](/es/platform/channels/drops.html#entrada). Se recorre este arreglo para desplegar por renglón el `meta.uuid` y `meta.title` de cada Entrada. 
+En [Páginas de Contenido](/es/platform/channels/pages.html#pagina-de-contenido) puedes generar un listado de todas las Entradas de un Tipo. En este caso, tomamos todas las Entradas del Tipo `product` en el Espacio `My Bank`. La variable `entries`  de la línea 1 obtiene un arreglo del drop [Entry](/es/platform/channels/drops.html#entrada). Se recorre este arreglo para desplegar por renglón el `meta.uuid` y `meta.title` de cada Entrada. 
 
 ```liquid
-{% assign entries = spaces['mi-banco'].types['producto'].entries %}
-<p>Los productos que ofrecemos son:</p>
+{% assign entries = spaces['my-bank'].types['product'].entries %}
+<p>Products:</p>
 <ul>
 {% for entry in entries %}
   <li>{{ entry.meta.uuid }} -- {{ entry.meta.title }}</li>
@@ -25,7 +25,7 @@ Para poder usar estos ejemplos en tu sitio, debes reemplazar el ID de Espacio y 
 En el caso de una entrada de cardinalidad single (en este ejemplo es un aviso de privacidad), puedes usar `entry` para desplegar el URL de la siguiente manera:
 
 ```liquid
-Visita nuestro <a href="{{ spaces['mi-banco'].types['privacidad'].entry.url }}">Aviso de Privacidad</a>.
+Visit our <a href="{{ spaces['my-bank'].types['privacy'].entry.url }}">Privacy Policy</a>.
 ```
 
 ## Desplegar cantidad total de Entradas
@@ -33,8 +33,8 @@ Visita nuestro <a href="{{ spaces['mi-banco'].types['privacidad'].entry.url }}">
 Para acceder a la cantidad total de entradas que retorna un filtro de contenido, puedes usar el filtro de Liquid `entries.size`, por ejemplo:
 
 ```liquid
-{% assign entries = spaces['mi-banco'].types['products'].entries %}
-<p>Ofrecemos un total de {{ entries.size }} productos para ti!</p>
+{% assign entries = spaces['my-bank'].types['products'].entries %}
+<p>You have a total of {{ entries.size }} products!</p>
 ```
 
 ## Filtros
@@ -55,8 +55,8 @@ Todos los filtros deben recibir un arreglo de Entries y es posible concatenar mu
 En el siguiente ejemplo, filtramos las Entradas de tipo `post`, con categoría `news`. Después tomamos el resultado y desplegamos todas las Entradas de tipo `news`:
 
 ```liquid
-{% assign entries = spaces['mi-banco'].types['post'].entries | by_category: 'news' %}
-<p>Estas son todas nuestras noticias:</p>
+{% assign entries = spaces['my-bank'].types['post'].entries | by_category: 'news' %}
+<p>News:</p>
 <ul>
 {% for entry in entries %}
 <li><a href="entry.url">{{ entry.meta.title }}</a></li>
@@ -65,11 +65,11 @@ En el siguiente ejemplo, filtramos las Entradas de tipo `post`, con categoría `
 
 ### Filtro concatenado
 
-En el siguiente ejemplo, filtramos las Entradas de tipo `post`, con categoría `news`, que además tengan el tag `campaña`. Después tomamos el resultado y desplegamos las noticias que cumplen todos los criterios:
+En el siguiente ejemplo, filtramos las Entradas de tipo `post`, con categoría `news`, que además tengan el tag `campaign`. Después tomamos el resultado y desplegamos las noticias que cumplen todos los criterios:
 
 ```liquid
-{% assign entries = spaces['mi-banco'].types['post'].entries | by_category: 'news' | by_tag: 'campaña' %}
-<p>Las siguientes noticias son relevantes para ti!</p>
+{% assign entries = spaces['my-bank'].types['post'].entries | by_category: 'news' | by_tag: 'campaign' %}
+<p>News for you!</p>
 <ul>
 {% for entry in entries %}
 <li><a href="entry.url">{{ entry.meta.title }}</a></li>
@@ -149,13 +149,13 @@ Para ordenar por un campo personalizado, debes usar como parámetro el `fields.u
 
 Para los entries con campos de ubicación se pueden generar fácilmente mapas con los filtros `static_map` y `dynamic_map`, estos usan Google Maps Static API y Google Maps Javascript API respectivamente. El siguiente ejemplo genera mapas para el field `Locations` con un tamaño de 600x300 px, un zoom de nivel 5, con tipo de mapa 'roadmap' y con un ícono personalizado.
 
-```
+```liquid
 {{ entry.fields.['Locations'] | static_map: '600x300',5,'roadmap','https://goo.gl/5y3S82'}}
 ```
 
 El filtro `dynamic_map` acepta un atributo adicional para controlar la visibilidad de los controles de zoom, arrastre y pantalla completa.
 
-```
+```liquid
 {{ entry.fields['Locations'] | dynamic_map: '600x300',5,'roadmap','https://goo.gl/5y3S82',true}}
 ```
 

--- a/docs/es/platform/channels/liquid-markup/tags.md
+++ b/docs/es/platform/channels/liquid-markup/tags.md
@@ -192,7 +192,7 @@ A menudo hay que alternar entre diferentes colores o tareas similares. Liquid ti
 
 resultará en
 
-```plain
+```shell
 one
 two
 three
@@ -214,7 +214,7 @@ el nombre del grupo. Esto puede incluso ser una variable.
 
 resultará en
 
-```text
+```shell
 one
 two
 one

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -239,7 +239,7 @@ Modyo permite la implementación de Progressive Web Apps (PWA) dentro de los can
 
 El manifiesto sirve para indicar cómo quieres que un navegador muestre tu canal digital. Lo puedes activar en Modyo marcando la casilla. Al activarlo, se crea esta ruta:
 
-```
+```bash
 https://[domain]/[site-name]/manifest.json
 ```
 
@@ -259,7 +259,7 @@ Si no personalizas el manifiesto, pero agregas la ruta en Plantillas, este queda
 
 El Service Worker permite que el canal digital realice distintas acciones o mantenga ciertos datos conectados dentro del caché para ofrecer una estructura en caso de tener una mala conexión. Puedes habilitar el Service Worker a través de la casilla correspondiente. Al activarlo, se crea la siguiente ruta:
 
-```
+```bash
 https://[domain]/[site-name]/serviceworker.js
 ```
 
@@ -561,7 +561,7 @@ Un valor muy estricto puede interferir con algunas características como [Google
 
 Una política apta para producción debe asegurar que todos los recursos, como imágenes y hojas de estilo, se carguen desde fuentes confiables y requiere que todos los scripts sean seguros y confiables para la aplicación. Por ejemplo, una política estricta para el _template minimal_ se vería así:
 
-```
+```bash
 default-src 'self'; img-src 'self' https://cloud.modyocdn.com; font-src 'self' https://cloud.modyocdn.com http://cdn.materialdesignicons.com; style-src 'self' http://cdn.materialdesignicons.com; script-src 'self'
 ```
 

--- a/docs/es/platform/channels/widgets.md
+++ b/docs/es/platform/channels/widgets.md
@@ -38,7 +38,7 @@ Por defecto comienzas comparando la versión publicada con la versión editable.
 **Botón principal:**
 
 - **Guardar:** Guarda los cambios actuales.
-- **Enviar a revisión:**Si está habilitada la revisión en equipo, puedes enviar el widget a revisión y notificar a los revisores que el widget está listo para ser revisado.
+- **Enviar a revisión:** Si está habilitada la revisión en equipo, puedes enviar el widget a revisión y notificar a los revisores que el widget está listo para ser revisado.
 - **Publicar:** Te lleva a la vista de [publicación conjunta](/es/platform/core/key-concepts.html#revision-y-publicacion-conjunta) donde puedes publicar tus widgets.
 
 **Otras acciones principales:**
@@ -137,7 +137,7 @@ Con i18n puedes configurar y agregar nuevos idiomas a tus widgets.
 
 Para manejar la internacionalización en los Widgets de nuestro [catálogo de widgets](/es/widgets/) usamos el paquete [**Vue I18n**](https://kazupon.github.io/vue-i18n/) instalado mediante el plugin [vue-cli-plugin-i18n](https://github.com/kazupon/vue-cli-plugin-i18n), pueden revisar su documentación [aquí](https://kazupon.github.io/vue-i18n/introduction.html). Al instalar el plugin, se crea una carpeta para los idiomas llamada `locales` y un archivo de configuración llamado `i18n.js`.
 
-``` treeview{3,5-7}
+```shell{3,5-7}
 ├── src/
 │   ├── App.vue
 │   ├── i18n.js
@@ -180,7 +180,7 @@ La variable `liquid.lang` la tenemos que crear en Modyo Platform. Para crear est
 1. Abre la Vista `theme` en la sección Vistas -> Javascript -> theme.
 1. Agrega el siguiente código:
 
-``` js
+```shell
 window.liquid = {
  lang: '{{@site.language}}' === 'en' ? 'en-US' : 'es-CL'
 };
@@ -192,11 +192,11 @@ Este código asigna a la variable `liquid.lang` el lenguaje, dependiendo del val
 
 Para agregar un idioma nuevo al sitio, simplemente creamos un archivo **JSON** en la carpeta `locales` donde su nombre es el código del idioma a añadir. Por ejemplo, si queremos agregar portugués de Brasil, agrega `pt-BR.json`:
 
-``` treeview{4}
+```shell{4}
 ├── src/
 │   ├── locales/
 │   │   ├── en-US.json
-│   │   ├── pt-BR.json <-- nuevo idioma
+│   │   ├── pt-BR.json <-- new language
 │   │   └── es-CL.json
 ```
 :::warning Atención
@@ -212,7 +212,6 @@ Para poder localizar los mensajes de error que el validador nos muestra, tenemos
 3. Retornamos el objeto **messages** modificado.
 
 ```js
-// 1
 import esCL from 'vee-validate/dist/locale/es-CL.json';
 import enUS from 'vee-validate/dist/locale/en-US.json';
 import ptBR from 'vee-validate/dist/locale/pt-BR.json';
@@ -223,22 +222,22 @@ function loadLocaleMessages() {
   const locales = require.context('./locales', true, /[A-Za-z0-9-_,\s]+\.json$/i);
   const messages = {};
   locales.keys().forEach((key) => {...});
-  // 2
+ 
   messages['es-CL'] = {
     ...messages['es-CL'],
     validations: esCL.messages,
   };
-  // 2
+
   messages['en-US'] = {
     ...messages['en-US'],
     validations: enUS.messages,
   };
-  // 3
+
   messages['pt-BR'] = {
     ...messages['pt-BR'],
     validations: ptBR.messages,
   };
-  // 4
+
   return messages;
 }
 ```

--- a/docs/es/platform/content/entries.md
+++ b/docs/es/platform/content/entries.md
@@ -246,10 +246,10 @@ URL: `https://test.modyo.com/api/content/spaces/test-space/types/nuevo/entries/4
 {
   "meta":
   {
-    "name": "MiNuevaEntrada",
-    "slug": "minuevaentrada",
+    "name": "MyNewEntry",
+    "slug": "mynewentry",
     "tags": [],
-    "type": "nuevoTipo",
+    "type": "newType",
     "uuid": "45fa2ef7-bf12-47a3-8ff7-f7d1f5f36844",
     "space": "test-space",
     "author":

--- a/docs/es/platform/content/public-api-reference.md
+++ b/docs/es/platform/content/public-api-reference.md
@@ -17,7 +17,7 @@ Por el momento sólo existe, de forma oficial, un SDK para Javascript. A futuro 
 
 Para realizar cualquier acción, es necesario conocer la estructura de rutas de los contenidos en la API, la cual se hace de la siguiente manera:
 
-```
+```bash
 https://www.example.com/api/content/spaces/:space_uid/types/:type_uid/schema
 
 https://www.example.com/api/content/spaces/:space_uid/types/:type_uid/entries?[filters]

--- a/docs/es/platform/core/api.md
+++ b/docs/es/platform/core/api.md
@@ -113,7 +113,7 @@ Al final de la documentación, encontrarás una sección llamada "Models" que co
 
 El siguiente código es una parte del modelo para objeto **User**:
 
-```
+```shell
 User{
 schemas	    [...]
 id	        string example: 2441309d85324e7793ae

--- a/docs/es/platform/core/integrations/oidc.md
+++ b/docs/es/platform/core/integrations/oidc.md
@@ -107,7 +107,6 @@ axios_api.interceptors.request.use(appendTokenToRequest ,errorRequest);
 1. Agrega otro snippet personalizado llamado `controller_js` y copia el siguiente código:
 
 ```js
-// se encarga de levantar el modal de advertencia que avisará el cierre próximo de la sesión, esta variable devolverá una promesa que será efectiva si se hace click en el botón Mantener Sesión y que lanzará una promesa reject en el caso de seleccionar el botón con la negativa de continuar
 var modalConfirm = function() {
   return new Promise(function(resolve, reject) {
     $("#session-modal").modal({
@@ -125,30 +124,26 @@ var modalConfirm = function() {
     });
   });
 };
-// será la que se encarga de al iniciarse comenzar el tracking del tiempo para levantar este modal y manejar del lado Front la sesión a continuación se explica cada una de las propiedades y métodos de este objeto que maneja la sesión
+
 var sessionManager = {
-  // propiedad que define el tiempo desde la última actividad hasta el fin de la sesión en segundos (ojo no el tiempo de refresco del token sino el de finalización de la sesión, es recomendado que este sea un minuto menor al declarado por el provider del Open ID Connect para tener un poco de holgura con la sesión y el cierre de la misma sea 100% valido)
   timeToEndSessionInSeconds: 900,
-  // propiedad donde se define el tiempo de levantamiento del modal de inactividad desde la última acción o petición en la página
   timeToRaiseWarningModalInSeconds: 720,
-  // propiedad que guarda el timestamp del último momento de actividad del sessionManager
   lastActionTimeInThisWindow: new Date().getTime(),
-  // función que convierte segundos a milisegundos
+
   secondsToMilisecs: function(minutes) {
     return minutes * 1000;
   },
-  // propiedad para almacenar el interval id de revisión de eventos de sesión
   intevalId:null,
-  // función que determina si se esta accediendo a la aplicación desde el modyoShell o no
+
   isModyoAppShell: function() {
     return /; Modyo_App_Shell/.test(navigator.userAgent);
   },
-  // método que debe ser ejecutado en cada carga de página para comenzar el proceso de eventos de sesión a hacer seguimiento recomendado hacer esta invocación sessionManager.init() en el head del layout para comenzar a trackear la sesión (en algunos casos se define que los developers no lancen esta invocación en ese caso la API de prueba a conectar debe tener también este if y así lograrás que axios_api sirva para el entorno develop y el de desarrollo uno con sesión y el otro sin sesión manager)
+
   init: function() {
     this.resetIdleTime();
     this.intevalId=this.interval();
   },
-  // reinicia el tiempo de espera o crea una nueva actividad en el sitio
+
   resetIdleTime: function() {
     this.lastActionTimeInThisWindow = new Date().getTime();
     var sessionEndTime =
@@ -160,16 +155,17 @@ var sessionManager = {
       this.secondsToMilisecs(this.timeToRaiseWarningModalInSeconds);
     localStorage.setItem("timeToRaiseWarningModal", raiseWarningModalTime);
   },
-  // método que inicia la actividad cada segundo js que maneja los eventos de sesión
+
+
   interval: function() {
     var self = this;
     return setInterval(this.checkSessionEvents, 1000, self);
   },
-  // método que levanta el modal de warning time
+
   raiseModal: function() {
     return modalConfirm();
   },
-  // método que cierra sesión y limpia storage
+
   logout: function() {
     localStorage.clear();
     sessionStorage.clear();
@@ -183,7 +179,7 @@ var sessionManager = {
       window.location.href = "{{site.account_url}}/logout?site={{site.uuid}}";
     }
   },
-  // método que revisa los eventos de sesión para determinar si es momento de cierre de la misma o de mantenerla después de mostrar el modal
+
   checkSessionEvents: function(self) {
     var sessionEndTime = localStorage.getItem("timeToEndSession");
     var raiseWarningModalTime = localStorage.getItem("timeToRaiseWarningModal");
@@ -234,18 +230,18 @@ Este es el modal a activar en el paso anterior con bootstrap para el manejo del 
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="session-modal-label">
-          Su sesión va a expirar
+          Session about to expire
         </h5>
       </div>
       <div class="modal-body text-center">
         <p>
-          Su sesión va a expirar en <span id="expiration-time"></span> segundos.
+          Your session will expire in <span id="expiration-time"></span> seconds.
         </p>
-        <p>¿Quiere mantener su sesión?</p>
+        <p>Close Session?</p>
       </div>
       <div class="modal-footer">
         <button id="session-modal-yes" type="button" class="btn btn-primary">
-          Si
+          Yes
         </button>
         <button
           id="session-modal-no"

--- a/docs/es/platform/customers/forms.md
+++ b/docs/es/platform/customers/forms.md
@@ -163,7 +163,7 @@ El correo de agradecimiento te permite personalizar un correo que será enviado 
 A continuación, tienes un ejemplo de código que podrás usar como base para personalizar el correo de agradecimiento.
 
 ```liquid
-Enviaste esta respuesta el: {{ 'now' | date: "%b %d, %y" }}
+Message Sent: {{ 'now' | date: "%b %d, %y" }}
 <table width="600px">
     <tr>
         <td><b>user name</b></td>


### PR DESCRIPTION
- Se remueven todos los mensajes en español del codigo para poder reutilizarlo en la version en ingles de docs
- se incluyen tags para desplegar código en caso de que no existan (tarea miscelanea)