### PR TITLE
eliminacion de referencias a Modyo 10

### DIFF
--- a/docs/es/architecture/patterns/public-site.md
+++ b/docs/es/architecture/patterns/public-site.md
@@ -168,10 +168,7 @@ La [internacionalización](/es/architecture/patterns/internationalization) en un
 
 Es importante destacar que al implementar idiomas mediante la clonación de sitios, los contenidos de los espacios no se duplican, ya que estos sí admiten varios idiomas. A la vez, es relevante mencionar que cualquier técnica basada en JavaScript o dinámica para cambiar el idioma de un sitio sin seguir nuestras recomendaciones puede afectar diversos atributos mencionados en esta guía, como la accesibilidad o la indexación.
 
-:::tip Modyo 10
-La próxima versión de Modyo incluirá soporte mejorado para la internacionalización, lo que permitirá trabajar con varios idiomas en un mismo sitio y cambiar de idioma dinámicamente sin la necesidad de duplicar esfuerzos.
-:::
-
+Modyo cuenta con soporte avanzado para la internacionalización, lo que te permite trabajar con varios idiomas en un mismo sitio y cambiar de idioma dinámicamente sin la necesidad de duplicar esfuerzos.
 
 ### Búsqueda
 En un sitio público, la búsqueda de contenido es un elemento fundamental. Para ello, la plataforma dispone de un buscador interno que indexa el contenido del sitio y proporciona una interfaz sencilla para mostrar los resultados. Este buscador utiliza criterios internos para evaluar la relevancia de los resultados, basándose en prácticas comunes de indexación como priorizar títulos sobre descripciones, frecuencia de palabras clave, entre otros.

--- a/docs/es/architecture/patterns/public-site.md
+++ b/docs/es/architecture/patterns/public-site.md
@@ -168,8 +168,6 @@ La [internacionalización](/es/architecture/patterns/internationalization) en un
 
 Es importante destacar que al implementar idiomas mediante la clonación de sitios, los contenidos de los espacios no se duplican, ya que estos sí admiten varios idiomas. A la vez, es relevante mencionar que cualquier técnica basada en JavaScript o dinámica para cambiar el idioma de un sitio sin seguir nuestras recomendaciones puede afectar diversos atributos mencionados en esta guía, como la accesibilidad o la indexación.
 
-Modyo cuenta con soporte avanzado para la internacionalización, lo que te permite trabajar con varios idiomas en un mismo sitio y cambiar de idioma dinámicamente sin la necesidad de duplicar esfuerzos.
-
 ### Búsqueda
 En un sitio público, la búsqueda de contenido es un elemento fundamental. Para ello, la plataforma dispone de un buscador interno que indexa el contenido del sitio y proporciona una interfaz sencilla para mostrar los resultados. Este buscador utiliza criterios internos para evaluar la relevancia de los resultados, basándose en prácticas comunes de indexación como priorizar títulos sobre descripciones, frecuencia de palabras clave, entre otros.
 

--- a/docs/es/architecture/patterns/spa.md
+++ b/docs/es/architecture/patterns/spa.md
@@ -33,6 +33,4 @@ Para implementar una SPA con Modyo debes usar las capacidades de [Modyo Connect]
 
 Los cambios son gestionados directamente por el repositorio de código del servicio y mediante el uso de automatizaciones puedes realizar despliegues e invalidaciones de caché al momento de incorporar o mezclar los cambios.
 
-:::tip Modyo 10
-En Modyo 10, la futura versión de la plataforma, habrá soporte directo desde la consola de administración web para el despliegue de módulos estáticos en la CDN. Esto proporcionará un sistema de hospedaje estático para trabajar con SPAs y otro tipo de librerías, dejando a la plataforma en control de los despliegues y las invalidaciones de caché.
-:::
+Desde la consola de administración web tienes soporte directo para el despliegue de módulos estáticos en la CDN. Esto proporciona un sistema de hospedaje estático para trabajar con SPAs y otro tipo de librerías, dejando a la plataforma en control de los despliegues y las invalidaciones de caché.

--- a/docs/es/architecture/patterns/spa.md
+++ b/docs/es/architecture/patterns/spa.md
@@ -33,4 +33,6 @@ Para implementar una SPA con Modyo debes usar las capacidades de [Modyo Connect]
 
 Los cambios son gestionados directamente por el repositorio de código del servicio y mediante el uso de automatizaciones puedes realizar despliegues e invalidaciones de caché al momento de incorporar o mezclar los cambios.
 
