### PR TITLE
518 actualizacion de links e imagenes para ingles

### DIFF
--- a/docs/en/platform/basics/learn-modyo.md
+++ b/docs/en/platform/basics/learn-modyo.md
@@ -16,34 +16,34 @@ Take as many courses as you need according to your role, or take them all to bec
 ## Basic Level
 The basic level courses are for people who are learning to use Modyo for the first time, we recommend that you always take the Introduction to Modyo course first, before moving on to other courses
 
-<a href="https://help.modyo.com/es/articles/6871283-introduccion-a-modyo" target="_blank">
-    <img src="https://cdn.modyo.cloud/uploads/07374707-2f79-40ad-ad1f-6f69f3b9bf9a/original/ES-01-intro-modyo.png" width="500" alt="Introducción a Modyo" />
+<a href="https://help.modyo.com/en/articles/6871283-introduction-to-modyo" target="_blank">
+    <img src="https://cdn.modyo.cloud/uploads/1646f557-ec49-44a7-87dd-3443eed53cc2/original/EN-01-intro-modyo.png" width="500" alt="Introducción a Modyo" />
 </a>
 
-<a href="https://help.modyo.com/es/articles/6872056-introduccion-a-la-gestion-de-contenidos" target="_blank">
-    <img src="https://cdn.modyo.cloud/uploads/54c82443-84d7-4bba-b19d-909b89192d59/original/ES-02-content-management.png" width="500" alt="Gestion de Contenidos" />
+<a href="https://help.modyo.com/en/articles/6872056-content-management" target="_blank">
+    <img src="https://cdn.modyo.cloud/uploads/6e152b2f-7aa7-4d57-a083-b1dea0dc8d5e/original/EN-02-content-management.png" width="500" alt="Gestion de Contenidos" />
 </a>
 
 ## Intermediate Level
 For users who already have a basic knowledge of using Modyo, these courses provide them with a deeper view of the tool.
 
-<a href="https://help.modyo.com/es/articles/6849565-learning-path-creacion-de-sitios-web" target="_blank">
-    <img src="https://cdn.modyo.cloud/uploads/7c8e3f90-8715-48ac-999d-3563932cd80c/original/ES-03-building-websites.png" width="500" alt="Desarrollo de sitios web" />
+<a href="https://help.modyo.com/en/articles/6849565-building-websites-with-modyo" target="_blank">
+    <img src="https://cdn.modyo.cloud/uploads/92b384ed-af1d-4425-afbf-c9b9beac48dd/original/EN-03-building-websites.png" width="500" alt="Desarrollo de sitios web" />
 </a>
 
-<a href="https://help.modyo.com/es/articles/6873913-crea-microfrontends-con-el-widget-builder" target="_blank">
-    <img src="https://cdn.modyo.cloud/uploads/dab8974d-7a2a-401c-b54a-f105c3b23cf4/original/Learning_path_04_Widget_builder_ES.png" width="500" alt="Microfrontends con el widget Builder" />
+<a href="https://help.modyo.com/en/articles/6873913-build-microfrontends-with-the-widget-builder" target="_blank">
+    <img src="https://cdn.modyo.cloud/uploads/1e54a266-5f38-4bd4-83a1-a5ae27e14002/original/Learning_path_04_Widget_builder.png" width="500" alt="Microfrontends con el widget Builder" />
 </a>
 
 ## Advanced Level
 Users who already have knowledge and experience, both in creating sites in Modyo and skills in developing web applications, can find useful resources in these advanced courses:
 
-<a href="https://help.modyo.com/es/articles/6873935-crea-microfrontends-con-el-cli-de-modyo" target="_blank">
-    <img src="https://cdn.modyo.cloud/uploads/9c9a6fe1-62bb-4d5b-a526-7a7d8cfa5a72/original/ES-06-CLI.png" width="500" alt="Microfrontends con el CLI" />
+<a href="https://help.modyo.com/en/articles/6873935-build-microfrontends-with-the-modyo-s-cli" target="_blank">
+    <img src="https://cdn.modyo.cloud/uploads/d6f4ab78-4576-4885-ad88-408b6616a645/original/EN-06-CLI.png" width="500" alt="Microfrontends con el CLI" />
 </a>
 
-<a href="https://help.modyo.com/es/articles/6873957-desarrollo-multiplataforma-con-pwas" target="_blank">
-    <img src="https://cdn.modyo.cloud/uploads/267c3da7-4ac3-4061-b9cf-d145fede3317/original/ES-05-PWA.png" width="500" alt="Apps Multiplataforma con PWA" />
+<a href="https://help.modyo.com/en/articles/6873957-cross-platform-development-with-pwas" target="_blank">
+    <img src="https://cdn.modyo.cloud/uploads/95655662-4a8e-42bb-b02b-000f315d72f4/original/EN-05-PWA.png" width="500" alt="Apps Multiplataforma con PWA" />
 </a>
 
 ## Additional Resources


### PR DESCRIPTION
Transifex no traduce el path a las imágenes y tampoco llegaron los links de los learning paths a transifex. Abrí este PR para actualizar las imagenes y los links. 

Ahora si, todo apunta al contenido en inglés y las imágenes para los Learning Paths son las correctas. Espero este correcto este proceso. 