### PR TITLE
Origination en el menu lateral INGLES

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -138,6 +138,7 @@ module.exports = {
                             "/en/platform/customers/events",
                             "/en/platform/customers/segments",
                             "/en/platform/customers/forms",
+                            "/en/platform/customers/origination",
                             "/en/platform/customers/messaging",
                             "/en/platform/customers/api",
                         ],


### PR DESCRIPTION
En este PR:

- Se muestra un enlace a origination en la versión en inglés



NO MEZCLAR HASTA QUE TERMINE EL PROCESO DE TRADUCCIÓN Y EXISTE EL ENLACE A ORIGINACIÓN

https://docs.modyo.com/en/platform/customers/origination.html

Enlaces muertos crashean toda la aplicación. 