-Desde la consola de administración web tienes soporte directo para el despliegue de módulos estáticos en la CDN. Esto proporciona un sistema de hospedaje estático para trabajar con SPAs y otro tipo de librerías, dejando a la plataforma en control de los despliegues y las invalidaciones de caché.
+:::tip Modyo 10
+En Modyo 10, la futura versión de la plataforma, habrá soporte directo desde la consola de administración web para el despliegue de módulos estáticos en la CDN. Esto proporcionará un sistema de hospedaje estático para trabajar con SPAs y otro tipo de librerías, dejando a la plataforma en control de los despliegues y las invalidaciones de caché.
+:::

--- a/docs/es/platform/content/asset-manager.md
+++ b/docs/es/platform/content/asset-manager.md
@@ -2,14 +2,17 @@
 search: true
 ---
 
-# Gestor de Archivos
+# Media
+
+:::tip Tip
+- En `Modyo 9` este espacio se llama **Gestor de archivos**. Si migras de Modyo 9 a Modyo 10 todos los assets se conservan y podrás elegir previamente a cuál espacio moverlos.
+:::
 
 Este espacio te permite cargar, organizar y gestionar tus archivos de forma simple y eficiente.
 
 - En `Modyo 9` este espacio se llama **Gestor de archivos**: Al migrar a Modyo 10 todos los assets se conservan y podrás elegir previamente a cuál espacio moverlos.
 
-- A partir de `Modyo 10` este espacio se denomina **Media**: Aquí (a diferencia del Gestor de Archivos en Modyo 9), los permisos de edición y eliminación de imágenes se llevan a cabo a través de grupos. De esta manera, un grupo puede tener permisos para ver y usar assets, pero no podrá modificarlos o eliminarlos.
-
+En Media puedes asignar permisos de edición y eliminación de imágenes a través de grupos. De esta manera, un grupo puede tener permisos para ver y usar assets, pero no podrá modificarlos o eliminarlos.
 Puedes cargar diversos tipos de media a este espacio, considerando las siguientes restricciones de tamaño por archivo:
 
 
@@ -60,15 +63,6 @@ Para cargar un archivo en Modyo, elige una de las siguientes opciones:
 
 #### En la sección dedicada para administrar archivos.
 
-`Modyo 9`
-1. En el menú lateral selecciona **Content**.
-1. Haz click en **Gestor de archivos**.
-1. Da click en el botón **+ Nuevo Asset**.
-1. Arrastra el archivo o haz click en el recuadro de carga para abrir una ventana de búsqueda.
-1. Agrega etiquetas al archivo si lo deseas.
-1. Da click en **Upload** para confirmar.
-
-`Modyo 10`
 1. En el menú lateral da click en el ícono de **Content**.
 1. Selecciona un espacio.
 1. En el menú lateral da click en **Media**.

--- a/docs/es/platform/content/asset-manager.md
+++ b/docs/es/platform/content/asset-manager.md
@@ -10,8 +10,6 @@ search: true
 
 Este espacio te permite cargar, organizar y gestionar tus archivos de forma simple y eficiente.
 
-- En `Modyo 9` este espacio se llama **Gestor de archivos**: Al migrar a Modyo 10 todos los assets se conservan y podrás elegir previamente a cuál espacio moverlos.
-
 En Media puedes asignar permisos de edición y eliminación de imágenes a través de grupos. De esta manera, un grupo puede tener permisos para ver y usar assets, pero no podrá modificarlos o eliminarlos.
 Puedes cargar diversos tipos de media a este espacio, considerando las siguientes restricciones de tamaño por archivo:
 

--- a/docs/es/platform/customers/realms.md
+++ b/docs/es/platform/customers/realms.md
@@ -272,8 +272,6 @@ Para integrar con Zendesk necesitas:
 - Shared secret de Zendesk
 - URL de la integración: e.g. mysubdomain.zendesk.com
 
-`solo disponible en Modyo 10`
-
 ### Salesforce
 
 Una integración de Salesforce con Modyo te permite vincular tus usuarios de Modyo con tus contactos de Salesforce.


### PR DESCRIPTION
En este PR eliminé las referencias a Modyo 10 y corregí el contenido, si era necesario, en estos documentos: 

* [Sitio Público | Modyo Docs](https://docs.modyo.com/es/architecture/patterns/public-site.html)  Internacionalizacion

* [Single Page Application | Modyo Docs](https://docs.modyo.com/es/architecture/patterns/spa.html#implementacion-de-una-spa-con-modyo)  Single Page Application

* [Reinos | Modyo Docs](https://docs.modyo.com/es/platform/customers/realms.html#zendesk)  Zendesk