### PR TITLE
elimina los ":" de los strings en negrita para prevenir errores

### DIFF
--- a/docs/es/architecture/patterns/accessibility.md
+++ b/docs/es/architecture/patterns/accessibility.md
@@ -11,11 +11,11 @@ La accesibilidad web se basa en el principio de diseño universal, que busca cre
 Aspectos clave de la accesibilidad web:
 
 
-- **Compatibilidad con tecnologías asistivas:** Asegurar que las tecnologías asistivas, como lectores de pantalla o teclados especiales, puedan navegar y acceder al contenido de manera efectiva.
-- **Etiquetado semántico:** Utilizar correctamente las etiquetas HTML para estructurar y describir el contenido de manera clara, permitiendo que las personas con discapacidades visuales o cognitivas comprendan la información presentada.
-- **Contraste y legibilidad:** Asegurar contraste adecuado entre texto y fondo para facilitar la lectura a personas con discapacidades visuales o dificultades de percepción.
-- **Facilidad de navegación y uso:** Diseñar interfaces intuitivas y fáciles de navegar, incorporando controles y elementos interactivos accesibles tanto con el mouse como con el teclado.
-- **Alternativas para contenido no textual:** Proporcionar descripciones textuales para imágenes o videos para que personas con discapacidades visuales o auditivas comprendan el contenido.
+- **Compatibilidad con tecnologías asistivas**: Asegurar que las tecnologías asistivas, como lectores de pantalla o teclados especiales, puedan navegar y acceder al contenido de manera efectiva.
+- **Etiquetado semántico**: Utilizar correctamente las etiquetas HTML para estructurar y describir el contenido de manera clara, permitiendo que las personas con discapacidades visuales o cognitivas comprendan la información presentada.
+- **Contraste y legibilidad**: Asegurar contraste adecuado entre texto y fondo para facilitar la lectura a personas con discapacidades visuales o dificultades de percepción.
+- **Facilidad de navegación y uso**: Diseñar interfaces intuitivas y fáciles de navegar, incorporando controles y elementos interactivos accesibles tanto con el mouse como con el teclado.
+- **Alternativas para contenido no textual**: Proporcionar descripciones textuales para imágenes o videos para que personas con discapacidades visuales o auditivas comprendan el contenido.
 
 La accesibilidad web es esencial para la inclusión y la igualdad de acceso a la información y los servicios en línea. Cumplir con estándares y pautas de accesibilidad, como las establecidas por el Consorcio World Wide Web (W3C) en las Pautas de Accesibilidad al Contenido Web (WCAG), es fundamental para crear una web accesible y llegar a un público más amplio.
 
@@ -25,10 +25,10 @@ La accesibilidad web es esencial para la inclusión y la igualdad de acceso a la
 
 La accesibilidad web se mide mediante diferentes técnicas y evaluaciones. Algunas de las formas más comunes son:
 
-- **Evaluación manual:** Consiste en revisar manualmente el sitio web o la aplicación para identificar posibles barreras de accesibilidad, incluyendo verificar la estructura del contenido, el uso correcto de etiquetas, el contraste, la navegabilidad, la presencia de alternativas para contenido no textual y otros aspectos clave.
-- **Herramientas de evaluación automática:** Utiliza herramientas automatizadas que analizan el código y el contenido de un sitio web en busca de problemas de accesibilidad. Estas herramientas pueden detectar elementos faltantes o incorrectos, proporcionar recomendaciones y generar informes sobre el nivel de accesibilidad del sitio.
-- **Pruebas con usuarios reales:** Implica que personas con discapacidades o limitaciones prueben y evalúen la accesibilidad del sitio web. Los usuarios reales pueden proporcionar comentarios valiosos para encontrar barreras e identificar áreas de mejora.
-- **Cumplimiento de estándares y pautas:** Consiste en evaluar si el sitio web cumple con los estándares y pautas de accesibilidad establecidos, como las WCAG del W3C.
+- **Evaluación manual**: Consiste en revisar manualmente el sitio web o la aplicación para identificar posibles barreras de accesibilidad, incluyendo verificar la estructura del contenido, el uso correcto de etiquetas, el contraste, la navegabilidad, la presencia de alternativas para contenido no textual y otros aspectos clave.
+- **Herramientas de evaluación automática**: Utiliza herramientas automatizadas que analizan el código y el contenido de un sitio web en busca de problemas de accesibilidad. Estas herramientas pueden detectar elementos faltantes o incorrectos, proporcionar recomendaciones y generar informes sobre el nivel de accesibilidad del sitio.
+- **Pruebas con usuarios reales**: Implica que personas con discapacidades o limitaciones prueben y evalúen la accesibilidad del sitio web. Los usuarios reales pueden proporcionar comentarios valiosos para encontrar barreras e identificar áreas de mejora.
+- **Cumplimiento de estándares y pautas**: Consiste en evaluar si el sitio web cumple con los estándares y pautas de accesibilidad establecidos, como las WCAG del W3C.
 
 La accesibilidad web es un proceso continuo que debes realizar periódicamente para garantizar que un sitio web o aplicación sea siempre accesible, especialmente durante fases de desarrollo y actualizaciones. Es esencial considerar las necesidades y los comentarios de usuarios con discapacidades, ya que son quienes mejor pueden evaluar la accesibilidad del sitio.
 

--- a/docs/es/architecture/patterns/bff.md
+++ b/docs/es/architecture/patterns/bff.md
@@ -12,10 +12,10 @@ El patrón BFF resuelve esto añadiendo una capa de backend específica para cad
 
 Ventajas del patrón BFF:
 
-- **Adaptabilidad:** Se adapta a las necesidades de cada cliente y a las necesidades de visualización, optimizando la experiencia del usuario.
-- **Independencia del frontend:** Los equipos de frontend y backend pueden trabajar de manera independiente y realizar cambios sin afectar a los otros componentes.
-- **Mejora de rendimiento:** Optimiza consultas y respuestas de datos para cada cliente, mejorando así el rendimiento de la aplicación.
-- **Facilidad de evolución:** Simplifica la evolución y mantenimiento de la aplicación al separar responsabilidades. Se pueden realizar cambios en una interfaz de usuario sin afectar a otras partes del sistema.
+- **Adaptabilidad**: Se adapta a las necesidades de cada cliente y a las necesidades de visualización, optimizando la experiencia del usuario.
+- **Independencia del frontend**: Los equipos de frontend y backend pueden trabajar de manera independiente y realizar cambios sin afectar a los otros componentes.
+- **Mejora de rendimiento**: Optimiza consultas y respuestas de datos para cada cliente, mejorando así el rendimiento de la aplicación.
+- **Facilidad de evolución**: Simplifica la evolución y mantenimiento de la aplicación al separar responsabilidades. Se pueden realizar cambios en una interfaz de usuario sin afectar a otras partes del sistema.
 
 
 ### Implementación de BFF con Modyo

--- a/docs/es/architecture/patterns/code-reuse.md
+++ b/docs/es/architecture/patterns/code-reuse.md
@@ -8,9 +8,9 @@ El reuso de código es la práctica de escribir código que puedes usar en múlt
 
 Esta práctica ofrece múltiples ventajas, como:
 
-- **Eficiencia:** Ahorro de tiempo y esfuerzo al no tener que escribir el mismo código una y otra vez.
-- **Consistencia:** Ayuda a asegurar que ciertas funciones se comporten de manera consistente en todas las partes de una aplicación o en diferentes aplicaciones.
-- **Mantenibilidad:** Es más fácil y más rápido actualizar o corregir errores en una única base de código reutilizable que en múltiples copias del mismo código.
+- **Eficiencia**: Ahorro de tiempo y esfuerzo al no tener que escribir el mismo código una y otra vez.
+- **Consistencia**: Ayuda a asegurar que ciertas funciones se comporten de manera consistente en todas las partes de una aplicación o en diferentes aplicaciones.
+- **Mantenibilidad**: Es más fácil y más rápido actualizar o corregir errores en una única base de código reutilizable que en múltiples copias del mismo código.
 
 Existen varias formas de reutilizar código en el desarrollo de aplicaciones web. Esto incluye el uso de librerías o frameworks, la creación de componentes reutilizables y la organización del código, de manera que puedes referenciar y reutilizar fácilmente partes del mismo en distintas partes de una aplicación.
 

--- a/docs/es/architecture/patterns/ddd.md
+++ b/docs/es/architecture/patterns/ddd.md
@@ -8,15 +8,15 @@ El Domain-Driven Design (DDD) es una metodología de desarrollo de software que 
 
 Ventajas del DDD:
 
-- **Comunicación mejorada:** Fomenta el uso de un lenguaje común llamado "lenguaje ubicuo" entre desarrolladores, stakeholders y usuarios; lo que mejora la comunicación y la comprensión en el proyecto.
-- **Enfoque en el dominio del negocio:** Garantiza que el software se adapte a las necesidades y procesos del negocio.
-- **Diseño de software de alta calidad:** Promueve los principios SOLID de diseño de software, lo que conlleva a un software más mantenible y adaptable.
+- **Comunicación mejorada**: Fomenta el uso de un lenguaje común llamado "lenguaje ubicuo" entre desarrolladores, stakeholders y usuarios; lo que mejora la comunicación y la comprensión en el proyecto.
+- **Enfoque en el dominio del negocio**: Garantiza que el software se adapte a las necesidades y procesos del negocio.
+- **Diseño de software de alta calidad**: Promueve los principios SOLID de diseño de software, lo que conlleva a un software más mantenible y adaptable.
 
 Desventajas del DDD:
 
-- **Complejidad:** Puede ser complejo y requerir tiempo y esfuerzo considerables para implementar correctamente. Puede no ser adecuado para aplicaciones más simples o equipos con menos experiencia en diseño de software.
-- **Requiere conocimiento del dominio:** Para usar DDD efectivamente, los desarrolladores deben tener o adquirir un buen entendimiento del dominio del negocio, lo cual puede ser un desafío en algunos contextos.
-- **No es adecuado para todas las aplicaciones:** Es más útil en aplicaciones empresariales complejas. En aplicaciones con lógica de negocio simple, la sobrecarga de DDD puede no justificar los beneficios.
+- **Complejidad**: Puede ser complejo y requerir tiempo y esfuerzo considerables para implementar correctamente. Puede no ser adecuado para aplicaciones más simples o equipos con menos experiencia en diseño de software.
+- **Requiere conocimiento del dominio**: Para usar DDD efectivamente, los desarrolladores deben tener o adquirir un buen entendimiento del dominio del negocio, lo cual puede ser un desafío en algunos contextos.
+- **No es adecuado para todas las aplicaciones**: Es más útil en aplicaciones empresariales complejas. En aplicaciones con lógica de negocio simple, la sobrecarga de DDD puede no justificar los beneficios.
 
 El DDD puede ser una herramienta valiosa para desarrollar software de alta calidad que se alinee estrechamente con las necesidades de un negocio. Sin embargo, es importante considerar cuidadosamente si es el enfoque adecuado para tu situación específica.
 

--- a/docs/es/architecture/patterns/design-system.md
+++ b/docs/es/architecture/patterns/design-system.md
@@ -14,19 +14,19 @@ Su finalidad principal es mejorar la eficiencia y la consistencia en el proceso 
 
 Ventajas:
 
-- **Consistencia:** Un sistema de diseño mantiene la consistencia en múltiples productos y plataformas al proporcionar un conjunto estándar de componentes y estilos.
-- **Eficiencia:** Los equipos pueden trabajar más rápido al reutilizar componentes existentes, en lugar de diseñar y codificar elementos desde cero para cada nuevo proyecto.
-- **Colaboración:** Fomenta una mejor colaboración entre los diseñadores y desarrolladores, al proporcionar un lenguaje visual común y directrices claras para la implementación.
-- **Usabilidad y experiencia de usuario:** La consistencia proporcionada por un sistema de diseño mejora la experiencia de usuario, evitando la necesidad de aprender nuevas interfaces para cada producto.
-- **Mantenibilidad:** Las actualizaciones y las correcciones de errores son más fáciles de implementar al utilizar componentes estandarizados.
+- **Consistencia**: Un sistema de diseño mantiene la consistencia en múltiples productos y plataformas al proporcionar un conjunto estándar de componentes y estilos.
+- **Eficiencia**: Los equipos pueden trabajar más rápido al reutilizar componentes existentes, en lugar de diseñar y codificar elementos desde cero para cada nuevo proyecto.
+- **Colaboración**: Fomenta una mejor colaboración entre los diseñadores y desarrolladores, al proporcionar un lenguaje visual común y directrices claras para la implementación.
+- **Usabilidad y experiencia de usuario**: La consistencia proporcionada por un sistema de diseño mejora la experiencia de usuario, evitando la necesidad de aprender nuevas interfaces para cada producto.
+- **Mantenibilidad**: Las actualizaciones y las correcciones de errores son más fáciles de implementar al utilizar componentes estandarizados.
 
 Desventajas:
 
-- **Tiempo y recursos:** Crear y mantener un sistema de diseño requiere una inversión significativa de tiempo y recursos, especialmente en las primeras etapas.
-- **Flexibilidad limitada:** Los sistemas de diseño pueden ser restrictivos y limitar la creatividad al requerir el uso de componentes estándar.
-- **Adopción y resistencia al cambio:** Puede ser un desafío lograr que todos los miembros del equipo adopten y sigan consistentemente el sistema de diseño.
-- **Mantenibilidad:** El sistema de diseño debe evolucionar con los cambios en productos y necesidades de los usuarios, lo que requiere un compromiso continuo con su mantenimiento y actualización.
-- **Sobre-estandarización:** Llevado al extremo, puede llevar a productos que se ven y se sienten demasiado similares, sin individualidad.
+- **Tiempo y recursos**: Crear y mantener un sistema de diseño requiere una inversión significativa de tiempo y recursos, especialmente en las primeras etapas.
+- **Flexibilidad limitada**: Los sistemas de diseño pueden ser restrictivos y limitar la creatividad al requerir el uso de componentes estándar.
+- **Adopción y resistencia al cambio**: Puede ser un desafío lograr que todos los miembros del equipo adopten y sigan consistentemente el sistema de diseño.
+- **Mantenibilidad**: El sistema de diseño debe evolucionar con los cambios en productos y necesidades de los usuarios, lo que requiere un compromiso continuo con su mantenimiento y actualización.
+- **Sobre-estandarización**: Llevado al extremo, puede llevar a productos que se ven y se sienten demasiado similares, sin individualidad.
 
 Un sistema de diseño bien implementado y mantenido puede ofrecer más ventajas que desventajas. Sin embargo, requiere una inversión continua y el compromiso del equipo para garantizar su éxito a largo plazo.
 
@@ -52,12 +52,12 @@ Esto incluye snippets con CSS, HTML y parámetros configurables, así como widge
 
 Implementar un sistema de diseño en la web involucra crear y mantener un conjunto coherente de estándares de diseño y componentes de interfaz de usuario (UI) reutilizables. Para ello, sigue estos pasos:
 
-- **Definir los Estándares de Diseño:** Incluye colores, tipografías, espaciado, iconografía y otros elementos visuales comunes en toda tu web o aplicación. Documenta estos estándares en una guía de estilo o manual de marca.
-- **Crear Componentes de UI Reutilizables:** Desarrolla una biblioteca de componentes de UI que puedas reutilizar en toda la web o aplicación, como botones, formularios, tarjetas y barras de navegación. Estos componentes deben crearse de manera que sean fácilmente reutilizables y modificables.
-- **Documentar el Uso de Componentes:** Acompaña la creación de componentes con guías de implementación, mejores prácticas y ejemplos de uso.
-- **Mantener el Sistema de Diseño:** Mantén y actualiza el sistema de diseño conforme cambian las necesidades de tu web o aplicación. Revisa y actualiza regularmente los componentes y estándares del sistema.
-- **Herramientas de Implementación:** Utiliza herramientas como Storybook, Figma, Sketch y Adobe XD para crear, mantener y compartir sistemas de diseño.
-- **Colaboración y Adopción:** Asegúrate que el equipo de desarrollo esta alineado con el sistema de diseño y lo incorpora en su flujo de trabajo. Considera asignar un propietario o equipo dedicado para supervisar y mantener el sistema de diseño.
+- **Definir los Estándares de Diseño**: Incluye colores, tipografías, espaciado, iconografía y otros elementos visuales comunes en toda tu web o aplicación. Documenta estos estándares en una guía de estilo o manual de marca.
+- **Crear Componentes de UI Reutilizables**: Desarrolla una biblioteca de componentes de UI que puedas reutilizar en toda la web o aplicación, como botones, formularios, tarjetas y barras de navegación. Estos componentes deben crearse de manera que sean fácilmente reutilizables y modificables.
+- **Documentar el Uso de Componentes**: Acompaña la creación de componentes con guías de implementación, mejores prácticas y ejemplos de uso.
+- **Mantener el Sistema de Diseño**: Mantén y actualiza el sistema de diseño conforme cambian las necesidades de tu web o aplicación. Revisa y actualiza regularmente los componentes y estándares del sistema.
+- **Herramientas de Implementación**: Utiliza herramientas como Storybook, Figma, Sketch y Adobe XD para crear, mantener y compartir sistemas de diseño.
+- **Colaboración y Adopción**: Asegúrate que el equipo de desarrollo esta alineado con el sistema de diseño y lo incorpora en su flujo de trabajo. Considera asignar un propietario o equipo dedicado para supervisar y mantener el sistema de diseño.
 
 :::tip Tip
 Un sistema de diseño es más que una colección de componentes UI y guías de estilo; es una parte integral del proceso de diseño y desarrollo que fomenta la coherencia y mejora la colaboración entre diseñadores y desarrolladores.

--- a/docs/es/architecture/patterns/hybrid-site.md
+++ b/docs/es/architecture/patterns/hybrid-site.md
@@ -21,10 +21,10 @@ La segmentación de contenidos personaliza y adapta el contenido que se muestra 
 
 Los segmentos pueden estar definidos por diversos criterios, incluyendo:
 
-- **Comportamiento del usuario:** páginas visitadas, compras realizadas o interacciones anteriores con el sitio o la aplicación.
-- **Información demográfica:** detalles como edad, género, ubicación, educación y otros datos demográficos del usuario.
-- **Intereses del usuario:** lo que se conoce o infiere que le interesa al usuario, basado en sus comportamientos pasados o en la información proporcionada.
-- **Etapa en el viaje del cliente:** punto en el que se encuentra el usuario en el recorrido del cliente o en el embudo de ventas. Por ejemplo, un usuario podría estar en la etapa de descubrimiento, consideración, decisión o fidelización.
+- **Comportamiento del usuario**: páginas visitadas, compras realizadas o interacciones anteriores con el sitio o la aplicación.
+- **Información demográfica**: detalles como edad, género, ubicación, educación y otros datos demográficos del usuario.
+- **Intereses del usuario**: lo que se conoce o infiere que le interesa al usuario, basado en sus comportamientos pasados o en la información proporcionada.
+- **Etapa en el viaje del cliente**: punto en el que se encuentra el usuario en el recorrido del cliente o en el embudo de ventas. Por ejemplo, un usuario podría estar en la etapa de descubrimiento, consideración, decisión o fidelización.
 
 En Modyo, los segmentos se definen de manera individual para cada dominio de usuarios, lo que permite crear varios segmentos en paralelo. Posteriormente, estos segmentos se pueden aplicar tanto a los contenidos como a las aplicaciones web.
 

--- a/docs/es/architecture/patterns/internationalization.md
+++ b/docs/es/architecture/patterns/internationalization.md
@@ -8,11 +8,11 @@ La internacionalización en aplicaciones web es el proceso de diseñar y desarro
 
 Para lograr esto, se deben considerar aspectos como:
 
-- **Localización de texto:** Implica separar el contenido textual de la aplicación de su código subyacente, permitiendo su traducción y adaptación a diferentes idiomas. Esto se logra mediante el uso de archivos de recursos o bases de datos.
-- **Formato de fecha y hora:** Las aplicaciones deben presentar fechas y horas en formatos comprensibles y aceptables en diversas regiones, incluyendo diferentes formatos de fecha, marcas de tiempo y opciones de zona horaria.
-- **Formato numérico y monetario:** Los sistemas de numeración y los símbolos monetarios varían según el país. Las aplicaciones web deben ser capaces de adaptar la forma en que muestran los números y los valores monetarios según las preferencias culturales de los usuarios.
-- **Soporte de caracteres y codificación:** Diferentes idiomas utilizan diferentes juegos de caracteres y codificaciones. Las aplicaciones web deben manejar y mostrar correctamente caracteres especiales y letras acentuadas correspondientes a diferentes idiomas.
-- **Diseño de interfaz:** La interfaz debe ser flexible para adaptarse a diferentes longitudes de texto y estructuras gramaticales. Por ejemplo, los idiomas escritos de derecha a izquierda requieren un diseño de interfaz inverso en comparación con los idiomas escritos de izquierda a derecha.
+- **Localización de texto**: Implica separar el contenido textual de la aplicación de su código subyacente, permitiendo su traducción y adaptación a diferentes idiomas. Esto se logra mediante el uso de archivos de recursos o bases de datos.
+- **Formato de fecha y hora**: Las aplicaciones deben presentar fechas y horas en formatos comprensibles y aceptables en diversas regiones, incluyendo diferentes formatos de fecha, marcas de tiempo y opciones de zona horaria.
+- **Formato numérico y monetario**: Los sistemas de numeración y los símbolos monetarios varían según el país. Las aplicaciones web deben ser capaces de adaptar la forma en que muestran los números y los valores monetarios según las preferencias culturales de los usuarios.
+- **Soporte de caracteres y codificación**: Diferentes idiomas utilizan diferentes juegos de caracteres y codificaciones. Las aplicaciones web deben manejar y mostrar correctamente caracteres especiales y letras acentuadas correspondientes a diferentes idiomas.
+- **Diseño de interfaz**: La interfaz debe ser flexible para adaptarse a diferentes longitudes de texto y estructuras gramaticales. Por ejemplo, los idiomas escritos de derecha a izquierda requieren un diseño de interfaz inverso en comparación con los idiomas escritos de izquierda a derecha.
 
 La implementación de prácticas de internacionalización facilita la traducción, localización y adaptación de la aplicación a diferentes idiomas y culturas. Esto amplía su alcance, llega a audiencias más amplias y mejora la experiencia del usuario al ofrecer contenido relevante y adaptado a su contexto local.
 

--- a/docs/es/architecture/patterns/micro-frontend.md
+++ b/docs/es/architecture/patterns/micro-frontend.md
@@ -14,16 +14,16 @@ Los micro frontends permiten a los equipos trabajar con mayor autonomía, ya que
 
 #### Características
 
-- **Son tecnológicamente agnósticos:** Cada equipo puede trabajar con diferentes tecnologías o versiones, ya que los micro frontends no dependen unos de otros. Por ejemplo, en una misma aplicación web, un micro frontend puede estar desarrollado en React y otro en Angular.
-- **Aislan el código del equipo:** Son aplicaciones independientes que no comparten recursos entre sí. Los códigos son independientes en cada equipo y se versionan por separado.
-- **Usan APIs nativas:** Los micro frontends favorecen las funciones nativas del navegador en lugar de desarrollar APIs personalizadas. Por ejemplo, utilizan controles nativos de geolocalización en lugar de desarrollos personalizados.
-- **Construyen un sitio resiliente:** En caso de que un micro frontend falle, su estado no contamina a los demás, ya que se cargan de forma asincrónica e independiente.
+- **Son tecnológicamente agnósticos**: Cada equipo puede trabajar con diferentes tecnologías o versiones, ya que los micro frontends no dependen unos de otros. Por ejemplo, en una misma aplicación web, un micro frontend puede estar desarrollado en React y otro en Angular.
+- **Aislan el código del equipo**: Son aplicaciones independientes que no comparten recursos entre sí. Los códigos son independientes en cada equipo y se versionan por separado.
+- **Usan APIs nativas**: Los micro frontends favorecen las funciones nativas del navegador en lugar de desarrollar APIs personalizadas. Por ejemplo, utilizan controles nativos de geolocalización en lugar de desarrollos personalizados.
+- **Construyen un sitio resiliente**: En caso de que un micro frontend falle, su estado no contamina a los demás, ya que se cargan de forma asincrónica e independiente.
 
 #### Beneficios
 
-- **Actualizaciones incrementales:** Al ser componentes independientes, los cambios y despliegues a producción también lo son. Para muchas organizaciones, este es el motivo principal para adoptar micro frontends.
-- **Código desacoplado y más simple:** El código de cada micro frontend es más pequeño que el de la aplicación completa, lo que facilita el trabajo de los desarrolladores.
-- **Despliegues independientes:** Al igual que en los microservicios, los despliegues independientes son un componente clave en la arquitectura de micro frontends. Cada micro frontend tiene su propio proceso de construcción, prueba y despliegue. Al reducir el alcance de cada despliegue, disminuye el riesgo asociado.
+- **Actualizaciones incrementales**: Al ser componentes independientes, los cambios y despliegues a producción también lo son. Para muchas organizaciones, este es el motivo principal para adoptar micro frontends.
+- **Código desacoplado y más simple**: El código de cada micro frontend es más pequeño que el de la aplicación completa, lo que facilita el trabajo de los desarrolladores.
+- **Despliegues independientes**: Al igual que en los microservicios, los despliegues independientes son un componente clave en la arquitectura de micro frontends. Cada micro frontend tiene su propio proceso de construcción, prueba y despliegue. Al reducir el alcance de cada despliegue, disminuye el riesgo asociado.
 - **Equipos independientes**: Los equipos independientes tienen mayor sentido de propiedad y control de los productos que mantienen, lo que fomenta un trabajo más rápido y eficiente.
 
 

--- a/docs/es/architecture/patterns/microservice.md
+++ b/docs/es/architecture/patterns/microservice.md
@@ -30,12 +30,12 @@ Cada servicio se crea para manejar capacidades empresariales específicas y se c
 
 #### Beneficios de los microservicios
 
-- **Agilidad:** Fomentan equipos pequeños e independientes que pueden trabajar de manera más rápida y eficiente en contextos bien comprendidos. Esto reduce los tiempos de desarrollo y aumenta el rendimiento de la organización.
-- **Escalabilidad flexible:** Permiten que cada servicio se escale de forma independiente para satisfacer la demanda de la característica de la aplicación que respalda. Esto permite a los equipos adaptarse a las necesidades de la infraestructura, medir con precisión el costo de una característica y mantener disponibilidad si un servicio experimenta un aumento en la demanda.
-- **Implementación sencilla:** Los microservicios permiten la integración y entrega continua, lo que facilita probar nuevas ideas y revertirlas si algo no funciona. El bajo costo de los errores permite experimentar, facilita la actualización del código y acelera el tiempo de comercialización de las nuevas características.
-- **Libertad tecnológica:** No siguen un enfoque de "diseño único". Los equipos tienen la libertad de elegir la mejor herramienta para resolver cada tarea o situación.
-- **Código reutilizable:** La división del software en módulos pequeños y bien definidos permite a los equipos usar funciones para diferentes propósitos. Un servicio desarrollado para una función específica puede ser utilizado como componente básico para otra característica. Esto facilita el inicio de una aplicación, ya que los desarrolladores pueden crear nuevas capacidades sin tener que escribir código desde cero.
-- **Resiliencia:** La independencia del servicio aumenta la resistencia a los errores. En caso de existir un error en un servicio, las aplicaciones pueden degradar la funcionalidad sin afectar toda la aplicación.
+- **Agilidad**: Fomentan equipos pequeños e independientes que pueden trabajar de manera más rápida y eficiente en contextos bien comprendidos. Esto reduce los tiempos de desarrollo y aumenta el rendimiento de la organización.
+- **Escalabilidad flexible**: Permiten que cada servicio se escale de forma independiente para satisfacer la demanda de la característica de la aplicación que respalda. Esto permite a los equipos adaptarse a las necesidades de la infraestructura, medir con precisión el costo de una característica y mantener disponibilidad si un servicio experimenta un aumento en la demanda.
+- **Implementación sencilla**: Los microservicios permiten la integración y entrega continua, lo que facilita probar nuevas ideas y revertirlas si algo no funciona. El bajo costo de los errores permite experimentar, facilita la actualización del código y acelera el tiempo de comercialización de las nuevas características.
+- **Libertad tecnológica**: No siguen un enfoque de "diseño único". Los equipos tienen la libertad de elegir la mejor herramienta para resolver cada tarea o situación.
+- **Código reutilizable**: La división del software en módulos pequeños y bien definidos permite a los equipos usar funciones para diferentes propósitos. Un servicio desarrollado para una función específica puede ser utilizado como componente básico para otra característica. Esto facilita el inicio de una aplicación, ya que los desarrolladores pueden crear nuevas capacidades sin tener que escribir código desde cero.
+- **Resiliencia**: La independencia del servicio aumenta la resistencia a los errores. En caso de existir un error en un servicio, las aplicaciones pueden degradar la funcionalidad sin afectar toda la aplicación.
 
 ### Implementación de microservicios con Modyo
 
@@ -47,11 +47,11 @@ Los microservicios desarrollados en Modyo Connect tienen la capacidad de escalar
 
 Algunas consideraciones importantes al desarrollar microservicios en Modyo Connect son:
 
-- **Spring Boot:** Framework utilizado para el desarrollo
-- **Modyo Commons Library:** Librería de apoyo para tareas comunes como la gestión de errores, registros de logs,
+- **Spring Boot**: Framework utilizado para el desarrollo
+- **Modyo Commons Library**: Librería de apoyo para tareas comunes como la gestión de errores, registros de logs,
   autenticación, etc.
-- **OpenAPI:** Estándar para la definición y publicación de APIs en el API Gateway
-- **Estructura y estilo de código:** Recomendamos utilizar el inicializador de [Spring Boot](https://start.spring.io)
+- **OpenAPI**: Estándar para la definición y publicación de APIs en el API Gateway
+- **Estructura y estilo de código**: Recomendamos utilizar el inicializador de [Spring Boot](https://start.spring.io)
   o [Yeoman](https://yeoman.io/generators) para dar una estándar al código fuente. Recomendamos además, seguir el
   estilo de código recomendado por [Google](https://google.github.io/styleguide/javaguide.html).
 
@@ -59,20 +59,20 @@ Algunas consideraciones importantes al desarrollar microservicios en Modyo Conne
 
 Los microservicios que requieren de persistencia relacional de datos deben considerar las siguientes pautas:
 
-- **Bloqueos:** Evitar consultas que puedan generar [bloqueos](https://www.baeldung.com/jpa-pessimistic-locking) en las tablas de la base de datos durante momentos de alta demanda.
-- **Eficiencia:** Traer únicamente la información requerida de la base de datos. En ocasiones puede ser beneficiosos utilizar [lazy loading](https://www.baeldung.com/hibernate-lazy-eager-loading) para evitar consultas innecesarias a la base de datos en cada iteración dentro de un bucle.
-- **Índices:** Asegurar que los índices aplicados al esquema sean efectivos. Usar el comando [“explain”](https://dev.mysql.com/doc/refman/8.0/en/using-explain.html) de forma local para verificar su uso.
-- **Migraciones y versionamiento:** Asegurar el [versionamiento y la automatización](https://flywaydb.org) de tareas que operan sobre el esquema de datos.
-- **Pool de conexiones:** Asegurar una configuración correcta del [pool de conexiones](https://www.baeldung.com/java-connection-pooling)y dimensionar adecuadamente el motor de base de datos, según la concurrencia y escalabilidad esperada.
+- **Bloqueos**: Evitar consultas que puedan generar [bloqueos](https://www.baeldung.com/jpa-pessimistic-locking) en las tablas de la base de datos durante momentos de alta demanda.
+- **Eficiencia**: Traer únicamente la información requerida de la base de datos. En ocasiones puede ser beneficiosos utilizar [lazy loading](https://www.baeldung.com/hibernate-lazy-eager-loading) para evitar consultas innecesarias a la base de datos en cada iteración dentro de un bucle.
+- **Índices**: Asegurar que los índices aplicados al esquema sean efectivos. Usar el comando ["explain"](https://dev.mysql.com/doc/refman/8.0/en/using-explain.html) de forma local para verificar su uso.
+- **Migraciones y versionamiento**: Asegurar el [versionamiento y la automatización](https://flywaydb.org) de tareas que operan sobre el esquema de datos.
+- **Pool de conexiones**: Asegurar una configuración correcta del [pool de conexiones](https://www.baeldung.com/java-connection-pooling)y dimensionar adecuadamente el motor de base de datos, según la concurrencia y escalabilidad esperada.
 
 #### Conexión con servicios externos
 
 Los microservicios desarrollados en Modyo Connect pueden integrarse a otros sistemas, como APIs y Web Services externos. Para ello debes tener presente las siguientes consideraciones:
 
-- **Conectividad:** Asegurar que la conectividad desde las redes de AWS hacia los endpoints del servicio estén definidos y sean estables.
-- **Seguridad:** Asegurar que el enlace a los servicios externos se establezca mediante un canal seguro, mediante VPNs o [mTLS](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/).
-- **Manejo de errores:** Los errores originados en servicios externos deben ser gestionados de manera apropiada a nivel del microservicio para asegurar una experiencia de usuario satisfactoria.
-- **Timeouts y bloqueos:** Los servicios externos con problemas de rendimiento o conectividad pueden causar bloqueos en la experiencia del usuario o un uso excesivo de recursos dentro del microservicio. Recomendamos definir timeouts razonables en cada llamada, alineados con los definidos en el API Gateway. Además, te sugerimos utilizar invocaciones asíncronas cuando los tiempos de respuesta no sean predecibles.
+- **Conectividad**: Asegurar que la conectividad desde las redes de AWS hacia los endpoints del servicio estén definidos y sean estables.
+- **Seguridad**: Asegurar que el enlace a los servicios externos se establezca mediante un canal seguro, mediante VPNs o [mTLS](https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/).
+- **Manejo de errores**: Los errores originados en servicios externos deben ser gestionados de manera apropiada a nivel del microservicio para asegurar una experiencia de usuario satisfactoria.
+- **Timeouts y bloqueos**: Los servicios externos con problemas de rendimiento o conectividad pueden causar bloqueos en la experiencia del usuario o un uso excesivo de recursos dentro del microservicio. Recomendamos definir timeouts razonables en cada llamada, alineados con los definidos en el API Gateway. Además, te sugerimos utilizar invocaciones asíncronas cuando los tiempos de respuesta no sean predecibles.
 
 #### Arquitectura Héxagonal
 La arquitectura hexagonal, también conocida como Arquitectura Puertos y Adaptadores, es un patrón de arquitectura de software que se enfoca en la separación de las preocupaciones (System on a Chip o SoC) y en la independencia del hardware y del software en una aplicación.
@@ -81,9 +81,9 @@ Esta arquitectura organiza la aplicación de manera que el núcleo de la lógica
 
 La arquitectura hexagonal se compone de tres capas principales:
 
-- **Capa de dominio:** Contiene la lógica de negocio de la aplicación y representa el núcleo de la arquitectura. Esta capa es independiente de la interfaz de usuario y de la capa de infraestructura.
-- **Capa de adaptadores de infraestructura:** Contiene los adaptadores que conectan la capa de dominio con las capas de infraestructura. Los adaptadores se encargan de transformar los datos entre los formatos de la capa de dominio y los formatos específicos de la infraestructura; por ejemplo, bases de datos y servicios web.
-- **Capa de infraestructura:** Contiene los componentes específicos de la infraestructura que se utilizan en la aplicación, como bases de datos, servicios web y sistemas de archivos.
+- **Capa de dominio**: Contiene la lógica de negocio de la aplicación y representa el núcleo de la arquitectura. Esta capa es independiente de la interfaz de usuario y de la capa de infraestructura.
+- **Capa de adaptadores de infraestructura**: Contiene los adaptadores que conectan la capa de dominio con las capas de infraestructura. Los adaptadores se encargan de transformar los datos entre los formatos de la capa de dominio y los formatos específicos de la infraestructura; por ejemplo, bases de datos y servicios web.
+- **Capa de infraestructura**: Contiene los componentes específicos de la infraestructura que se utilizan en la aplicación, como bases de datos, servicios web y sistemas de archivos.
 
 La arquitectura hexagonal tiene varios beneficios, entre ellos:
 
@@ -97,8 +97,8 @@ Los microservicios de Dynamic Framework se desarrollan siguiendo los principios 
 
 #### Otras consideraciones
 
-- **Tareas pesadas:** Recomendamos usar procesamiento en segundo plano, mediante [colas de mensajería](/es/connect/components/infrastructure.html#colas-de-mensajeria), para servicios lentos o sensibles a las fluctuaciones de tráfico.
-- **Programación de tareas:** Para servicios que requieren programación de tareas, recomendamos usar [ShedLock](https://www.baeldung.com/shedlock-spring) en los microservicios que requieran agendamiento de tareas programadas.
-- **Workflows y máquina de estado:** Se recomienda el uso de [máquinas de estados](https://www.baeldung.com/spring-state-machine) para la orquestación de procesos complejos. Así como integrar tecnologías de workflows con Spring Boot.
-- **Arquitectura hexagonal:** Para desarrollo, pruebas y mantenimiento más flexibles y centrados en el dominio de la aplicación, este patrón de diseño de software separa la lógica de negocio de una aplicación de sus servicios externos.
-- **API de Modyo:** Recomendamos usar el API administrativa de la plataforma Modyo para tareas comunes, como el envío de mensajes a usuarios o la integración con el contenido administrado.
+- **Tareas pesadas**: Recomendamos usar procesamiento en segundo plano, mediante [colas de mensajería](/es/connect/components/infrastructure.html#colas-de-mensajeria), para servicios lentos o sensibles a las fluctuaciones de tráfico.
+- **Programación de tareas**: Para servicios que requieren programación de tareas, recomendamos usar [ShedLock](https://www.baeldung.com/shedlock-spring) en los microservicios que requieran agendamiento de tareas programadas.
+- **Workflows y máquina de estado**: Se recomienda el uso de [máquinas de estados](https://www.baeldung.com/spring-state-machine) para la orquestación de procesos complejos. Así como integrar tecnologías de workflows con Spring Boot.
+- **Arquitectura hexagonal**: Para desarrollo, pruebas y mantenimiento más flexibles y centrados en el dominio de la aplicación, este patrón de diseño de software separa la lógica de negocio de una aplicación de sus servicios externos.
+- **API de Modyo**: Recomendamos usar el API administrativa de la plataforma Modyo para tareas comunes, como el envío de mensajes a usuarios o la integración con el contenido administrado.

--- a/docs/es/architecture/patterns/public-site.md
+++ b/docs/es/architecture/patterns/public-site.md
@@ -78,10 +78,10 @@ Esta recomendación es tanto por la inherente complejidad en el código de cada 
 
 Otras razones para evitar usar frameworks de JavaScript en sitios públicos son:
 
-- **Rendimiento:** Cada vez que un visitante carga una página, el navegador debe descargar y ejecutar el código JavaScript para mostrar y manipular los elementos de la página. El uso excesivo de JavaScript puede alentar la carga de la página, especialmente en dispositivos con conexiones lentas o recursos limitados.
-- **Accesibilidad:** Algunos usuarios pueden tener dificultades para acceder y usar contenido interactivo basado en Javascript. Esto incluye personas con discapacidades visuales que emplean lectores de pantalla, usuarios con conexiones lentas o dispositivos antiguos, y aquellos que desactivan Javascript por seguridad o preferencia personal.
-- **Mantenimiento y compatibilidad:** Reducir las dependencias de Javascript simplifica el mantenimiento del sitio. Además, estas soluciones tienden a tener mayor compatibilidad con diversos navegadores y dispositivos.
-- **Seguridad:** Limitar el uso de Javascript disminuye la superficie de ataque potencial y mejora la seguridad del sitio.
+- **Rendimiento**: Cada vez que un visitante carga una página, el navegador debe descargar y ejecutar el código JavaScript para mostrar y manipular los elementos de la página. El uso excesivo de JavaScript puede alentar la carga de la página, especialmente en dispositivos con conexiones lentas o recursos limitados.
+- **Accesibilidad**: Algunos usuarios pueden tener dificultades para acceder y usar contenido interactivo basado en Javascript. Esto incluye personas con discapacidades visuales que emplean lectores de pantalla, usuarios con conexiones lentas o dispositivos antiguos, y aquellos que desactivan Javascript por seguridad o preferencia personal.
+- **Mantenimiento y compatibilidad**: Reducir las dependencias de Javascript simplifica el mantenimiento del sitio. Además, estas soluciones tienden a tener mayor compatibilidad con diversos navegadores y dispositivos.
+- **Seguridad**: Limitar el uso de Javascript disminuye la superficie de ataque potencial y mejora la seguridad del sitio.
 
 En lugar de usar frameworks de Javascript, te sugerimos optar por HTML estático y, en caso de requerirlo, aprovechar el uso de del lenguaje Liquid.
 
@@ -143,9 +143,9 @@ En el contexto de sitios públicos, Modyo recomienda gestionar ambientes previos
 
 El uso de stages posibilita la creación de entornos separados y aislados para construir, probar y verificar el funcionamiento del sitio antes de ser desplegado en un entorno de producción. Esto ayuda a prevenir fallos que podrían afectar a los usuarios finales. En el caso de sitios públicos, se pueden definir, por ejemplo, los siguientes stages:
 
-- **Develop:** para llevar a cabo el desarrollo e integración de cambios.
-- **Certification:** destinado a pruebas previas al despliegue en producción.
-- **Main:** versión productiva del sitio.
+- **Develop**: para llevar a cabo el desarrollo e integración de cambios.
+- **Certification**: destinado a pruebas previas al despliegue en producción.
+- **Main**: versión productiva del sitio.
 
 Los stages pueden tener configuraciones independientes, como por ejemplo, las variables del sitio. Esto te permite ajustar comportamientos entre diferentes ambientes, por ejemplo, cambiar la URL de una API que proporciona información al sitio.
 
@@ -237,10 +237,10 @@ En el caso de Modyo Enterprise On Premise, puedes implementar características s
 Por último, entre los requisitos más importantes que un sitio público debe considerar, son aquellos relacionados con la privacidad de los datos de los usuarios. La atención a la privacidad es importante no solo desde un punto de vista legal y regulatorio, sino también como una manifestación del compromiso de la organización de hacer las cosas de manera correcta y transparente.
 
 En un sitio público, se maneja una cantidad limitada de información de usuario, pero esto no exime el cumplimiento de requisitos como:
-- **Cookie Banners:** Corresponde a los banners que brindan a los usuarios la opción de deshabilitar el seguimiento de ciertas cookies en el sitio, de manera completa o individual. El banner debe explicar la razón de cada cookie que se pretende instalar en el navegador del usuario.
-- **Cookie Policy:** Corresponde a la política que mantiene el sitio sobre el tipo de cookies utilizadas y su propósito, además de lo que eventualmente podría suceder con la experiencia del usuario en caso de no aceptarlas. La cookie policy generalmente se aceptan en el cookie banner.
-- **Privacy Policy:** Engloba la política de la organización con respecto a la privacidad de los datos del usuario en el contexto del sitio. Si el sitio público es un punto de entrada a un sistema privado o transaccional, esta política puede extenderse para cubrir todo el sistema.
-- **Gestión de consentimiento:** Consiste en registrar de manera precisa los consentimientos derivados de cualquier aceptación de condiciones por parte del usuario. Los registros de consentimiento deben guardarse durante un período determinado, conforme a las regulaciones vigentes en cada país.
+- **Cookie Banners**: Corresponde a los banners que brindan a los usuarios la opción de deshabilitar el seguimiento de ciertas cookies en el sitio, de manera completa o individual. El banner debe explicar la razón de cada cookie que se pretende instalar en el navegador del usuario.
+- **Cookie Policy**: Corresponde a la política que mantiene el sitio sobre el tipo de cookies utilizadas y su propósito, además de lo que eventualmente podría suceder con la experiencia del usuario en caso de no aceptarlas. La cookie policy generalmente se aceptan en el cookie banner.
+- **Privacy Policy**: Engloba la política de la organización con respecto a la privacidad de los datos del usuario en el contexto del sitio. Si el sitio público es un punto de entrada a un sistema privado o transaccional, esta política puede extenderse para cubrir todo el sistema.
+- **Gestión de consentimiento**: Consiste en registrar de manera precisa los consentimientos derivados de cualquier aceptación de condiciones por parte del usuario. Los registros de consentimiento deben guardarse durante un período determinado, conforme a las regulaciones vigentes en cada país.
 
 ### Otros requerimientos
 Finalmente, reservamos algunos requerimientos en específico que conviene tener en cuenta a la hora de implementar un sitio público.

--- a/docs/es/architecture/patterns/pwa.md
+++ b/docs/es/architecture/patterns/pwa.md
@@ -8,12 +8,12 @@ Las Progressive Web Applications (PWA) son aplicaciones web que combinan caracte
 
 Ventajas de las PWA:
 
-- **Instalación en el dispositivo:** Pueden instalarse en el dispositivo del usuario y accederse desde el escritorio o la pantalla de inicio, sin necesidad de una tienda de aplicaciones.
-- **Funcionamiento offline:** Gracias al almacenamiento en caché de navegadores modernos, las PWA pueden funcionar con conexiones intermitentes o sin conexión a Internet.
-- **Notificaciones push:** Pueden notificar a los usuarios, según se configuren.
-- **Acceso a hardware del dispositivo:** Pueden acceder a la cámara, GPS y más del dispositivo del usuario.
-- **Adaptabilidad a diferentes tamaños de pantalla:** Permitiendo unificar experiencias en diferentes dispositivos.
-- **Actualizaciones automáticas:** Garantizan que los usuarios siempre tengan la versión más reciente de la aplicación.
+- **Instalación en el dispositivo**: Pueden instalarse en el dispositivo del usuario y accederse desde el escritorio o la pantalla de inicio, sin necesidad de una tienda de aplicaciones.
+- **Funcionamiento offline**: Gracias al almacenamiento en caché de navegadores modernos, las PWA pueden funcionar con conexiones intermitentes o sin conexión a Internet.
+- **Notificaciones push**: Pueden notificar a los usuarios, según se configuren.
+- **Acceso a hardware del dispositivo**: Pueden acceder a la cámara, GPS y más del dispositivo del usuario.
+- **Adaptabilidad a diferentes tamaños de pantalla**: Permitiendo unificar experiencias en diferentes dispositivos.
+- **Actualizaciones automáticas**: Garantizan que los usuarios siempre tengan la versión más reciente de la aplicación.
 
 
 ### AppShell Nativo
@@ -28,10 +28,10 @@ WebView difiere significativamente de los navegadores nativos del dispositivo, l
 
 Las PWA pueden tener limitaciones en iOS debido a:
 
-- **Limitaciones del navegador:** En iOS, los navegadores disponibles, como Safari, tienen ciertas limitaciones en cuanto al soporte de funciones y tecnologías web. Esto puede afectar el rendimiento y la funcionalidad de las PWA en comparación con otros navegadores más modernos y compatibles con estándares web.
-- **Limitaciones del servicio de notificaciones:** Las notificaciones push son una característica importante de las PWA, pero solo los navegadores Safari y Firefox las admiten actualmente en iOS.
-- **Problemas de almacenamiento en caché:** El almacenamiento en caché de los recursos de una PWA puede ser más restrictivo en iOS que en otras plataformas. Esto puede llevar a que algunas funcionalidades no funcionen correctamente o a problemas con la actualización de contenido.
-- **Limitaciones de ejecución en segundo plano:** iOS tiene restricciones estrictas en la ejecución de código en segundo plano para ahorrar batería y mejorar el rendimiento. Esto puede afectar la capacidad de una PWA para funcionar correctamente en situaciones en las que se requiere un procesamiento continuo en segundo plano.
+- **Limitaciones del navegador**: En iOS, los navegadores disponibles, como Safari, tienen ciertas limitaciones en cuanto al soporte de funciones y tecnologías web. Esto puede afectar el rendimiento y la funcionalidad de las PWA en comparación con otros navegadores más modernos y compatibles con estándares web.
+- **Limitaciones del servicio de notificaciones**: Las notificaciones push son una característica importante de las PWA, pero solo los navegadores Safari y Firefox las admiten actualmente en iOS.
+- **Problemas de almacenamiento en caché**: El almacenamiento en caché de los recursos de una PWA puede ser más restrictivo en iOS que en otras plataformas. Esto puede llevar a que algunas funcionalidades no funcionen correctamente o a problemas con la actualización de contenido.
+- **Limitaciones de ejecución en segundo plano**: iOS tiene restricciones estrictas en la ejecución de código en segundo plano para ahorrar batería y mejorar el rendimiento. Esto puede afectar la capacidad de una PWA para funcionar correctamente en situaciones en las que se requiere un procesamiento continuo en segundo plano.
 
 Apple está trabajando en mejorar el soporte de PWA en iOS y ha introducido nuevas funcionalidades en versiones más recientes del sistema operativo. Sin embargo, aún existen limitaciones respecto a otras plataformas.
 
@@ -55,9 +55,9 @@ TWA funciona utilizando Chrome Custom Tabs, una variante de Chrome integrada en 
 
 Apple no tiene una funcionalidad equivalente a TWA en iOS. Sin embargo, ha introducido algunas características para mejorar la experiencia de las PWAs en dispositivos iOS, como por ejemplo:
 
-- **Añadir a la pantalla de inicio:** Permite a los usuarios agregar un acceso directo a una PWA en la pantalla de inicio. La PWA se ejecutará en el navegador Safari en pantalla completa.
-- **Manifiesto de aplicaciones web:** Permite personalizar la apariencia y el comportamiento de una PWA en iOS usando un archivo JSON que describe la PWA y sus características, como el nombre, los iconos, los colores temáticos y la orientación.
-- **Service Workers:** Una tecnología que permite almacenar en caché de recursos, funcionar sin conexión y mejorar el rendimiento de una PWA. Aunque Apple ha introducido limitaciones en la ejecución de Service Workers en segundo plano en iOS, aún se pueden aprovechar para mejorar la experiencia de la PWA mientras está activa en el navegador Safari.
+- **Añadir a la pantalla de inicio**: Permite a los usuarios agregar un acceso directo a una PWA en la pantalla de inicio. La PWA se ejecutará en el navegador Safari en pantalla completa.
+- **Manifiesto de aplicaciones web**: Permite personalizar la apariencia y el comportamiento de una PWA en iOS usando un archivo JSON que describe la PWA y sus características, como el nombre, los iconos, los colores temáticos y la orientación.
+- **Service Workers**: Una tecnología que permite almacenar en caché de recursos, funcionar sin conexión y mejorar el rendimiento de una PWA. Aunque Apple ha introducido limitaciones en la ejecución de Service Workers en segundo plano en iOS, aún se pueden aprovechar para mejorar la experiencia de la PWA mientras está activa en el navegador Safari.
 
 Estas características no ofrecen una experiencia idéntica a TWA, pero pueden mejorar la experiencia de las PWAs en iOS.
 
@@ -70,16 +70,16 @@ Apple puede introducir cambios o nuevas funcionalidades en futuras actualizacion
 
 Algunos ejemplos destacados de Progressive Web Applications (PWA) que muestran la versatilidad y eficacia de esta tecnología, son:
 
-- **Twitter Lite:** Una versión ligera de la aplicación de X (antes conocida como Twitter) que está diseñada para ser rápida y eficiente en el consumo de datos. Ofrece una experiencia similar a la aplicación nativa, con características como notificaciones push y acceso offline.
-- **Pinterest:** La PWA de Pinterest logró aumentar significativamente la tasa de participación de los usuarios y el tiempo que pasan en la plataforma. Proporciona una experiencia de usuario fluida con tiempos de carga rápidos.
-- **Spotify Web Player:** Permite a los usuarios escuchar música y acceder a sus playlists sin necesidad de descargar una aplicación separada. Funciona en diferentes plataformas y navegadores.
-- **Starbucks:** La PWA de Starbucks permite a los clientes ver el menú, personalizar sus pedidos y agregarlos a la cesta, incluso cuando están offline. Una vez que se restaura la conexión, pueden completar la compra.
-- **Uber:** La versión web de Uber es una PWA que ofrece una experiencia de usuario similar a la aplicación nativa pero con un tiempo de carga más rápido y un consumo de datos menor.
-- **Forbes:** La PWA de esta revista ofrece una experiencia de lectura más rápida y atractiva. La aplicación carga rápidamente los contenidos y permite a los lectores continuar leyendo offline.
-- **Alibaba:** El gigante del comercio electrónico chino desarrolló una PWA para mejorar la experiencia móvil de sus usuarios. Lograron aumentar las conversiones y la participación de los usuarios en dispositivos móviles.
-- **OLX:** Mercado global en línea que utiliza una PWA para ofrecer una experiencia de navegación más rápida y eficiente, lo que resultó en un aumento en la participación y la retención de usuarios.
-- **Flipkart Lite:** Flipkart, uno de los mayores minoristas en línea de la India, creó su PWA para ofrecer una experiencia de compra eficiente con acceso offline y notificaciones push.
-- **The Washington Post:** Su PWA proporciona una experiencia de lectura rápida y fluida. Los lectores pueden acceder a los artículos y continuar leyendo offline.
+- **Twitter Lite**: Una versión ligera de la aplicación de X (antes conocida como Twitter) que está diseñada para ser rápida y eficiente en el consumo de datos. Ofrece una experiencia similar a la aplicación nativa, con características como notificaciones push y acceso offline.
+- **Pinterest**: La PWA de Pinterest logró aumentar significativamente la tasa de participación de los usuarios y el tiempo que pasan en la plataforma. Proporciona una experiencia de usuario fluida con tiempos de carga rápidos.
+- **Spotify Web Player**: Permite a los usuarios escuchar música y acceder a sus playlists sin necesidad de descargar una aplicación separada. Funciona en diferentes plataformas y navegadores.
+- **Starbucks**: La PWA de Starbucks permite a los clientes ver el menú, personalizar sus pedidos y agregarlos a la cesta, incluso cuando están offline. Una vez que se restaura la conexión, pueden completar la compra.
+- **Uber**: La versión web de Uber es una PWA que ofrece una experiencia de usuario similar a la aplicación nativa pero con un tiempo de carga más rápido y un consumo de datos menor.
+- **Forbes**: La PWA de esta revista ofrece una experiencia de lectura más rápida y atractiva. La aplicación carga rápidamente los contenidos y permite a los lectores continuar leyendo offline.
+- **Alibaba**: El gigante del comercio electrónico chino desarrolló una PWA para mejorar la experiencia móvil de sus usuarios. Lograron aumentar las conversiones y la participación de los usuarios en dispositivos móviles.
+- **OLX**: Mercado global en línea que utiliza una PWA para ofrecer una experiencia de navegación más rápida y eficiente, lo que resultó en un aumento en la participación y la retención de usuarios.
+- **Flipkart Lite**: Flipkart, uno de los mayores minoristas en línea de la India, creó su PWA para ofrecer una experiencia de compra eficiente con acceso offline y notificaciones push.
+- **The Washington Post**: Su PWA proporciona una experiencia de lectura rápida y fluida. Los lectores pueden acceder a los artículos y continuar leyendo offline.
 
 A través de estos ejemplos podemos ver cómo diversas industrias y empresas utilizan las PWA en diferentes contextos para mejorar la experiencia de usuario, aumentar la participación y lograr sus objetivos comerciales clave.
 

--- a/docs/es/architecture/patterns/repository.md
+++ b/docs/es/architecture/patterns/repository.md
@@ -10,9 +10,9 @@ Un repositorio se puede entender como un almacén de objetos en memoria que se c
 
 El patrón de repositorio tiene tres propósitos principales:
 
-- **Separar la lógica de la aplicación de la lógica de la base de datos:** Esto facilita la escritura y el mantenimiento del código de la aplicación al reducir la necesidad de lógica para la manipulación de la base de datos.
-- **Facilitar las pruebas:** Al permitir el intercambio del repositorio real con una implementación ficticia para pruebas sin afectar la base de datos real.
-- **Proporcionar una interfaz coherente para el acceso a datos:** Independientemente de la ubicación de los datos o la implementación de las operaciones de la base de datos, la aplicación siempre interactúa con un repositorio a través de una interfaz coherente.
+- **Separar la lógica de la aplicación de la lógica de la base de datos**: Esto facilita la escritura y el mantenimiento del código de la aplicación al reducir la necesidad de lógica para la manipulación de la base de datos.
+- **Facilitar las pruebas**: Al permitir el intercambio del repositorio real con una implementación ficticia para pruebas sin afectar la base de datos real.
+- **Proporcionar una interfaz coherente para el acceso a datos**: Independientemente de la ubicación de los datos o la implementación de las operaciones de la base de datos, la aplicación siempre interactúa con un repositorio a través de una interfaz coherente.
 
 Una desventaja del patrón de repositorio es que puede añadir complejidad adicional al código, sin embargo, frecuentemente, los beneficios de la separación de preocupaciones, la mejora en las pruebas y la coherencia en el acceso a los datos superan esta desventaja.
 

--- a/docs/es/architecture/patterns/spa.md
+++ b/docs/es/architecture/patterns/spa.md
@@ -10,17 +10,17 @@ En lugar de cargar páginas completamente nuevas, las SPAs utilizan técnicas de
 
 Ventajas de las SPAs:
 
-- **Experiencia de usuario fluida:** Ofrecen una experiencia más rápida y fluida para los usuarios, ya que las actualizaciones de contenido se realizan de forma dinámica y sin interrupciones.
-- **Interactividad y navegación rápida:** Permiten una navegación más rápida y fluida en la aplicación, al solo actualizar los componentes necesarios y no cargar páginas adicionales.
-- **Mejora del rendimiento:** Mejoran el rendimiento general de la aplicación y reducen los tiempos de carga al disminuir la cantidad de datos y recursos que se deben transmitir y procesar en cada interacción.
-- **Desarrollo más eficiente:** Permiten un desarrollo más eficiente al utilizar frameworks y bibliotecas modernas, como React, Angular o Vue.js, que ofrecen un enfoque basado en componentes y facilitan la reutilización de código.
+- **Experiencia de usuario fluida**: Ofrecen una experiencia más rápida y fluida para los usuarios, ya que las actualizaciones de contenido se realizan de forma dinámica y sin interrupciones.
+- **Interactividad y navegación rápida**: Permiten una navegación más rápida y fluida en la aplicación, al solo actualizar los componentes necesarios y no cargar páginas adicionales.
+- **Mejora del rendimiento**: Mejoran el rendimiento general de la aplicación y reducen los tiempos de carga al disminuir la cantidad de datos y recursos que se deben transmitir y procesar en cada interacción.
+- **Desarrollo más eficiente**: Permiten un desarrollo más eficiente al utilizar frameworks y bibliotecas modernas, como React, Angular o Vue.js, que ofrecen un enfoque basado en componentes y facilitan la reutilización de código.
 
 Desventajas de las SPAs:
 
-- **Mayor complejidad inicial:** Pueden tener una curva de aprendizaje más pronunciada debido a la necesidad de comprender y trabajar con frameworks y herramientas adicionales.
-- **Mayor consumo de memoria:** Pueden requerir más memoria en el navegador debido a la necesidad de mantener todo el estado de la aplicación en memoria al navegar.
-- **SEO y compartición social:** Los rastreadores de búsqueda y las vistas previas de enlaces pueden no interpretar correctamente el contenido dinámico de las SPAs, lo que puede presentar desafíos relacionados con el SEO y con compartir en redes sociales.
-- **Dependencia de JavaScript:** Requieren que los usuarios tengan Javascript habilitado en su navegador para funcionar correctamente.
+- **Mayor complejidad inicial**: Pueden tener una curva de aprendizaje más pronunciada debido a la necesidad de comprender y trabajar con frameworks y herramientas adicionales.
+- **Mayor consumo de memoria**: Pueden requerir más memoria en el navegador debido a la necesidad de mantener todo el estado de la aplicación en memoria al navegar.
+- **SEO y compartición social**: Los rastreadores de búsqueda y las vistas previas de enlaces pueden no interpretar correctamente el contenido dinámico de las SPAs, lo que puede presentar desafíos relacionados con el SEO y con compartir en redes sociales.
+- **Dependencia de JavaScript**: Requieren que los usuarios tengan Javascript habilitado en su navegador para funcionar correctamente.
 
 :::tip Tip
 Es importante evaluar cuidadosamente las necesidades del proyecto y los requisitos específicos antes de optar por desarrollar una SPA. Aunque las SPAs ofrecen muchas ventajas, también presentan desafíos adicionales que deben considerarse.

--- a/docs/es/architecture/patterns/ssg.md
+++ b/docs/es/architecture/patterns/ssg.md
@@ -8,26 +8,26 @@ El Static Site Generation (SSG) o generación de sitios estáticos, es un enfoqu
 
 El proceso de SSG implica los siguientes pasos:
 
-- **Compilación:** Se generan las páginas HTML estáticas en función de los datos y las plantillas definidas en el proyecto. Esto se puede lograr utilizando herramientas y generadores estáticos como Gatsby, Hugo, Jekyll, Next.js, entre otros.
-- **Generación de contenido:** Durante la compilación, las herramientas de generación estática toman los datos y las plantillas definidas y generan las páginas HTML estáticas correspondientes para cada ruta o sección del sitio web. Esto puede incluir la generación de contenido dinámico como blogs, listados de productos o páginas de categorías.
-- **Despliegue:** Una vez generadas las páginas HTML estáticas, se cargan en un servidor web para su distribución. El servidor web puede ser tan simple como un servidor de archivos estáticos o utilizar servicios de alojamiento como Netlify, Amplify, Vercel o GitHub Pages.
+- **Compilación**: Se generan las páginas HTML estáticas en función de los datos y las plantillas definidas en el proyecto. Esto se puede lograr utilizando herramientas y generadores estáticos como Gatsby, Hugo, Jekyll, Next.js, entre otros.
+- **Generación de contenido**: Durante la compilación, las herramientas de generación estática toman los datos y las plantillas definidas y generan las páginas HTML estáticas correspondientes para cada ruta o sección del sitio web. Esto puede incluir la generación de contenido dinámico como blogs, listados de productos o páginas de categorías.
+- **Despliegue**: Una vez generadas las páginas HTML estáticas, se cargan en un servidor web para su distribución. El servidor web puede ser tan simple como un servidor de archivos estáticos o utilizar servicios de alojamiento como Netlify, Amplify, Vercel o GitHub Pages.
 
 Ventajas del SSG:
 
-- **Rendimiento rápido:** Su rendimiento es rápido y el tiempo de carga reducido, ya que no requiere procesamiento en tiempo real en el servidor.
-- **Seguridad mejorada:** Reduce la superficie de ataque y mejora la seguridad al no permitir la ejecución de código del lado del servidor.
-- **Escalabilidad y resistencia:** Se puede servir fácilmente desde una red de distribución de contenido (CDN), lo que permite escalabilidad y distribución global eficiente. Además, al no depender de recursos dinámicos, los sitios estáticos pueden manejar grandes volúmenes de tráfico sin degradar su rendimiento.
-- **Facilidad de mantenimiento:** El proceso de desarrollo y mantenimiento se simplifica, ya que los cambios en el contenido o la estructura del sitio pueden realizarse sin requerir operaciones de servidor o bases de datos.
+- **Rendimiento rápido**: Su rendimiento es rápido y el tiempo de carga reducido, ya que no requiere procesamiento en tiempo real en el servidor.
+- **Seguridad mejorada**: Reduce la superficie de ataque y mejora la seguridad al no permitir la ejecución de código del lado del servidor.
+- **Escalabilidad y resistencia**: Se puede servir fácilmente desde una red de distribución de contenido (CDN), lo que permite escalabilidad y distribución global eficiente. Además, al no depender de recursos dinámicos, los sitios estáticos pueden manejar grandes volúmenes de tráfico sin degradar su rendimiento.
+- **Facilidad de mantenimiento**: El proceso de desarrollo y mantenimiento se simplifica, ya que los cambios en el contenido o la estructura del sitio pueden realizarse sin requerir operaciones de servidor o bases de datos.
 
 Sin embargo, es importante tener en cuenta que los SSG pueden no ser adecuados para todos los casos de uso. Si se requiere contenido altamente dinámico o interacciones en tiempo real, puede ser más apropiado utilizar enfoques como el Server-Side Rendering (SSR) o las aplicaciones de una sola página (SPA) para lograr la interactividad necesaria.
 
 Desventajas del SSG:
 
-- **Limitaciones en la interactividad dinámica:** Pueden ser más difícil lograr funcionalidades que requieren actualizaciones en tiempo real o interacciones complejas.
-- **Mayor complejidad en proyectos a gran escala:** En proyectos grandes y complejos, mantener y actualizar múltiples páginas estáticas puede ser más difícil en comparación con un sistema dinámico. En casos donde existen numerosos enlaces internos o cambios frecuentes en la estructura del sitio, se requiere de planificación y gestión cuidadosas para mantener la coherencia y la eficiencia en el desarrollo.
-- **Necesidad de compilación previa:** Las páginas deben compilarse previamente antes de ser servidas, lo que significa que cualquier cambio en el contenido o en la estructura del sitio requiere una nueva compilación y un nuevo despliegue para que los cambios sean visibles. Si los cambios deben ser reflejados inmediatamente sin una compilación previa, puede ser necesario considerar otros enfoques, como Server Side Rendering (SSR) o aplicaciones de una sola página (SPA).
-- **Dificultad con contenido dinámico y personalizado:** Puede dificultar la inclusión de contenido dinámico o personalizado en función de interacciones del usuario o de datos externos en tiempo real.
-- **Mayor tiempo de compilación en proyectos grandes:** A medida que el proyecto crece en tamaño y complejidad, el tiempo necesario para compilar las páginas puede aumentar considerablemente, haciendo más lento el flujo de trabajo de desarrollo; por lo que recomendamos una planificación adecuada para gestionar tiempos de compilación en proyectos más grandes.
+- **Limitaciones en la interactividad dinámica**: Pueden ser más difícil lograr funcionalidades que requieren actualizaciones en tiempo real o interacciones complejas.
+- **Mayor complejidad en proyectos a gran escala**: En proyectos grandes y complejos, mantener y actualizar múltiples páginas estáticas puede ser más difícil en comparación con un sistema dinámico. En casos donde existen numerosos enlaces internos o cambios frecuentes en la estructura del sitio, se requiere de planificación y gestión cuidadosas para mantener la coherencia y la eficiencia en el desarrollo.
+- **Necesidad de compilación previa**: Las páginas deben compilarse previamente antes de ser servidas, lo que significa que cualquier cambio en el contenido o en la estructura del sitio requiere una nueva compilación y un nuevo despliegue para que los cambios sean visibles. Si los cambios deben ser reflejados inmediatamente sin una compilación previa, puede ser necesario considerar otros enfoques, como Server Side Rendering (SSR) o aplicaciones de una sola página (SPA).
+- **Dificultad con contenido dinámico y personalizado**: Puede dificultar la inclusión de contenido dinámico o personalizado en función de interacciones del usuario o de datos externos en tiempo real.
+- **Mayor tiempo de compilación en proyectos grandes**: A medida que el proyecto crece en tamaño y complejidad, el tiempo necesario para compilar las páginas puede aumentar considerablemente, haciendo más lento el flujo de trabajo de desarrollo; por lo que recomendamos una planificación adecuada para gestionar tiempos de compilación en proyectos más grandes.
 
 
 ### Implementación del SSG en Modyo

--- a/docs/es/architecture/patterns/sso.md
+++ b/docs/es/architecture/patterns/sso.md
@@ -9,11 +9,11 @@ Single Sign-On (SSO) o inicio de sesión único, es un método de autenticación
 El SSO se fundamenta en un sistema de confianza entre los proveedores de servicios y un proveedor de identidad centralizado. Al iniciar sesión en el proveedor de identidad, este genera un token de sesión que autentica al usuario en las aplicaciones y servicios que integran el entorno de SSO, lo que permite al usuario moverse entre los servicios sin realizar autenticaciones adicionales.
 
 Ventajas de utilizar SSO:
-- **Mejora la experiencia del usuario:** Simplifica el proceso de inicio de sesión, lo que agiliza el acceso a las aplicaciones, especialmente en entornos corporativos con numerosas aplicaciones.
-- **Reduce el soporte técnico:** Disminuye  la cantidad de contraseñas que los usuarios deben recordar, reduciendo la necesidad de solicitudes de restablecimiento de contraseñas y problemas relacionados, que el equipo de soporte técnico debe atender.
-- **Mejora la seguridad:** Centraliza la autenticación, lo que facilita monitorear y gestionar el acceso a varias aplicaciones. Los usuarios pueden centrarse en crear una contraseña sólida y además, las soluciones de SSO suelen incluir características de seguridad robustas, como la autenticación de dos factores.
-- **Ahorra tiempo y aumenta la productividad:** Los usuarios pueden acceder rápidamente a todas las aplicaciones que necesitan sin iniciar sesión en cada una por separado.
-- **Simplifica la administración:** Para los administradores de TI, la implementación de SSO permite gestionar un conjunto de credenciales por usuario en lugar de administrar el acceso a cada aplicación individualmente.
+- **Mejora la experiencia del usuario**: Simplifica el proceso de inicio de sesión, lo que agiliza el acceso a las aplicaciones, especialmente en entornos corporativos con numerosas aplicaciones.
+- **Reduce el soporte técnico**: Disminuye  la cantidad de contraseñas que los usuarios deben recordar, reduciendo la necesidad de solicitudes de restablecimiento de contraseñas y problemas relacionados, que el equipo de soporte técnico debe atender.
+- **Mejora la seguridad**: Centraliza la autenticación, lo que facilita monitorear y gestionar el acceso a varias aplicaciones. Los usuarios pueden centrarse en crear una contraseña sólida y además, las soluciones de SSO suelen incluir características de seguridad robustas, como la autenticación de dos factores.
+- **Ahorra tiempo y aumenta la productividad**: Los usuarios pueden acceder rápidamente a todas las aplicaciones que necesitan sin iniciar sesión en cada una por separado.
+- **Simplifica la administración**: Para los administradores de TI, la implementación de SSO permite gestionar un conjunto de credenciales por usuario en lugar de administrar el acceso a cada aplicación individualmente.
 
 :::danger Seguridad
 Es importante tener en cuenta que, si no se implementa correctamente, el SSO puede presentar riesgos de seguridad. Por ejemplo, si las credenciales de SSO de un usuario se ven comprometidas, un atacante podría obtener acceso a todas las aplicaciones a las que el usuario tiene acceso. Por lo tanto, es crucial implementar medidas de seguridad sólidas, como la autenticación de dos factores y políticas de contraseñas fuertes.

--- a/docs/es/architecture/patterns/ssr.md
+++ b/docs/es/architecture/patterns/ssr.md
@@ -10,16 +10,16 @@ En el SSR, el servidor es responsable de procesar la solicitud del cliente y gen
 
 Ventajas del SSR:
 
-- **Optimización para motores de búsqueda:** El contenido pre-renderizado es más accesible para los motores de búsqueda, lo que facilita su indexación y el posicionamiento en los resultados de búsqueda.
-- **Mejor rendimiento inicial:** El usuario ve rápidamente el contenido visual sin esperar a que se cargue y ejecute el código JavaScript en el navegador.
-- **Compatibilidad con dispositivos con recursos limitados:** Reduce la carga de procesamiento en el cliente, lo que es beneficioso en dispositivos móviles o navegadores más antiguos.
-- **Mejor SEO y compartición en redes sociales:** Es más amigable con las redes sociales y los rastreadores de búsqueda, al proporcionar contenido completo y enriquecido para compartir y rastrear.
+- **Optimización para motores de búsqueda**: El contenido pre-renderizado es más accesible para los motores de búsqueda, lo que facilita su indexación y el posicionamiento en los resultados de búsqueda.
+- **Mejor rendimiento inicial**: El usuario ve rápidamente el contenido visual sin esperar a que se cargue y ejecute el código JavaScript en el navegador.
+- **Compatibilidad con dispositivos con recursos limitados**: Reduce la carga de procesamiento en el cliente, lo que es beneficioso en dispositivos móviles o navegadores más antiguos.
+- **Mejor SEO y compartición en redes sociales**: Es más amigable con las redes sociales y los rastreadores de búsqueda, al proporcionar contenido completo y enriquecido para compartir y rastrear.
 
 Desventajas del SSR:
 
-- **Mayor carga en el servidor:** El SSR implica que el servidor debe generar y enviar el contenido HTML completo en cada solicitud, lo que puede aumentar la carga en el servidor, especialmente en aplicaciones con alta carga de solicitudes.
-- **Menor interactividad:** Las interacciones y actualizaciones posteriores en la página pueden requerir solicitudes adicionales al servidor, lo que puede resultar en una menor interactividad en comparación con aplicaciones de una sola página (SPA).
-- **Mayor complejidad de implementación:** Implementar el SSR puede requerir configuración y manejo más complejo en el servidor.
+- **Mayor carga en el servidor**: El SSR implica que el servidor debe generar y enviar el contenido HTML completo en cada solicitud, lo que puede aumentar la carga en el servidor, especialmente en aplicaciones con alta carga de solicitudes.
+- **Menor interactividad**: Las interacciones y actualizaciones posteriores en la página pueden requerir solicitudes adicionales al servidor, lo que puede resultar en una menor interactividad en comparación con aplicaciones de una sola página (SPA).
+- **Mayor complejidad de implementación**: Implementar el SSR puede requerir configuración y manejo más complejo en el servidor.
 
 El Server Side Rendering es una técnica útil en escenarios donde el SEO y el rendimiento inicial son críticos. Sin embargo, su implementación requierede cuidado en la arquitectura y la ejecución debido a su impacto en la carga del servidor y la interactividad de la aplicación.
 

--- a/docs/es/architecture/patterns/web-components.md
+++ b/docs/es/architecture/patterns/web-components.md
@@ -8,9 +8,9 @@ Un web component es una tecnología web que permite crear elementos personalizad
 
 Están compuestos por tres principales tecnologías:
 
-- **Custom Elements:** Permiten la creación de elementos HTML personalizados con funcionalidad y comportamiento definidos en JavaScript.
-- **Shadow DOM:** Proporciona un ámbito de encapsulación para los estilos y la estructura de un componente. El Shadow DOM permite que los estilos y elementos internos de un componente no afecten ni sean afectados por el resto de la página.
-- **HTML Templates:** Definen fragmentos de código HTML que pueden clonarse y utilizarse múltiples veces. Se utilizan para definir la estructura inicial de un componente.
+- **Custom Elements**: Permiten la creación de elementos HTML personalizados con funcionalidad y comportamiento definidos en JavaScript.
+- **Shadow DOM**: Proporciona un ámbito de encapsulación para los estilos y la estructura de un componente. El Shadow DOM permite que los estilos y elementos internos de un componente no afecten ni sean afectados por el resto de la página.
+- **HTML Templates**: Definen fragmentos de código HTML que pueden clonarse y utilizarse múltiples veces. Se utilizan para definir la estructura inicial de un componente.
 
 Combinando estas tecnologías, los Web Components permiten la creación de componentes personalizados con su propio comportamiento y apariencia. Estos componentes pueden ser utilizados en diversas partes de una aplicación web o en diferentes proyectos.
 
@@ -22,11 +22,11 @@ La implementación de Web Components está respaldada por estándares web y es c
 
 Existen diferentes herramientas para desarrollar Web Components, como Polymer y Stencil, estas son algunas de las diferencias clave entre ellas:
 
-- **Enfoque y madurez:** Polymer, desarrollado por Google, simplifica la creación de Web Components y ofrece una amplia gama de características. Stencil es un compilador de componentes web que se centra en la eficiencia y el rendimiento.
-- **Tamaño y dependencias:** La bilbioteca de Polymer es más grande, mientras que Stencil es más liviano y se enfoca en la generación de código optimizado y sin dependencias adicionales.
-- **Soporte de navegadores:** Ambos frameworks son compatibles con la mayoría de los navegadores modernos. Sin embargo, Polymer utiliza polyfills para garantizar la compatibilidad con navegadores más antiguos.
-- **Lenguaje de programación:** Polymer utiliza JavaScript moderno y el patrón de programación basado en clases para definir los componentes, Stencil usa TypeScript, un superconjunto de JavaScript que agrega características de tipado estático y otras funcionalidades.
-- **Rendimiento:** Stencil está optimizado para el rendimiento, mientras que Polymer ofrece un buen rendimiento sin estar optimizado específicamente para ello.
+- **Enfoque y madurez**: Polymer, desarrollado por Google, simplifica la creación de Web Components y ofrece una amplia gama de características. Stencil es un compilador de componentes web que se centra en la eficiencia y el rendimiento.
+- **Tamaño y dependencias**: La bilbioteca de Polymer es más grande, mientras que Stencil es más liviano y se enfoca en la generación de código optimizado y sin dependencias adicionales.
+- **Soporte de navegadores**: Ambos frameworks son compatibles con la mayoría de los navegadores modernos. Sin embargo, Polymer utiliza polyfills para garantizar la compatibilidad con navegadores más antiguos.
+- **Lenguaje de programación**: Polymer utiliza JavaScript moderno y el patrón de programación basado en clases para definir los componentes, Stencil usa TypeScript, un superconjunto de JavaScript que agrega características de tipado estático y otras funcionalidades.
+- **Rendimiento**: Stencil está optimizado para el rendimiento, mientras que Polymer ofrece un buen rendimiento sin estar optimizado específicamente para ello.
 
 Ambas herramientas son poderosas y se adaptan a diferentes casos de uso. Si requieres una biblioteca completa y consolidada con numerosas características, Polymer es una excelente elección. En cambio, si priorizas el rendimiento y deseas crear Web Components altamente optimizados y nativos, Stencil puede ser la opción más adecuada.
 

--- a/docs/es/architecture/resources/web-performance.md
+++ b/docs/es/architecture/resources/web-performance.md
@@ -8,13 +8,13 @@ En la web, el rendimiento se refiere a la velocidad y eficiencia con la que una 
 
 Para lograr un rendimiento web óptimo, puedes aplicar diversas técnicas y prácticas, entre ellas:
 
-- **Optimización de imágenes:** Las imágenes suelen ser los elementos más pesados en una página web. Comprimir y optimizar imágenes reduce su tamaño y mejora los tiempos de carga. Utiliza herramientas de compresión y formatos eficientes, como JPEG, PNG y SVG, según necesites.
-- **Caché:** El caché es una técnica que permite almacenar en el navegador recursos estáticos de una página web, como archivos CSS, JavaScript e imágenes. Usa encabezados de caché adecuados para indicar al navegador que almacene en caché estos recursos. Esto evita descargas repetidas y acelera el tiempo de carga de las páginas.
-- **Minificación y compresión de archivos:** La minificación es el proceso de eliminar espacios en blanco y comentarios, lo que reduce el tamaño de los archivos CSS y JavaScript. Además, la compresión GZIP reduce aún más el tamaño de los archivos transferidos entre el servidor y el cliente, mejorando los tiempos de carga.
-- **Renderizado eficiente:** Renderiza eficientemente, priorizando contenidos visibles y evitando bloqueos en el hilo principal. Usa técnicas como carga progresiva para cargar primero los contenidos visibles, carga asíncrona  o carga diferida de archivos JavaScript para scripts pesados.
-- **Optimización del servidor:** Configura y optimiza el servidor que aloja el sitio. Usa caché en el servidor, compresión de respuestas y cabeceras HTTP adecuadas para mejorar eficiencia y velocidad de respuesta del servidor.
-- **Optimización de la red:** Para reducir las solicitudes de red y minimizar los tiempos de latencia combina y reduce archivos CSS y JavaScript, utiliza la carga bajo demanda de contenido y aprovecha técnicas de agrupamiento de recursos.
-- **Detección y resolución de cuellos de botella:** Realiza pruebas de rendimiento y monitoreo para identificar posibles cuellos de botella y áreas de mejora. Herramientas como Lighthouse, PageSpeed Insights y WebPageTest pueden ayudarte a evaluar el rendimiento de una página web y ofrecer recomendaciones específicas.
+- **Optimización de imágenes**: Las imágenes suelen ser los elementos más pesados en una página web. Comprimir y optimizar imágenes reduce su tamaño y mejora los tiempos de carga. Utiliza herramientas de compresión y formatos eficientes, como JPEG, PNG y SVG, según necesites.
+- **Caché**: El caché es una técnica que permite almacenar en el navegador recursos estáticos de una página web, como archivos CSS, JavaScript e imágenes. Usa encabezados de caché adecuados para indicar al navegador que almacene en caché estos recursos. Esto evita descargas repetidas y acelera el tiempo de carga de las páginas.
+- **Minificación y compresión de archivos**: La minificación es el proceso de eliminar espacios en blanco y comentarios, lo que reduce el tamaño de los archivos CSS y JavaScript. Además, la compresión GZIP reduce aún más el tamaño de los archivos transferidos entre el servidor y el cliente, mejorando los tiempos de carga.
+- **Renderizado eficiente**: Renderiza eficientemente, priorizando contenidos visibles y evitando bloqueos en el hilo principal. Usa técnicas como carga progresiva para cargar primero los contenidos visibles, carga asíncrona  o carga diferida de archivos JavaScript para scripts pesados.
+- **Optimización del servidor**: Configura y optimiza el servidor que aloja el sitio. Usa caché en el servidor, compresión de respuestas y cabeceras HTTP adecuadas para mejorar eficiencia y velocidad de respuesta del servidor.
+- **Optimización de la red**: Para reducir las solicitudes de red y minimizar los tiempos de latencia combina y reduce archivos CSS y JavaScript, utiliza la carga bajo demanda de contenido y aprovecha técnicas de agrupamiento de recursos.
+- **Detección y resolución de cuellos de botella**: Realiza pruebas de rendimiento y monitoreo para identificar posibles cuellos de botella y áreas de mejora. Herramientas como Lighthouse, PageSpeed Insights y WebPageTest pueden ayudarte a evaluar el rendimiento de una página web y ofrecer recomendaciones específicas.
 
 Estas son algunas técnicas y prácticas para mejorar el rendimiento web. Sin embargo, cada sitio y aplicación web tiene requisitos y consideraciones específicas, por lo que es importante evaluar y ajustar estas prácticas a las necesidades del proyecto.
 
@@ -22,12 +22,12 @@ Estas son algunas técnicas y prácticas para mejorar el rendimiento web. Sin em
 
 La medición del rendimiento web se basa en diversas métricas y herramientas. Aquí se presentan aspectos clave a considerar:
 
-- **Tiempo de Carga:** Es el tiempo que toma para que una página cargue por completo. Lo puedes medir con Google PageSpeed Insights, GTmetrix u otras.
-- **Tiempo hasta el primer byte (TTFB):** Mide el tiempo desde la solicitud inicial hasta la recepción del primer byte del servidor. Cuanto más corto sea el TTFB, mejor.
-- **Tiempo de interacción del usuario (TBT):** Indica cuánto tiempo se requiere para que una página cargue lo suficiente como para que el usuario pueda interactuar con ella.
-- **Tiempo de pintura del contenido más grande (LCP):** Métrica de Google que mide cuánto tiempo tarda en cargar el componente más grande visible, como una imagen o bloque de texto.
-- **Desplazamiento acumulativo de diseño (CLS):** Otra métrica de Google, mide cuánto se mueven los elementos de una página durante la carga.
-- **Índice de velocidad (Speed Index):** Indica cuánto tiempo tarda una página en mostrarse visualmente al usuario.
-- **Puntuación de rendimiento:** Métrica de herramientas como Lighthouse de Google que proporcionan una puntuación general basada en múltiples métricas de rendimiento.
+- **Tiempo de Carga**: Es el tiempo que toma para que una página cargue por completo. Lo puedes medir con Google PageSpeed Insights, GTmetrix u otras.
+- **Tiempo hasta el primer byte (TTFB)**: Mide el tiempo desde la solicitud inicial hasta la recepción del primer byte del servidor. Cuanto más corto sea el TTFB, mejor.
+- **Tiempo de interacción del usuario (TBT)**: Indica cuánto tiempo se requiere para que una página cargue lo suficiente como para que el usuario pueda interactuar con ella.
+- **Tiempo de pintura del contenido más grande (LCP)**: Métrica de Google que mide cuánto tiempo tarda en cargar el componente más grande visible, como una imagen o bloque de texto.
+- **Desplazamiento acumulativo de diseño (CLS)**: Otra métrica de Google, mide cuánto se mueven los elementos de una página durante la carga.
+- **Índice de velocidad (Speed Index)**: Indica cuánto tiempo tarda una página en mostrarse visualmente al usuario.
+- **Puntuación de rendimiento**: Métrica de herramientas como Lighthouse de Google que proporcionan una puntuación general basada en múltiples métricas de rendimiento.
 
 Además de estas métricas, la facilidad de uso y la capacidad de respuesta del diseño en diferentes dispositivos y tamaños de pantalla también influyen en la percepción general del rendimiento del usuario. Puedes utilizar herramientas como Google Lighthouse, PageSpeed Insights, WebPageTest.org y GTmetrix para obtener más información y recomendaciones de mejora.

--- a/docs/es/platform/README.md
+++ b/docs/es/platform/README.md
@@ -24,16 +24,16 @@ Modyo es una plataforma de experiencia digital que te ayuda a crear experiencias
 
 ### ¿Para qué usar Modyo?
 
-* **Para crear experiencias digitales integradas:** Modyo te permite crear experiencias digitales personalizadas para tus consumidores, independientemente de su canal.
-* **Para crear agilidad y gobernabilidad:** Modyo te ayuda a agilizar el desarrollo de tus experiencias digitales y a garantizar su calidad.
-* **Para crear experiencias digitales a través de widgets:** Modyo te ofrece una amplia biblioteca de widgets que puedes usar para crear experiencias digitales rápidamente.
+* **Para crear experiencias digitales integradas**: Modyo te permite crear experiencias digitales personalizadas para tus consumidores, independientemente de su canal.
+* **Para crear agilidad y gobernabilidad**: Modyo te ayuda a agilizar el desarrollo de tus experiencias digitales y a garantizar su calidad.
+* **Para crear experiencias digitales a través de widgets**: Modyo te ofrece una amplia biblioteca de widgets que puedes usar para crear experiencias digitales rápidamente.
 
 
 ### ¿Por qué usar Modyo?
 
-* **Modyo es seguro:** Modyo te ofrece un entorno de desarrollo seguro, tanto en la nube como local (On Premise) para que puedas crear experiencias digitales sin preocuparte por la seguridad de tus datos.
-* **Modyo es escalable:** Modyo puede escalar para satisfacer las necesidades de tu negocio, sin importar su tamaño. Grandes equipos digitales pueden agilizar la creación de contenido y componentes desarrollados para frontend
-* **Modyo es adaptable:** Modyo es adaptable a tus necesidades específicas y  provee una amplia librería de widgets inteligentes que pueden ser conectados a diversos sistemas de su empresa.
+* **Modyo es seguro**: Modyo te ofrece un entorno de desarrollo seguro, tanto en la nube como local (On Premise) para que puedas crear experiencias digitales sin preocuparte por la seguridad de tus datos.
+* **Modyo es escalable**: Modyo puede escalar para satisfacer las necesidades de tu negocio, sin importar su tamaño. Grandes equipos digitales pueden agilizar la creación de contenido y componentes desarrollados para frontend
+* **Modyo es adaptable**: Modyo es adaptable a tus necesidades específicas y  provee una amplia librería de widgets inteligentes que pueden ser conectados a diversos sistemas de su empresa.
 
 ### ¿Para quién es Modyo?
 

--- a/docs/es/platform/basics/Readme.md
+++ b/docs/es/platform/basics/Readme.md
@@ -25,16 +25,16 @@ Modyo es una plataforma de experiencia digital que te ayuda a crear experiencias
 
 ### ¿Para qué usar Modyo?
 
-* **Para crear experiencias digitales integradas:** Modyo te permite crear experiencias digitales personalizadas para tus consumidores, independientemente de su canal.
-* **Para crear agilidad y gobernabilidad:** Modyo te ayuda a agilizar el desarrollo de tus experiencias digitales y a garantizar su calidad.
-* **Para crear experiencias digitales a través de widgets:** Modyo te ofrece una amplia biblioteca de widgets que puedes usar para crear experiencias digitales rápidamente.
+* **Para crear experiencias digitales integradas**: Modyo te permite crear experiencias digitales personalizadas para tus consumidores, independientemente de su canal.
+* **Para crear agilidad y gobernabilidad**: Modyo te ayuda a agilizar el desarrollo de tus experiencias digitales y a garantizar su calidad.
+* **Para crear experiencias digitales a través de widgets**: Modyo te ofrece una amplia biblioteca de widgets que puedes usar para crear experiencias digitales rápidamente.
 
 
 ### ¿Por qué usar Modyo?
 
-* **Modyo es seguro:** Modyo te ofrece un entorno de desarrollo seguro, tanto en la nube como local (On Premise) para que puedas crear experiencias digitales sin preocuparte por la seguridad de tus datos.
-* **Modyo es escalable:** Modyo puede escalar para satisfacer las necesidades de tu negocio, sin importar su tamaño. Grandes equipos digitales pueden agilizar la creación de contenido y componentes desarrollados para frontend
-* **Modyo es adaptable:** Modyo es adaptable a tus necesidades específicas y  provee una amplia librería de widgets inteligentes que pueden ser conectados a diversos sistemas de su empresa.
+* **Modyo es seguro**: Modyo te ofrece un entorno de desarrollo seguro, tanto en la nube como local (On Premise) para que puedas crear experiencias digitales sin preocuparte por la seguridad de tus datos.
+* **Modyo es escalable**: Modyo puede escalar para satisfacer las necesidades de tu negocio, sin importar su tamaño. Grandes equipos digitales pueden agilizar la creación de contenido y componentes desarrollados para frontend
+* **Modyo es adaptable**: Modyo es adaptable a tus necesidades específicas y  provee una amplia librería de widgets inteligentes que pueden ser conectados a diversos sistemas de su empresa.
 
 ### ¿Para quién es Modyo?
 

--- a/docs/es/platform/basics/key-concepts.md
+++ b/docs/es/platform/basics/key-concepts.md
@@ -70,49 +70,49 @@ A continuación, algunos términos clave en Modyo y sus definiciones:
 
 #### Generales
 
-* [**CORS:**](/es/platform/core/security.html#control-de-acceso-http-cross-origin-resource-sharing-cors) Cross Origin Resource Sharing - Permite compartir recursos en distintos dominios.
-* **Cuenta:** Punto de acceso a todas las funcionalidades de Modyo.
-* [**Equipo:**](/es/platform/core/roles.html#equipo) Todos los usuarios con acceso al admin de Modyo. Se les puede asignar roles y permisos.
-* [**Integraciones:**](/es/platform/core/integrations) Forma para delegar o federar el proceso de inicio de autenticación de usuarios o miembros del equipo.
-* [**Política de contraseña:**](/es/platform/core/security.html#politica-de-contrasena) Permite definir reglas para la creación o modificación de contraseñas.
-* [**Revisión en equipo:**](/es/platform/core/key-concepts.html#revision-en-equipo) Flujo de revisión de los elementos versionados. Se puede solicitar la aprobación de múltiples miembros del equipo.
-* [**Sitio:**](/es/platform/channels/sites.html) Herramienta para crear canales digitales dentro de Modyo. La operación de sitios abarca el desarrollo, diseño y flujo de navegación.
-* [**Versión editable:**](/es/platform/core/key-concepts.html#editable) La versión que puedes modificar y previsualizar de los elementos versionados.
-* [**Variables globales:**](/es/platform/core/key-concepts.html#variables-globales) Elementos que puedes definir de forma global y reutilizar en distintos sitios.
-* [**Versión programada:**](/es/platform/core/key-concepts.html#programado) Versión que será publicada en una fecha y hora determinada.
-* [**Versión publicada:**](/es/platform/core/key-concepts.html#publicado) Versión visible o productiva de los elementos versionados. Esta versión no se puede modificar.
-* [**Versión de respaldo:**](/es/platform/core/key-concepts.html#respaldos) Versiones publicadas previamente.
-* [**Webhook:**](/es/platform/core/webhooks.html) Envía información automáticamente a un sistema externo cuando ocurre un evento determinado.
+* [**CORS**:](/es/platform/core/security.html#control-de-acceso-http-cross-origin-resource-sharing-cors) Cross Origin Resource Sharing - Permite compartir recursos en distintos dominios.
+* **Cuenta**: Punto de acceso a todas las funcionalidades de Modyo.
+* [**Equipo**:](/es/platform/core/roles.html#equipo) Todos los usuarios con acceso al admin de Modyo. Se les puede asignar roles y permisos.
+* [**Integraciones**:](/es/platform/core/integrations) Forma para delegar o federar el proceso de inicio de autenticación de usuarios o miembros del equipo.
+* [**Política de contraseña**:](/es/platform/core/security.html#politica-de-contrasena) Permite definir reglas para la creación o modificación de contraseñas.
+* [**Revisión en equipo**:](/es/platform/core/key-concepts.html#revision-en-equipo) Flujo de revisión de los elementos versionados. Se puede solicitar la aprobación de múltiples miembros del equipo.
+* [**Sitio**:](/es/platform/channels/sites.html) Herramienta para crear canales digitales dentro de Modyo. La operación de sitios abarca el desarrollo, diseño y flujo de navegación.
+* [**Versión editable**:](/es/platform/core/key-concepts.html#editable) La versión que puedes modificar y previsualizar de los elementos versionados.
+* [**Variables globales**:](/es/platform/core/key-concepts.html#variables-globales) Elementos que puedes definir de forma global y reutilizar en distintos sitios.
+* [**Versión programada**:](/es/platform/core/key-concepts.html#programado) Versión que será publicada en una fecha y hora determinada.
+* [**Versión publicada**:](/es/platform/core/key-concepts.html#publicado) Versión visible o productiva de los elementos versionados. Esta versión no se puede modificar.
+* [**Versión de respaldo**:](/es/platform/core/key-concepts.html#respaldos) Versiones publicadas previamente.
+* [**Webhook**:](/es/platform/core/webhooks.html) Envía información automáticamente a un sistema externo cuando ocurre un evento determinado.
 
 
 #### Modyo Content
 
-* [**Assets:**](/es/platform/content/asset-manager.html#acerca-de-la-interfaz) Archivos cargados en la plataforma para ser usados en contenido y sitios.
-* [**Campo:**](/es/platform/content/types.html#campos) Unidad básica para formar tipos de contenido.
-* [**Categorías:**](/es/platform/content/entries.html#categorias) Estructura jerárquica para organizar el contenido de tus espacios.
-* [**Entrada:**](/es/platform/content/entries.html) Conjunto de valores asociados a campos definidos en el tipo de contenido.
-* [**Espacio:**](/es/platform/content/spaces.html) Repositorio de recursos donde los miembros del equipo definen tipos de contenido, crean y publicar entradas.
-* **Tags:** Etiquetas para ordenar y filtrar entradas.
-* [**Tipo de contenido:**](/es/platform/content/types.html)  Estructura con campos que te permite definir distintos contenidos.
+* [**Assets**:](/es/platform/content/asset-manager.html#acerca-de-la-interfaz) Archivos cargados en la plataforma para ser usados en contenido y sitios.
+* [**Campo**:](/es/platform/content/types.html#campos) Unidad básica para formar tipos de contenido.
+* [**Categorías**:](/es/platform/content/entries.html#categorias) Estructura jerárquica para organizar el contenido de tus espacios.
+* [**Entrada**:](/es/platform/content/entries.html) Conjunto de valores asociados a campos definidos en el tipo de contenido.
+* [**Espacio**:](/es/platform/content/spaces.html) Repositorio de recursos donde los miembros del equipo definen tipos de contenido, crean y publicar entradas.
+* **Tags**: Etiquetas para ordenar y filtrar entradas.
+* [**Tipo de contenido**:](/es/platform/content/types.html)  Estructura con campos que te permite definir distintos contenidos.
 
 
 #### Modyo Channels
 
-* [**Dominios:**](/es/platform/channels/sites.html#dominios) La URL de tu sitio, puedes modificarla, al igual que los certificados de seguridad de tu sitio.
-* [**Meta tags:**](/es/platform/channels/pages.html#meta-tags) Personaliza tus meta etiquetas para mejorar la indexación en motores de búsqueda.
-* [**Navegación:**](/es/platform/channels/navigation.html) Te permite modificar el menú principal de tu sitio a través de una interfaz sencilla.
-* [**Página:**](/es/platform/channels/pages.html) Te permiten crear una estructura para tu sitio. Puedes añadir contenido no estructurado y personalizar las rutas donde se muestra el contenido.
-* [**PWA:**](/es/platform/channels/sites.html#pwa) Configura el _serviceworker_ y manifiesto de tu sitio para su uso fuera de línea.
-* [**SEO:**](/es/platform/channels/sites.html#seo) Configura como se ve tu sitio ante robots de indexación.
-* [**Templates:**](/es/platform/channels/templates.html) Son la base de tu sitio y definen la estructura básica de las páginas.
-* [**Widget:**](/es/platform/channels/widgets.html) Paquete de funcionalidad reutilizable con HTML, JavaScript y CSS que puedes usar en distintas páginas.
+* [**Dominios**:](/es/platform/channels/sites.html#dominios) La URL de tu sitio, puedes modificarla, al igual que los certificados de seguridad de tu sitio.
+* [**Meta tags**:](/es/platform/channels/pages.html#meta-tags) Personaliza tus meta etiquetas para mejorar la indexación en motores de búsqueda.
+* [**Navegación**:](/es/platform/channels/navigation.html) Te permite modificar el menú principal de tu sitio a través de una interfaz sencilla.
+* [**Página**:](/es/platform/channels/pages.html) Te permiten crear una estructura para tu sitio. Puedes añadir contenido no estructurado y personalizar las rutas donde se muestra el contenido.
+* [**PWA**:](/es/platform/channels/sites.html#pwa) Configura el _serviceworker_ y manifiesto de tu sitio para su uso fuera de línea.
+* [**SEO**:](/es/platform/channels/sites.html#seo) Configura como se ve tu sitio ante robots de indexación.
+* [**Templates**:](/es/platform/channels/templates.html) Son la base de tu sitio y definen la estructura básica de las páginas.
+* [**Widget**:](/es/platform/channels/widgets.html) Paquete de funcionalidad reutilizable con HTML, JavaScript y CSS que puedes usar en distintas páginas.
 
 #### Modyo Customers
 
-* [**Campañas:**](/es/platform/customers/messaging.html#campanas) Definen el canal de comunicación con el usuario. Te permiten llegar a tus usuarios a través de correos y notificaciones.
-* [**Campo personalizado:**](/es/platform/customers/settings.html#custom-fields) Te permite añadir atributos personalizados al perfil de los usuarios.
-* [**Filtros:**](/es/platform/customers/segments.html#filtros) Unidad que te permite construir segmentos.
-* [**Formulario:**](/es/platform/customers/forms.html) Para capturar datos de tus usuarios en tus sitios.
-* [**Mensajería:**](/es/platform/customers/messaging.html) Controla los canales de comunicación directa con tus usuarios.
-* [**Segmento:**](/es/platform/customers/segments.html) Te permite añadir y agrupar usuarios mediante grupos de filtros con distintas condiciones.
-* [**Usuario:**](/es/platform/customers/users.html) Quien accede y se registra en los sitios de Modyo.
+* [**Campañas**:](/es/platform/customers/messaging.html#campanas) Definen el canal de comunicación con el usuario. Te permiten llegar a tus usuarios a través de correos y notificaciones.
+* [**Campo personalizado**:](/es/platform/customers/settings.html#custom-fields) Te permite añadir atributos personalizados al perfil de los usuarios.
+* [**Filtros**:](/es/platform/customers/segments.html#filtros) Unidad que te permite construir segmentos.
+* [**Formulario**:](/es/platform/customers/forms.html) Para capturar datos de tus usuarios en tus sitios.
+* [**Mensajería**:](/es/platform/customers/messaging.html) Controla los canales de comunicación directa con tus usuarios.
+* [**Segmento**:](/es/platform/customers/segments.html) Te permite añadir y agrupar usuarios mediante grupos de filtros con distintas condiciones.
+* [**Usuario**:](/es/platform/customers/users.html) Quien accede y se registra en los sitios de Modyo.

--- a/docs/es/platform/basics/learn-modyo.md
+++ b/docs/es/platform/basics/learn-modyo.md
@@ -52,4 +52,4 @@ Además de todos los cursos que tienes acá siempre puedes encontrar informació
 
 **[Comunidad de Modyo:](https://es.modyo.com/comunidad)** en esta sección tenemos casos de uso prácticos, preguntas frecuentes de nuestros usuarios y webinars pregrabados para que vayas más allá de la teoría y encuentres la solución a problemas cotidianos de uso.
 
-**[Webinars:](https://es.modyo.com/webinars):** Cada mes, todos nuestros usuarios reciben invitaciones para asistir a sesiones en vivo con toda nuestra comunidad, puedes hacer preguntas y resolverlas con nuestros especialistas.
+**[Webinars:](https://es.modyo.com/webinars)**: Cada mes, todos nuestros usuarios reciben invitaciones para asistir a sesiones en vivo con toda nuestra comunidad, puedes hacer preguntas y resolverlas con nuestros especialistas.

--- a/docs/es/platform/channels/cli.md
+++ b/docs/es/platform/channels/cli.md
@@ -8,9 +8,9 @@ La Interfaz de Línea de Comandos de Modyo (CLI) es una herramienta basada en do
 
  #### Beneficios de la CLI de Modyo
 
-- **Trabajo en local:** Puedes crear widgets de cualquier tamaño o complejidad desde tu entorno local.
-- **Almacenamiento en repositorios locales:** Facilita la gestión de los widgets y la colaboración con otros desarrolladores al utilizar sistemas de control de versiones.
-- **Reutilización de widgets:** Permite crear un widget una vez y reutilizarlo en múltiples sitios y ocasiones.
+- **Trabajo en local**: Puedes crear widgets de cualquier tamaño o complejidad desde tu entorno local.
+- **Almacenamiento en repositorios locales**: Facilita la gestión de los widgets y la colaboración con otros desarrolladores al utilizar sistemas de control de versiones.
+- **Reutilización de widgets**: Permite crear un widget una vez y reutilizarlo en múltiples sitios y ocasiones.
 
 ## Instalación
 
@@ -53,19 +53,19 @@ $ modyo-cli autocomplete bash
 
 ## Configuración del entorno
 
-El siguiente paso es configurar tu proyecto para facilitar la carga de widgets en la plataforma Modyo e incluirlos en las páginas que construyas. Aunque puedes especificar todo como parámetros en la llamada push, recomendamos definir un conjunto de variables de entorno en un archivo `.env`. Este archivo te permitirá especificar atributos como la URL de la cuenta, el sitio donde se alojará y el token de acceso, entre otro. 
+El siguiente paso es configurar tu proyecto para facilitar la carga de widgets en la plataforma Modyo e incluirlos en las páginas que construyas. Aunque puedes especificar todo como parámetros en la llamada push, recomendamos definir un conjunto de variables de entorno en un archivo `.env`. Este archivo te permitirá especificar atributos como la URL de la cuenta, el sitio donde se alojará y el token de acceso, entre otro.
 
 #### Acciones Previas
 
-1. **Obtener un token de acceso a Modyo:** Para obtener el token necesitas tener un usuario o [crear uno](/es/platform/core/roles.html#crear-usuario) que tenga como mínimo el [rol](/es/platform/core/roles.html#roles) de site developer-cli en los sitios o stages donde desplegarás tu widget. Una vez que hayas creado el usuario, puedes [configurarle un token de acceso](/es/platform/core/api.html#autenticacion). Este token será utilizado para configurar y activar los despliegues en la plataforma.
+1. **Obtener un token de acceso a Modyo**: Para obtener el token necesitas tener un usuario o [crear uno](/es/platform/core/roles.html#crear-usuario) que tenga como mínimo el [rol](/es/platform/core/roles.html#roles) de site developer-cli en los sitios o stages donde desplegarás tu widget. Una vez que hayas creado el usuario, puedes [configurarle un token de acceso](/es/platform/core/api.html#autenticacion). Este token será utilizado para configurar y activar los despliegues en la plataforma.
 
-2. **Identificar la aplicación donde publicarás:**
+2. **Identificar la aplicación donde publicarás**:
 Para obtener el ID de tu aplicación, ve al resumen de tu aplicación donde encontrarás el ID correspondiente. Recomendamos utilizar este valor siempre que sea posible. En caso que necesites utilizar el site host, lo encontrarás en la sección general de la configuración de tu aplicación.
 
 #### Configuración del Archivo .env
 
  Después de obtener la información de tu aplicación y generar los tokens requeridos, configura el archivo `.env` con los datos correspondientes.
- 
+
  Puedes utilizar el archivo de ejemplo `.env.example`incluido en la plantilla base. Este archivo trae predefinidas las variables necesarias y una breve descripción de cada una de ellas.
 
 

--- a/docs/es/platform/channels/global-snippets.md
+++ b/docs/es/platform/channels/global-snippets.md
@@ -15,11 +15,11 @@ Un cambio en un snippet global afecta a todas las aplicaciones web donde se est�
 
 En la vista de edición de snippets puedes crear y gestionar tus snippets globales. En la barra superior, tienes las siguientes opciones:
 
-- **Diferencias:** Permite comparar cambios entre múltiples versiones de un snippet. Puedes seleccionar las versiones a comparar y hacer reset o rollback a versiones previas.
-- **Otras acciones:**
+- **Diferencias**: Permite comparar cambios entre múltiples versiones de un snippet. Puedes seleccionar las versiones a comparar y hacer reset o rollback a versiones previas.
+- **Otras acciones**:
     - Archivar: Para archivar un snippet debes primero publicarlo.
     - Borrar: Para eliminar un snippet debes primero archivarlo.
-- **Guardar:** Una vez que hayas guardado tu snippet, este botón cambia de estado a **publicar**.
+- **Guardar**: Una vez que hayas guardado tu snippet, este botón cambia de estado a **publicar**.
 
 Arriba de la zona de trabajo están las siguientes secciones:
 

--- a/docs/es/platform/channels/liquid-markup/filters.md
+++ b/docs/es/platform/channels/liquid-markup/filters.md
@@ -184,7 +184,7 @@ Si no especificas parámetros de divisa con el filtro de currency, Modyo utiliza
 En caso de que el sitio no tenga un reino asociado y no especifiques parámetros, se aplicará el formato predefinido del idioma del sitio.
 :::
 
-**Parámetros:**
+**Parámetros**:
 
 - unit - símbolo de la moneda.
 - separator - separador de decimales.
@@ -216,7 +216,7 @@ Retorna el URL de una imagen usando su uuid del Gestor de Archivos. *e.g.*
 Retorna los tags de un video usando su uuid del Gestor de Archivos. *e.g.*
 <span v-pre>`{{ uuid | asset_video: 350, 300 }}`</span>
 
-**Parametros:**
+**Parametros**:
 - uuid (String) — asset uuid
 - width (Integer) (default: 300) — ancho
 - height (Integer) (default: 200) — largo
@@ -226,7 +226,7 @@ Retorna los tags de un video usando su uuid del Gestor de Archivos. *e.g.*
 Retorna una lista de Entradas que pertenecen a la Categoría seleccionada. *e.g.*
 <span v-pre>`{% assign filtered_entries = entries | by_category: 'category2,category1,category3' %}`</span>
 
-**Parametros:**
+**Parametros**:
 - entries (ArrayEntry) — array con entradas
 - list (String) (default: '') — String con categorías separadas por coma.
 
@@ -235,7 +235,7 @@ Retorna una lista de Entradas que pertenecen a la Categoría seleccionada. *e.g.
 Retorna una lista de Entradas que pertenecen a un lenguaje seleccionado. *e.g.*
 <span v-pre>`{% assign entries = widget.entries | locale: 'es,en,pt' %} => entries`</span>
 
-**Parametros:**
+**Parametros**:
 - entries (ArrayEntry) — array con entradas
 - locale (String) (default: '') — String con lenguajes separadas por coma.
 
@@ -244,7 +244,7 @@ Retorna una lista de Entradas que pertenecen a un lenguaje seleccionado. *e.g.*
 Retorna una lista de Entradas que pertenecen a un slug seleccionado. *e.g.*
 <span v-pre>`{% assign filtered_entries = entries | by_slug: 'slug2,slug1,slug' %}`</span>
 
-**Parametros:**
+**Parametros**:
 - entries (ArrayEntry) — array con entradas
 - slug (String) (default: '') — Slug separadas por coma.
 
@@ -253,7 +253,7 @@ Retorna una lista de Entradas que pertenecen a un slug seleccionado. *e.g.*
 Retorna una lista de Entradas que pertenecen a un tag seleccionado. *e.g.*
 <span v-pre>`{% assign entries = widget.entries | by_tag: 'tag2,tag1,tag3' %} => entries`</span>
 
-**Parametros:**
+**Parametros**:
 - entries (ArrayEntry) — array con entradas
 - locale (String) (default: '') — String con tags separadas por coma.
 
@@ -262,7 +262,7 @@ Retorna una lista de Entradas que pertenecen a un tag seleccionado. *e.g.*
 Retorna una lista de Entradas que pertenecen a un Tipo de Contenido seleccionado. *e.g.*
 <span v-pre>`{% assign filtered_entries = entries | by_type: 'type2,type1,type3' %}`</span>
 
-**Parametros:**
+**Parametros**:
 - entries (ArrayEntry) — array con entradas
 - locale (String) (default: '') — String con tipos de contenido separados por coma.
 
@@ -271,7 +271,7 @@ Retorna una lista de Entradas que pertenecen a un Tipo de Contenido seleccionado
 Retorna una lista de Entradas que cumplen con un filtro. *e.g.*
 <span v-pre>`{% assign entries = widget.entries | filter_by: field: 'name', eq: 'entry3Cat3' %}`</span>
 
-**Parametros:**
+**Parametros**:
 - entries (ArrayEntry) — array con entradas
 - opts (Hash) (default: {}) — hash con el campo y eq como el valor
 
@@ -283,11 +283,11 @@ Retorna una lista de Entradas que cumplen con un query. Se pueden usar operadore
 
 - gt, lt, in, all, nin
 
-**Fields:**
+**Fields**:
 - meta.category meta.category_slug meta.category_name meta.uuid meta.name meta.created_at
  meta.updated_at meta.published_at meta.unpublished_at meta.slug meta.tag
 
-**Url examples:**
+**Url examples**:
 
 - https://company.site.com/testsite?meta.category_slug=category3
 - https://company.site.com/testsite?meta.tag=tag_name
@@ -297,7 +297,7 @@ Retorna una lista de Entradas que cumplen con un query. Se pueden usar operadore
 *e.g.*
 <span v-pre>`{% assign entries = widget.entries | filter_by_query_string %}`</span>
 
-**Parametros:**
+**Parametros**:
 - entries (ArrayEntry) — array con entradas
 
 ### From Published Date
@@ -306,7 +306,7 @@ Retorna una lista de Entradas que tengan una fecha de publicación más reciente
 <span v-pre>`{% assign entries = widgets.entries | from_published_date: date %}
 `</span>
 
-**Parametros:**
+**Parametros**:
 - entries (ArrayEntry) — array con entradas
 - date (Datetime)(default: Time.zone.now) — fecha límite
 
@@ -315,7 +315,7 @@ Retorna una lista de Entradas que tengan una fecha de publicación más reciente
 Límita el número de resultados. *e.g.*
 <span v-pre>`{{ entries | limit: 1 }}`</span>
 
-**Parametros:**
+**Parametros**:
 - objeto(Array) — array
 - limit (Integer)(default: 1) — límite de resultados
 
@@ -324,7 +324,7 @@ Límita el número de resultados. *e.g.*
 Separa los resultados en páginas. *e.g.*
 <span v-pre>`{{ objects | paginated: 10, 2 }}`</span>
 
-**Parametros:**
+**Parametros**:
 - objeto(Array) — array
 - per_page (Integer) (default: 10) — objetos por página
 - page (Integer) (default: 1) — número de página a mostrar
@@ -334,7 +334,7 @@ Separa los resultados en páginas. *e.g.*
 Retorna un array con las entradas ordenadas por un campo *e.g.*
 <span v-pre>`{% assign entries = widgets.entries | sort_by: 'name', 'asc' %}`</span>
 
-**Parametros:**
+**Parametros**:
 - entries (ArrayEntry) — array con entradas
 - atributo (String) — campo por el cual se quiere ordenar
 - orden (String) - asc (asecendente) o desc (desciendiente)
@@ -346,7 +346,7 @@ Retorna una lista de Entradas que tengan una fecha de publicación más vieja qu
 <span v-pre>`{% assign entries = widgets.entries | to_published_date: date %}
 `</span>
 
-**Parametros:**
+**Parametros**:
 - entries (ArrayEntry) — array con entradas
 - date (Datetime)(default: Time.zone.now) — fecha límite
 

--- a/docs/es/platform/channels/navigation.md
+++ b/docs/es/platform/channels/navigation.md
@@ -12,14 +12,14 @@ Navegación sólo permite tres niveles de profundidad, por lo que puedes tener u
 
 En la parte superior de la vista, encontrarás el estado de publicación del menú:
 
-- **Publicado:** Este estado aparece luego de haber hecho una publicación y cuando las versiones editable y publicada son iguales.
-- **Cambios pendientes:** Este estado aparece si es que ya hay una versión publicada, pero hay cambios pendientes de publicar en tu versión editable.
-- **En revisión:** Este estado aparece cuando esté habilitada la [Revisión en Equipo](/es/platform/core/key-concepts.html) y se haya enviado a revisión la versión editable.
-- **Aprobado:** Este estado aparece cuando esté habilitada la [Revisión en Equipo](/es/platform/core/key-concepts.html) y si se cumplieron las condiciones de revisión del elemento. Si se encuentra en este estado, tus plantillas ya pueden ser publicados.
+- **Publicado**: Este estado aparece luego de haber hecho una publicación y cuando las versiones editable y publicada son iguales.
+- **Cambios pendientes**: Este estado aparece si es que ya hay una versión publicada, pero hay cambios pendientes de publicar en tu versión editable.
+- **En revisión**: Este estado aparece cuando esté habilitada la [Revisión en Equipo](/es/platform/core/key-concepts.html) y se haya enviado a revisión la versión editable.
+- **Aprobado**: Este estado aparece cuando esté habilitada la [Revisión en Equipo](/es/platform/core/key-concepts.html) y si se cumplieron las condiciones de revisión del elemento. Si se encuentra en este estado, tus plantillas ya pueden ser publicados.
 
 En la parte superior derecha, encuentras la última fecha de publicación y las acciones disponibles:
 
-**Vista previa:** Al hacer click en este ícono se abre una nueva pestaña con el modo vista previa del menú, donde puedes visualizar todos los cambios.
+**Vista previa**: Al hacer click en este ícono se abre una nueva pestaña con el modo vista previa del menú, donde puedes visualizar todos los cambios.
 
 :::warning Atención
 Puedes previsualizar los cambios como usuario sin sesión o usuario con sesión de Modyo. Para esto, es recomendable iniciar o cerrar la sesión de Modyo en el sitio antes de entrar al modo vista previa, Esto debido a que iniciar o cerrar sesión dentro del modo de vista previa puede generar errores de seguridad como  _x-frame-options_ o _mixed-content_, dependiendo de la configuración de dominios personalizados y SSL del sitio.
@@ -29,7 +29,7 @@ Puedes previsualizar los cambios como usuario sin sesión o usuario con sesión 
 El menú que has creado solo se visualizará en una página si lo agregas a través de una plantilla publicada. De lo contrario, el menú no se solicitará y no aparecerá en la página.
 :::
 
-**Diferencias:** Haz click aquí para acceder a la [vista de diferencias](/es/platform/core/key-concepts.html#revertir-un-cambio), en la cual puedes comparar los cambios entre diferentes versiones de tu menú.
+**Diferencias**: Haz click aquí para acceder a la [vista de diferencias](/es/platform/core/key-concepts.html#revertir-un-cambio), en la cual puedes comparar los cambios entre diferentes versiones de tu menú.
 
 Por defecto, inicias comparando la versión publicada con la versión editable. Usa los selectores de versiones para comparar con versiones de respaldo.
 
@@ -41,7 +41,7 @@ Por defecto se guardan hasta 20 respaldos de tal forma que los veinte respaldos 
 Para más información sobre el versionamiento, revisa la sección de [Versionado](/es/platform/core/key-concepts.html#versionado).
 :::
 
-**Actividad/Comentarios:** Solo aparece habilitada si tienes activada la [revisión en equipo](/es/platform/core/key-concepts.html) habilitada. Al hacerle click, despliega una barra lateral con el historial de actividad y comentarios del menú.
+**Actividad/Comentarios**: Solo aparece habilitada si tienes activada la [revisión en equipo](/es/platform/core/key-concepts.html) habilitada. Al hacerle click, despliega una barra lateral con el historial de actividad y comentarios del menú.
 
 Al final de la barra lateral, ves una caja de texto donde puedes escribir un comentario. Junto a cada actividad, puedes hacer click en _ver detalle_ para mostrar la información completa de ese registro de actividad.
 
@@ -62,16 +62,16 @@ Tu menú en este momento ya es público pero no se manda a llamar. Se necesita u
 
 **Acción principal**
 
-- **Guardar:** Guarda todos los cambios del menú.
-- **Enviar a revisión:** Cambia el estado del menú a "Esperando revisión". En este estado sigues haciendo cambios, pero cada cambio será notificado vía correo a los revisores asignados.
-- **Rechazar:** Vuelve al estado "En edición", notificando a los revisores que el elemento fue rechazado.
-- **Publicar:** Una vez que el menú fue aprobado, podrás ir a la vista de [publicación conjunta](/es/platform/channels/sites.html#revision-y-publicacion-conjunta) para publicar tu navegación.
+- **Guardar**: Guarda todos los cambios del menú.
+- **Enviar a revisión**: Cambia el estado del menú a "Esperando revisión". En este estado sigues haciendo cambios, pero cada cambio será notificado vía correo a los revisores asignados.
+- **Rechazar**: Vuelve al estado "En edición", notificando a los revisores que el elemento fue rechazado.
+- **Publicar**: Una vez que el menú fue aprobado, podrás ir a la vista de [publicación conjunta](/es/platform/channels/sites.html#revision-y-publicacion-conjunta) para publicar tu navegación.
 
 En la sección lateral derecha puedes ver una barra que cambia de acuerdo al ítem seleccionado en el área principal. En esta sección puedes ver las opciones:
 
-- **Nombre:** Nombre del elemento que aparecerá en el sitio.
-- **Page asociado:** Se puede asociar directamente a una página o a una URL personalizada.
-- **URL:** Si escogiste una URL personalizada en el elemento anterior, tienes diferentes opciones para configurar este ítem:
+- **Nombre**: Nombre del elemento que aparecerá en el sitio.
+- **Page asociado**: Se puede asociar directamente a una página o a una URL personalizada.
+- **URL**: Si escogiste una URL personalizada en el elemento anterior, tienes diferentes opciones para configurar este ítem:
 	- HTTP(s): Apunta a una dirección usando HTTP(s). Ejemplos:
 		- http://www.example.com
 		- https://www.example.com
@@ -88,9 +88,9 @@ En la sección lateral derecha puedes ver una barra que cambia de acuerdo al ít
 		- sms:+569-123-45678,9-123-45678?body=hello%20there&param1=a%20value
 	- Email: Genera una liga con el URI `mailto`. Ejemplos:
 		- mailto:info@example.com?subject=subject&cc=cc@example.com
-- **Abrir en pestaña nueva:** Le añade el atributo `target='blank'` al elemento HTML del item del menú, para que al hacerle click, se abra en una pestaña nueva.
-- **Privado:** Hace que el elemento seleccionado aparezca visible solo cuando hay una sesión de usuario activa en el sitio.
-- **Segmentos:** Si hay segmentos creados, también podrás segmentar este elemento para que los usuarios puedan ver este ítem de menú solo cuando tengan una sesión activa y que además se encuentren dentro de los segmentos seleccionados.
+- **Abrir en pestaña nueva**: Le añade el atributo `target='blank'` al elemento HTML del item del menú, para que al hacerle click, se abra en una pestaña nueva.
+- **Privado**: Hace que el elemento seleccionado aparezca visible solo cuando hay una sesión de usuario activa en el sitio.
+- **Segmentos**: Si hay segmentos creados, también podrás segmentar este elemento para que los usuarios puedan ver este ítem de menú solo cuando tengan una sesión activa y que además se encuentren dentro de los segmentos seleccionados.
 
 ## Ejemplos de Menu
 

--- a/docs/es/platform/channels/pages.md
+++ b/docs/es/platform/channels/pages.md
@@ -16,25 +16,25 @@ En la vista de edición, encuentras una barra superior con acciones, una grilla 
 
 En la barra superior, encuentras distintas acciones e información:
 
-**Título:** Se encuentra en la parte superior izquierda, e indica el nombre de la página que estás modificando. A la derecha el nombre, encontrarás el estado actual de la página. Esos pueden ser "Borrador", "En revisión", "Aprobado", "Cambios pendientes", "Publicado". Para aprender más sobre estos estados, puedes revisar la sección de [Versionado y Revisión en Equipo](/es/platform/core/key-concepts.html).
+**Título**: Se encuentra en la parte superior izquierda, e indica el nombre de la página que estás modificando. A la derecha el nombre, encontrarás el estado actual de la página. Esos pueden ser "Borrador", "En revisión", "Aprobado", "Cambios pendientes", "Publicado". Para aprender más sobre estos estados, puedes revisar la sección de [Versionado y Revisión en Equipo](/es/platform/core/key-concepts.html).
 
-**Fecha de publicación:** Si la página ha sido publicada, indicará la fecha de la última publicación.
+**Fecha de publicación**: Si la página ha sido publicada, indicará la fecha de la última publicación.
 
-**Vista previa:** Este ícono te permite abrir una pestaña nueva con el modo Vista Previa para visualizar los cambios que se han hecho en la página sin necesidad de publicarla.
+**Vista previa**: Este ícono te permite abrir una pestaña nueva con el modo Vista Previa para visualizar los cambios que se han hecho en la página sin necesidad de publicarla.
 
 :::warning Atención
 Puedes previsualizar las páginas como usuario sin sesión o usuario con sesión de Modyo. Para esto, es recomendable iniciar o cerrar la sesión de Modyo en el sitio antes de entrar al modo vista previa. Esto se debe a que iniciar o cerrar sesión dentro del modo de vista previa puede generar errores de seguridad como _x-frame-options_ o _mixed-content_, dependiendo de la configuración de dominios personalizados y SSL del sitio.
 :::
 
-**Diferencias:** Al hacer click en el ícono de diferencias,  accedes a la vista de diferencias de la página, donde puede seleccionar dos versiones a comparar, permitiendo ejecutar las acciones [reestablecer y rollback](/es/platform/core/key-concepts.html#revertir-un-cambio)
+**Diferencias**: Al hacer click en el ícono de diferencias,  accedes a la vista de diferencias de la página, donde puede seleccionar dos versiones a comparar, permitiendo ejecutar las acciones [reestablecer y rollback](/es/platform/core/key-concepts.html#revertir-un-cambio)
 
 :::tip Tip
 Si tu página está en estado _borrador_ no aparecerá el icono de diferencias, dado que no hay nada con que comparar la versión editable actual. Para aprender más sobre las diferencias y respaldos, revisa la sección de [versionado](/es/platform/core/key-concepts.html#versionado)
 :::
 
-**Actividad:** Despliega una barra lateral que muestra la actividad asociada a la página, como las modificaciones, publicaciones y comentarios. En la parte inferior de esta barra, puedes escribir comentarios asociados. En caso de que la página esté en revisión, todos los revisores asignados recibirán una notificación con el comentario.
+**Actividad**: Despliega una barra lateral que muestra la actividad asociada a la página, como las modificaciones, publicaciones y comentarios. En la parte inferior de esta barra, puedes escribir comentarios asociados. En caso de que la página esté en revisión, todos los revisores asignados recibirán una notificación con el comentario.
 
-**Otras acciones:**
+**Otras acciones**:
 
 - Archivar: Si una página no está publicada, esta acción te permite archivarla. Cuando una página está archivada, por defecto, no aparece en el índice de página, lo que permite mantener la estructura del sitio limpia.
 - Duplicar: Esta acción te permite copiar la versión editable de la página en la que estás. La versión copiada queda en estado _borrador_.
@@ -59,7 +59,7 @@ Para conocer los tipos de widgets que puedes agregar, ve [Widgets](/es/platform/
 
 Para conocer más acerca de páginas de contenido, ve [Página de Contenido](/es/platform/channels/pages.html#pagina-de-contenido)
 
-**Acción principal:** Es el botón verde en la parte superior derecha. Este botón puede tomar distintas formas:
+**Acción principal**: Es el botón verde en la parte superior derecha. Este botón puede tomar distintas formas:
 
 - Guardar: Te permite guardar los cambios que has hecho en la página.
 - Enviar a revisión: Si está habilitada la revisión en equipo, entonces si no hay cambios que guardar, esta acción te permitirá enviar a revisión la página y asignar revisores.
@@ -71,7 +71,7 @@ Para conocer más acerca de páginas de contenido, ve [Página de Contenido](/es
 * Si una página tiene hijos, solo puedes archivarla si todos estos se encuentran archivados.
 :::
 
-**Acciones secundarias:**
+**Acciones secundarias**:
 - Forzar publicación: Si es que eres administrador del sitio, entonces puedes ver y usar esta opción que te permite publicar la página en cualquier momento, incluso saltándote la revisión en equipo.
 - Despublicar: Si es que la página está publicada, entonces ves esta acción que te permite despublicar la página.
 
@@ -116,14 +116,14 @@ Es necesario que el CDN de tu cuenta esté en la nube para que los cambios se re
 Aquí puedes personalizar tu página usando widgets preestablecidos de la siguiente lista:
 
 
-- **HTML:** Te permite ingresar código HTML y CSS sin validaciones. No te permitirá ingresar código Javascript.
-- **Texto enriquecido:** Te permitirá hacer uso de un editor de texto enriquecido, en el que puedes darle formato al texto y cambiar entre la vista de código y texto enriquecido.
+- **HTML**: Te permite ingresar código HTML y CSS sin validaciones. No te permitirá ingresar código Javascript.
+- **Texto enriquecido**: Te permitirá hacer uso de un editor de texto enriquecido, en el que puedes darle formato al texto y cambiar entre la vista de código y texto enriquecido.
 :::warning Atención
 El widget de texto enriquecido cuenta con un formateador automático, por lo que el código que escribas en la vista de código puede verse afectado.
 :::
-- **Listado de contenido:** Muestra listados de contenido haciendo uso de filtros por espacio, tipo, idioma, tags, y categoría. Para modificar como se ven estos widgets, debes hacerlo en la sección de Widgets en [Templates](/es/platform/channels/templates.html).
-- **Contenido destacado:** Muestra un listado de entradas como imágenes "hero" en un carrusel.
-- **Personalizado:** Encontrarás un listado de todos los widgets que has creado y publicado en el widget builder.
+- **Listado de contenido**: Muestra listados de contenido haciendo uso de filtros por espacio, tipo, idioma, tags, y categoría. Para modificar como se ven estos widgets, debes hacerlo en la sección de Widgets en [Templates](/es/platform/channels/templates.html).
+- **Contenido destacado**: Muestra un listado de entradas como imágenes "hero" en un carrusel.
+- **Personalizado**: Encontrarás un listado de todos los widgets que has creado y publicado en el widget builder.
 
 Una vez seleccionado un widget en la sección central, el foco pasará a la pestaña lateral, donde podrás encontrar distintas opciones de configuración del widget y en caso de seleccionar un widget personalizado, encontrarás un link para ir directamente a su vista de edición en [widget builder](/es/platform/channels/widgets.html) y el listado de variables que el widget está usando. Si quieres sobrescribir el valor de una variable en particular para esa instancia del widget en esa página, debes seleccionar el checkbox a la izquierda de la variable y cambiar el valor que toma.
 
@@ -202,9 +202,9 @@ La página índice que contiene el listado de todas las entradas del tipo de con
 
 #### Edit
 
-- **Habilitar Índice de Entradas:** Deshabilitado por defecto. La ruta que toma es el nombre que se le dio a la página cuando fue creada. Si se deshabilita esta opción, solo las páginas de **Show** serán accesibles y si se intenta acceder se les mostrará un error 404.
-- **Layout:** La plantilla Layout que va a cargar para el Index.
-- **Custom Meta Tag:** Agrega custom meta tags para optimizar el SEO del índice. Este meta tag solo será cargado para el Index, no para el Show. También puedes utilizar Liquid para cargar meta tags dinámicos.
+- **Habilitar Índice de Entradas**: Deshabilitado por defecto. La ruta que toma es el nombre que se le dio a la página cuando fue creada. Si se deshabilita esta opción, solo las páginas de **Show** serán accesibles y si se intenta acceder se les mostrará un error 404.
+- **Layout**: La plantilla Layout que va a cargar para el Index.
+- **Custom Meta Tag**: Agrega custom meta tags para optimizar el SEO del índice. Este meta tag solo será cargado para el Index, no para el Show. También puedes utilizar Liquid para cargar meta tags dinámicos.
 
 ### Show
 
@@ -212,8 +212,8 @@ La pestaña en donde defines como van a lucir las entradas dinámicas. Aquí pod
 
 #### Edit:
 
-- **Layout:** La plantilla Layout que va a cargar para el Show.
-- **Custom Meta Tag:** Agrega custom meta tags para optimizar el SEO del show. Este meta tag solo será cargado para el Show, no para el Index. También puedes utilizar Liquid para cargar meta tags dinámicos.
+- **Layout**: La plantilla Layout que va a cargar para el Show.
+- **Custom Meta Tag**: Agrega custom meta tags para optimizar el SEO del show. Este meta tag solo será cargado para el Show, no para el Index. También puedes utilizar Liquid para cargar meta tags dinámicos.
 
 Un ejemplo básico de código Liquid+HTML que puedes usar en **Show** es:
 

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -9,9 +9,9 @@ Una aplicación web o web app despliega el contenido creado en content y channel
 
 Una web app puede estar en uno de estos tres estados:
 
-- **Habilitado:** Estado por defecto de las aplicaciones web recién creadas y aquellas que están habilitadas para uso.
-- **Cambios pendientes:** Existen modificaciones pendientes en la aplicación web. Un administrador puede verificar los cambios y publicar la aplicación web.
-- **Deshabilitado:** No es posible acceder a la aplicación web.
+- **Habilitado**: Estado por defecto de las aplicaciones web recién creadas y aquellas que están habilitadas para uso.
+- **Cambios pendientes**: Existen modificaciones pendientes en la aplicación web. Un administrador puede verificar los cambios y publicar la aplicación web.
+- **Deshabilitado**: No es posible acceder a la aplicación web.
 
 ## Crear una aplicación web
 
@@ -109,7 +109,7 @@ En la sección de configuración de la aplicación puedes personalizar tu web ap
 
 En esta sección puedes configurar:
 
-- **Nombre de la aplicación:** Este campo se usa como título por defecto para el SEO de tu web app.
+- **Nombre de la aplicación**: Este campo se usa como título por defecto para el SEO de tu web app.
 - **Descripción**
 
 :::warning Atención
@@ -117,9 +117,9 @@ En esta sección puedes configurar:
 Los cambios en el nombre y la descripción se reflejan de inmediato Modyo. La actualización en los resultados de búsqueda se verá una vez que los motores de búsqueda completen su proceso de reindexación.
 
 :::
-- **Logo de la aplicación:** Imagen que se muestra en la parte superior izquierda.
-- **Idioma de la aplicación:** El idioma en el que está disponible tu web app. Las opciones son: español, inglés y portugués.
-- **Zona horaria:** La zona horaria en que se muestran los campos de fecha y hora en la app. Esta configuración afecta a todas las secciones, incluyendo pages, navegación y plantillas, así como las llamadas de Liquid a los datos de la aplicación web.
+- **Logo de la aplicación**: Imagen que se muestra en la parte superior izquierda.
+- **Idioma de la aplicación**: El idioma en el que está disponible tu web app. Las opciones son: español, inglés y portugués.
+- **Zona horaria**: La zona horaria en que se muestran los campos de fecha y hora en la app. Esta configuración afecta a todas las secciones, incluyendo pages, navegación y plantillas, así como las llamadas de Liquid a los datos de la aplicación web.
 
 
 :::warning Atención
@@ -137,9 +137,9 @@ Para acceder a estos snippets:
 1. Haz click en plantillas en el menú lateral
 1. En la columna del lado derecho, da click en snippets y ve a la sección general. Puedes incrustarlos en el snippet _head_ y en las vistas _home_ y _base_.
 
-**Para crear snippets personalizados:**
+**Para crear snippets personalizados**:
 
-**Para el _head_:**
+**Para el _head_**:
 
 1. Utiliza este código:
 
@@ -182,9 +182,9 @@ Con esta configuración completada, cuando exista un valor asociado al campo **I
 
 
 
-- **Favicon:** Imagen que aparece al costado de la barra de dirección.
-- **Icono de Apple:** Imagen que se ve en los dispositivos móviles al usar el sitio como aplicación.
-- **Borrar:** Eliminar definitivamente un sitio y todo sus elementos.
+- **Favicon**: Imagen que aparece al costado de la barra de dirección.
+- **Icono de Apple**: Imagen que se ve en los dispositivos móviles al usar el sitio como aplicación.
+- **Borrar**: Eliminar definitivamente un sitio y todo sus elementos.
 
 :::danger Peligro
 Borrar es irreversible, por lo que debes estar completamente seguro al ejecutar esta acción.
@@ -195,15 +195,15 @@ Al presionar el botón de eliminado, el sistema te pedirá que ingreses el nombr
 
 
 **Visualización**
-- **Favicon:** Imagen que se muestra junto a la barra de dirección.
-- **Icono de Apple:** Imagen que se visualiza en dispositivos móviles iOS al marcar la aplicación como favorita.
+- **Favicon**: Imagen que se muestra junto a la barra de dirección.
+- **Icono de Apple**: Imagen que se visualiza en dispositivos móviles iOS al marcar la aplicación como favorita.
 
 **Privacidad**
-- **Público:** Todos los visitantes pueden ver la web app y su contenido sin necesidad de iniciar sesión.
-- **Privado:** Solo los usuarios con una sesión iniciada de Modyo pueden ver la web app.
-- **Mostrar home a visitas públicas:** La página de inicio de la web app se muestra a todos los visitantes, incluso aquellos que no hayan iniciado sesión. Al navegar a cualquier otra página, se solicita registro o inicio de sesión.
-- **Redireccionar al home cuando una URL no se encuentra:** Por defecto, la aplicación web muestra un error 404 cuando el usuario accede a una URL inexistente. Si marcas esta opción, el usuario será redirigido a la página de inicio de la web app en lugar del 404.
-- **Habilitar búsqueda:** Activa la función de búsqueda en la web app.
+- **Público**: Todos los visitantes pueden ver la web app y su contenido sin necesidad de iniciar sesión.
+- **Privado**: Solo los usuarios con una sesión iniciada de Modyo pueden ver la web app.
+- **Mostrar home a visitas públicas**: La página de inicio de la web app se muestra a todos los visitantes, incluso aquellos que no hayan iniciado sesión. Al navegar a cualquier otra página, se solicita registro o inicio de sesión.
+- **Redireccionar al home cuando una URL no se encuentra**: Por defecto, la aplicación web muestra un error 404 cuando el usuario accede a una URL inexistente. Si marcas esta opción, el usuario será redirigido a la página de inicio de la web app en lugar del 404.
+- **Habilitar búsqueda**: Activa la función de búsqueda en la web app.
 - **Habilitar la búsqueda en múltiples aplicaciones**
 
 :::tip Tip
@@ -217,13 +217,13 @@ Si habilitas la búsqueda en tu web app y usas el parámetro `multi=true` desde 
 Procede con cautela al modificar estas opciones, ya que pueden afectar el acceso a tu aplicación web y la experiencia de tus sus usuarios.
 :::
 
-- **Cambiar host:** Esta acción modifica la visibilidad y accesibilidad de la aplicación. Realizar un cambio de host puede impactar la visibilidad y disponibilidad de la aplicación web.
-- **Cambiar reino:** Despliega el reino de la aplicación. Al cambiar de reino pierdes toda la configuración de privacidad en tus web apps, páginas y navegación.
-- **Cambiar estado:** Cambia el estado de la aplicación, las opciones son:
+- **Cambiar host**: Esta acción modifica la visibilidad y accesibilidad de la aplicación. Realizar un cambio de host puede impactar la visibilidad y disponibilidad de la aplicación web.
+- **Cambiar reino**: Despliega el reino de la aplicación. Al cambiar de reino pierdes toda la configuración de privacidad en tus web apps, páginas y navegación.
+- **Cambiar estado**: Cambia el estado de la aplicación, las opciones son:
 	* Habilitado: Editable y visible al público. Este es el estado por defecto de una web app.
 	* Editable: Modificable pero no visible al público. Requiere inicio de sesión para acceder. Robots.txt, PWAs y el manifiesto están deshabilitados en este estado.
 	* Deshabilitado: No editable ni visible. En este estado, no es accesible ni visible para los usuarios.
-- **Eliminar aplicación:** Inicia la eliminación asíncrona de la aplicación y de todos sus elementos, como páginas y widgets.
+- **Eliminar aplicación**: Inicia la eliminación asíncrona de la aplicación y de todos sus elementos, como páginas y widgets.
 
 ::: danger Peligro
 Es irreversible la eliminación de una aplicación web.
@@ -237,19 +237,19 @@ El SEO (Search Engine Optimization) es fundamental para el posicionamiento en mo
 
 Puedes configurar:
 
-- **Tagline:** Descripción en los motores de búsqueda, debajo del nombre de la aplicación web.
-- **Actualizar automáticamente el archivo sitemap.xml para mí:** Permite a Modyo crear y mantener el sitemap.xml automáticamente. Desactiva esta opción para usar un mapa de sitio personalizado.
-- **Sitemap:** Este archivo XML permite a los motores de búsqueda indexar el contenido del sitio.
-- **Archivo sitemap.xml personalizado:** Archivo que permite a los motores de búsqueda indexar el contenido de la web app.
-- **Actualizar automáticamente el archivo robots.xml para mí:** Permite a Modyo crear y mantener robots.txt automáticamente. Desactiva esta opción para proporcionar instrucciones personalizadas a los rastreadores de web apps.
-- **Archivo robots.txt personalizado:** Archivo que indica a los robots rastreadores las partes de la aplicación pueden o no indexar.
+- **Tagline**: Descripción en los motores de búsqueda, debajo del nombre de la aplicación web.
+- **Actualizar automáticamente el archivo sitemap.xml para mí**: Permite a Modyo crear y mantener el sitemap.xml automáticamente. Desactiva esta opción para usar un mapa de sitio personalizado.
+- **Sitemap**: Este archivo XML permite a los motores de búsqueda indexar el contenido del sitio.
+- **Archivo sitemap.xml personalizado**: Archivo que permite a los motores de búsqueda indexar el contenido de la web app.
+- **Actualizar automáticamente el archivo robots.xml para mí**: Permite a Modyo crear y mantener robots.txt automáticamente. Desactiva esta opción para proporcionar instrucciones personalizadas a los rastreadores de web apps.
+- **Archivo robots.txt personalizado**: Archivo que indica a los robots rastreadores las partes de la aplicación pueden o no indexar.
 
 :::tip Tip
 Los archivos robots.txt y sitemap.xml solo son visibles con dominios personalizados. De lo contrario, se encuentran solo a nivel de plataforma, tienen sus valores por defecto y no se pueden personalizar.
 :::
 
-- **Meta tags personalizados:** Te permite configurar meta tags para todas las páginas y sus valores por defecto. Da click en **+ nuevo meta tag** para crear uno nuevo.
-- **Replicar meta tag en páginas:** Al crear un nuevo meta tag, selecciona esta opción para propagar el meta tag y su valor en todas las páginas de la web app. Debes guardar los cambios en meta tags y publicar todas las páginas modificadas para que los nuevos meta tags surtan efecto.
+- **Meta tags personalizados**: Te permite configurar meta tags para todas las páginas y sus valores por defecto. Da click en **+ nuevo meta tag** para crear uno nuevo.
+- **Replicar meta tag en páginas**: Al crear un nuevo meta tag, selecciona esta opción para propagar el meta tag y su valor en todas las páginas de la web app. Debes guardar los cambios en meta tags y publicar todas las páginas modificadas para que los nuevos meta tags surtan efecto.
 
 :::warning Atención
 Solo los administradores de la aplicación pueden añadir meta tags. Los developers pueden añadir y eliminar meta tags página por página.
@@ -323,7 +323,7 @@ Si desactivas el service worker, tu aplicación web seguirá funcionando, con fu
 
 #### Notificaciones WebPush
 
-Permite que tus usuarios reciban notificaciones WebPush junto con las campañas de notificación. Para enviar mensajes a tus usuarios debes asegurarte que tu aplicación esté vinculada a un reino y el estado de la aplicación esté en **Habilitado**. La gestión de las notificaciones se realiza a través de la [herramienta de mensajería](/es/platform/customers/messaging.html). 
+Permite que tus usuarios reciban notificaciones WebPush junto con las campañas de notificación. Para enviar mensajes a tus usuarios debes asegurarte que tu aplicación esté vinculada a un reino y el estado de la aplicación esté en **Habilitado**. La gestión de las notificaciones se realiza a través de la [herramienta de mensajería](/es/platform/customers/messaging.html).
 
 #### Manifiesto PWA
 
@@ -365,9 +365,9 @@ Es esencial informar a todos los miembros de la plataforma sobre cualquier cambi
 :::
 
 Activa la casilla para realizar modificaciones. Las variables que puedes modificar son:
-- **Host:** Ubicación de la aplicación web en del servidor.
-- **Dominio primario:** Dirección principal de la aplicación web.
-- **Dominio alternativo:** Dirección secundaria para redireccionar en caso de fallo en el primario.
+- **Host**: Ubicación de la aplicación web en del servidor.
+- **Dominio primario**: Dirección principal de la aplicación web.
+- **Dominio alternativo**: Dirección secundaria para redireccionar en caso de fallo en el primario.
 
 
 :::warning Atención

--- a/docs/es/platform/channels/templates.md
+++ b/docs/es/platform/channels/templates.md
@@ -10,20 +10,20 @@ Cuando creas un sitio, se completa con plantillas distintas para generar el tema
 
 En la sección de plantillas, el menú principal se oculta para optimizar el área de trabajo. En la parte superior izquierda, encuentras el nombre de la sección y el estado actual de la publicación:
 
-- **Publicado:** Hay una versión publicada y que la versión editable es idéntica.
-- **Cambios pendientes:** Existe una versión publicada, pero hay modificaciones pendientes de publicar en tu versión editable.
-- **En revisión:** La [revisión en equipo](/es/platform/core/key-concepts.html) está activada y se ha enviado a revisión la versión editable.
-- **Aprobado:** La [revisión en equipo](/es/platform/core/key-concepts.html) está activada y las condiciones de revisión del elemento se han cumplido. En este estado, la plantilla está lista para ser publicada.
+- **Publicado**: Hay una versión publicada y que la versión editable es idéntica.
+- **Cambios pendientes**: Existe una versión publicada, pero hay modificaciones pendientes de publicar en tu versión editable.
+- **En revisión**: La [revisión en equipo](/es/platform/core/key-concepts.html) está activada y se ha enviado a revisión la versión editable.
+- **Aprobado**: La [revisión en equipo](/es/platform/core/key-concepts.html) está activada y las condiciones de revisión del elemento se han cumplido. En este estado, la plantilla está lista para ser publicada.
 
 En la parte superior derecha, puedes ver la última fecha de publicación e íconos con las acciones disponibles:
 
-**Vista previa:** Da click en este ícono para abrir una nueva pestaña con la vista previa de las plantillas. Aquí puedes visualizar todos los cambios en tus plantillas, como si estuvieran publicados.
+**Vista previa**: Da click en este ícono para abrir una nueva pestaña con la vista previa de las plantillas. Aquí puedes visualizar todos los cambios en tus plantillas, como si estuvieran publicados.
 
 :::warning Atención
 Puedes previsualizar los cambios como usuario sin sesión o usuario con sesión activa de Modyo. Para esto, recomendamos iniciar o cerrar la sesión de Modyo en el sitio antes de entrar al modo vista previa, dado que si se inicia o cierra sesión dentro del modo vista previa. Esto se debe a que iniciar o cerrar sesión dentro del modo vista previa puede generar errores de seguridad como _x-frame-options_ o _mixed-content_, dependiendo de la configuración de dominios personalizados y SSL del sitio.
 :::
 
-**Diferencias:** Compara los cambios entre múltiples versiones de tus plantillas. Por defecto, Modyo compara la versión publicada con la versión editable. Usa los selectores de versiones para comparar con versiones de respaldo.
+**Diferencias**: Compara los cambios entre múltiples versiones de tus plantillas. Por defecto, Modyo compara la versión publicada con la versión editable. Usa los selectores de versiones para comparar con versiones de respaldo.
 
 :::tip Tip
 Cada vez que publicas una versión, la versión que estaba publicada pasa a ser una versión de respaldo. Por defecto, se guardan hasta 20 respaldos, permitiéndote comparar, restaurar y hacer rollback a las últimas 20 versiones
@@ -31,32 +31,32 @@ Cada vez que publicas una versión, la versión que estaba publicada pasa a ser 
 Para más información sobre el versionamiento, consulta la sección de [versionado](/es/platform/core/key-concepts.html#versionado).
 :::
 
-**Buscar en plantillas:** Despliega una barra lateral con un buscador de texto que explora todas las plantillas editables.
+**Buscar en plantillas**: Despliega una barra lateral con un buscador de texto que explora todas las plantillas editables.
 
-**Ver actividad:** Despliega una barra lateral que muestra el historial de actividad y donde puedes leer y escribir comentarios. Haz click en **ver detalle** para mostrar la información completa de cualquier registro de actividad.
+**Ver actividad**: Despliega una barra lateral que muestra el historial de actividad y donde puedes leer y escribir comentarios. Haz click en **ver detalle** para mostrar la información completa de cualquier registro de actividad.
 
-**Más acciones:** Este ícono te permite **archivar** o **borrar** una plantilla.
+**Más acciones**: Este ícono te permite **archivar** o **borrar** una plantilla.
 
 La última opción en la bara superior muestra las acciones principales que puedes llevar a cabo:
 
-- **Guardar:** Guarda todos los cambios de todas las plantillas.
-- **Enviar a revisión:** Cambia el estado de las plantillas a "Esperando revisión". En este estado puedes seguir haciendo modificaciones, pero cada cambio será notificado por correo a los revisores asignados.
-- **Forzar publicación:** Solo disponible para administradores del sitio, permite publicar inmediatamente una plantilla, incluso si está esperando revisión
-- **Rechazar:** Vuelve al estado "En edición" y notifica a los revisores que el elemento fue rechazado.
-- **Publicar:** Una vez que la plantilla ha sido aprobada, puedes enviarla a publicar.
+- **Guardar**: Guarda todos los cambios de todas las plantillas.
+- **Enviar a revisión**: Cambia el estado de las plantillas a "Esperando revisión". En este estado puedes seguir haciendo modificaciones, pero cada cambio será notificado por correo a los revisores asignados.
+- **Forzar publicación**: Solo disponible para administradores del sitio, permite publicar inmediatamente una plantilla, incluso si está esperando revisión
+- **Rechazar**: Vuelve al estado "En edición" y notifica a los revisores que el elemento fue rechazado.
+- **Publicar**: Una vez que la plantilla ha sido aprobada, puedes enviarla a publicar.
 
 En el área de trabajo principal, hay dos secciones:
 
-- **El área de edición:** El hacer click en una plantilla del listado del área de selección del lado derecho abrirá la plantilla en el área central con un editor de texto. Si abres múltiples plantillas, abrirán como pestañas en el área de trabajo.
-- **El área de selección de plantillas:** Selecciona la pestaña de vistas o snippets, según requieras.
+- **El área de edición**: El hacer click en una plantilla del listado del área de selección del lado derecho abrirá la plantilla en el área central con un editor de texto. Si abres múltiples plantillas, abrirán como pestañas en el área de trabajo.
+- **El área de selección de plantillas**: Selecciona la pestaña de vistas o snippets, según requieras.
 
 ## Layouts
 
 Modyo ofrece tres layouts predefinidos:
 
-* **Home:** Exclusivamente para la página principal del sitio.
-* **Base:** Todas las páginas, excepto la de inicio, usan este layout.
-* **Error:** Empleado en las vistas de error (404, 401), presentando un diseño limpio.
+* **Home**: Exclusivamente para la página principal del sitio.
+* **Base**: Todas las páginas, excepto la de inicio, usan este layout.
+* **Error**: Empleado en las vistas de error (404, 401), presentando un diseño limpio.
 
 Para crear un nuevo layout:
 1. En la sección de **Plantillas** da click en la pestaña **Vistas**
@@ -127,10 +127,10 @@ Es necesario que el CDN de tu cuenta esté en la nube para que los cambios se re
 
 En la sección de vistas puedes personalizar cuatro tipos de errores:
 
-* **Deshabilitado:** Se muestra cuando el sitio al que intentas acceder está [deshabilitado](/es/platform/channels/sites.html).
-* **404:** Si en la configuración de [restricciones del sitio](/es/platform/channels/sites.html#privacidad) decides mostrar el 404 en lugar de redireccionar a la página de inicio, se muestra este error al ingresar a una URL no definida.
-* **Privacy:** Se muestra cuando no tienes permisos para acceder al [sitio](/es/platform/channels/sites.html#privacidad) o a una de sus [páginas](/es/platform/channels/pages.html#privacidad).
-* **Template:** Visible cuando la página cargada tiene un error de sintaxis de Liquid. Es poco probable que veas esta vista, debido a que a partir de Modyo 8.1 la plataforma realiza una verificación de la sintaxis antes de guardar y publicar cambios en Plantillas.
+* **Deshabilitado**: Se muestra cuando el sitio al que intentas acceder está [deshabilitado](/es/platform/channels/sites.html).
+* **404**: Si en la configuración de [restricciones del sitio](/es/platform/channels/sites.html#privacidad) decides mostrar el 404 en lugar de redireccionar a la página de inicio, se muestra este error al ingresar a una URL no definida.
+* **Privacy**: Se muestra cuando no tienes permisos para acceder al [sitio](/es/platform/channels/sites.html#privacidad) o a una de sus [páginas](/es/platform/channels/pages.html#privacidad).
+* **Template**: Visible cuando la página cargada tiene un error de sintaxis de Liquid. Es poco probable que veas esta vista, debido a que a partir de Modyo 8.1 la plataforma realiza una verificación de la sintaxis antes de guardar y publicar cambios en Plantillas.
 
 ## CSS y JavaScript
 
@@ -195,10 +195,10 @@ En el área de trabajo, debajo de las pestañas, encontrarás una barra con esto
 **Elementos de la barra de herramientas**
 La barra de herramientas debajo de las pestañas del Template Builder contiene los siguientes elementos:
 
-- **Gestor de archivos:** Abre un modal que te permite acceder a todos los archivos de tu cuenta y copiar su URL. Selecciona la pestaña **Subir archivos** para cargar nuevos archivos. Para más información sobre los beneficios y funcionalidades de Gestor de Archivos, dirígete a [Gestor de Archivos](/es/platform/content/asset-manager.html)
-- **Atajos de teclado:** Muestra atajos de teclado útiles para Plantillas.
-- **Snippets:** Despliega un listado con todos los snippets y la opción de copiar su código de referencia.
-- **Cambios:** Despliega un listado de todas las veces y estados en los que has guardado la versión actual. Al hacer click en una de las sub-versiones, cambias el contenido del template a esa sub-versión.
+- **Gestor de archivos**: Abre un modal que te permite acceder a todos los archivos de tu cuenta y copiar su URL. Selecciona la pestaña **Subir archivos** para cargar nuevos archivos. Para más información sobre los beneficios y funcionalidades de Gestor de Archivos, dirígete a [Gestor de Archivos](/es/platform/content/asset-manager.html)
+- **Atajos de teclado**: Muestra atajos de teclado útiles para Plantillas.
+- **Snippets**: Despliega un listado con todos los snippets y la opción de copiar su código de referencia.
+- **Cambios**: Despliega un listado de todas las veces y estados en los que has guardado la versión actual. Al hacer click en una de las sub-versiones, cambias el contenido del template a esa sub-versión.
 
 :::tip Tip
 Al publicar una versión, el listado de cambios desaparece, debido a que la nueva versión editable no ha tenido cambios.

--- a/docs/es/platform/channels/widgets.md
+++ b/docs/es/platform/channels/widgets.md
@@ -14,37 +14,37 @@ En la vista de edición del widget, se puede ver la barra superior de acciones, 
 
 En la barra superior se encuentran las siguientes secciones:
 
-- **Borrador:** Este estado aparece cuando recién se haya creado un widget o cuando se haya despublicado.
-- **Publicado:** Este estado aparece luego de haber hecho una publicación y cuando las versiones editable y publicada son iguales.
-- **Cambios pendientes:** Este estado aparece si es que ya hay una versión publicada, pero hay cambios pendientes de publicar en versión editable.
-- **En revisión:** Este estado aparece cuando esté habilitada la [revisión en equipo](/es/platform/core/key-concepts.html) y se haya enviado a revisión la versión editable.
-- **Aprobado:** Este estado aparece cuando esté habilitada la [revisión en equipo](/es/platform/core/key-concepts.html) y se cumplen las condiciones de revisión del elemento. Si está en este estado, las plantillas están listas para ser publicadas.
+- **Borrador**: Este estado aparece cuando recién se haya creado un widget o cuando se haya despublicado.
+- **Publicado**: Este estado aparece luego de haber hecho una publicación y cuando las versiones editable y publicada son iguales.
+- **Cambios pendientes**: Este estado aparece si es que ya hay una versión publicada, pero hay cambios pendientes de publicar en versión editable.
+- **En revisión**: Este estado aparece cuando esté habilitada la [revisión en equipo](/es/platform/core/key-concepts.html) y se haya enviado a revisión la versión editable.
+- **Aprobado**: Este estado aparece cuando esté habilitada la [revisión en equipo](/es/platform/core/key-concepts.html) y se cumplen las condiciones de revisión del elemento. Si está en este estado, las plantillas están listas para ser publicadas.
 
 A la derecha, encuentras las siguientes acciones:
-**Vista previa:** Abre en una nueva pestaña la vista previa de la versión editable del widget.
+**Vista previa**: Abre en una nueva pestaña la vista previa de la versión editable del widget.
 
 :::warning Atención
 Puedes previsualizar los widgets como usuario sin sesión o usuario con sesión de Modyo. Para esto, es recomendable iniciar o cerrar la sesión de Modyo en el sitio antes de entrar al modo vista previa. Esto se debe a que iniciar o cerrar sesión dentro del modo de vista previa puede generar errores de seguridad como _x-frame-options_ o _mixed-content_, dependiendo de la configuración de dominios personalizados y SSL del sitio.
 :::
 
-**Diferencias:** Te lleva a la [vista de diferencias](/es/platform/core/key-concepts.html), en la cual puedes comparar los cambios que hay entre múltiples versiones del widget.
+**Diferencias**: Te lleva a la [vista de diferencias](/es/platform/core/key-concepts.html), en la cual puedes comparar los cambios que hay entre múltiples versiones del widget.
 
 Por defecto comienzas comparando la versión publicada con la versión editable. Usa los selectores de versiones para comparar con versiones de respaldo. Si el ícono no aparece, significa que no hay versión publicada de este widget.
 
-**Actividad:** Te permite desplegar una pestaña lateral que muestra la actividad y comentarios del widget.
+**Actividad**: Te permite desplegar una pestaña lateral que muestra la actividad y comentarios del widget.
 
-**Otras opciones:** Permite archivar y crear una copia del widget actual.
+**Otras opciones**: Permite archivar y crear una copia del widget actual.
 
-**Botón principal:**
+**Botón principal**:
 
-- **Guardar:** Guarda los cambios actuales.
-- **Enviar a revisión:** Si está habilitada la revisión en equipo, puedes enviar el widget a revisión y notificar a los revisores que el widget está listo para ser revisado.
-- **Publicar:** Te lleva a la vista de [publicación conjunta](/es/platform/core/key-concepts.html#revision-y-publicacion-conjunta) donde puedes publicar tus widgets.
+- **Guardar**: Guarda los cambios actuales.
+- **Enviar a revisión**: Si está habilitada la revisión en equipo, puedes enviar el widget a revisión y notificar a los revisores que el widget está listo para ser revisado.
+- **Publicar**: Te lleva a la vista de [publicación conjunta](/es/platform/core/key-concepts.html#revision-y-publicacion-conjunta) donde puedes publicar tus widgets.
 
-**Otras acciones principales:**
+**Otras acciones principales**:
 
-- **Despublicar:** Si el widget está publicado, puedes sacarlo de producción usando esta opción.
-- **Forzar publicación:** Si eres administrador del sitio, puedes utilizar esta opción para publicar inmediatamente un widget, incluso si está habilitada la Revisión en Equipo.
+- **Despublicar**: Si el widget está publicado, puedes sacarlo de producción usando esta opción.
+- **Forzar publicación**: Si eres administrador del sitio, puedes utilizar esta opción para publicar inmediatamente un widget, incluso si está habilitada la Revisión en Equipo.
 
 :::tip Tip
 Sólo se pueden archivar los widgets que han sido despublicados previamente.
@@ -62,11 +62,11 @@ Para aprender más sobre el flujo de publicación, revise la sección de [Versio
 
 En el área de trabajo se puede ver:
 
-- **Pestañas de código:** Se tiene a disposición una pestaña de JavaScript, CSS, y HTML para construir widgets.
-- **Gestor de archivos:** Al hacer click, se levanta el modal de gestión de archivos, donde se puede filtrar y buscar los archivos que has subido en el [Gestor de Archivos](/es/platform/content/asset-manager.html) y copiar su URL para usarlos en el widget. También se puede subir nuevos archivos desde este modal.
-- **Atajos de teclado:** Muestra una pequeña ventana informativa con algunos atajos de teclado útiles.
-- **Snippets:** Muestra una lista de los snippets disponibles desde el [Template Builder](/es/platform/channels/templates.html#snippets) y se copia su código para referenciarlos en el widget.
-- **Cambios:** Si se han guardado cambios y no han publicado, mostrará este listado de todas las veces guardadas cada uno de los archivos (JS, CSS, y HTML). Al hacer click en una sub-versión, se cambia el contenido de la pestaña por el contenido de la sub-versión que se hizo click.
+- **Pestañas de código**: Se tiene a disposición una pestaña de JavaScript, CSS, y HTML para construir widgets.
+- **Gestor de archivos**: Al hacer click, se levanta el modal de gestión de archivos, donde se puede filtrar y buscar los archivos que has subido en el [Gestor de Archivos](/es/platform/content/asset-manager.html) y copiar su URL para usarlos en el widget. También se puede subir nuevos archivos desde este modal.
+- **Atajos de teclado**: Muestra una pequeña ventana informativa con algunos atajos de teclado útiles.
+- **Snippets**: Muestra una lista de los snippets disponibles desde el [Template Builder](/es/platform/channels/templates.html#snippets) y se copia su código para referenciarlos en el widget.
+- **Cambios**: Si se han guardado cambios y no han publicado, mostrará este listado de todas las veces guardadas cada uno de los archivos (JS, CSS, y HTML). Al hacer click en una sub-versión, se cambia el contenido de la pestaña por el contenido de la sub-versión que se hizo click.
 
 :::tip Tip
 Para no perder los cambios que tienes actualmente, se debe guardar antes de saltar entre sub-versiones, de tal forma que siempre pueda volver a la última versión guardada en la lista de cambios.
@@ -80,9 +80,9 @@ En las tres pestañas del widget se puede hacer uso de Liquid. Para más informa
 
 En la columna de propiedades se pueden ver:
 
-- **Nombre:** Permite cambiar el nombre del widget
-- **Tags:** Permite añadir tags a un widget. Los tag son de uso administrativo y sirven para buscar y filtrar los widgets y así poder encontrarlos rápidamente.
-- **Páginas que usan este widget:** Verás un listado de páginas que están usando este widget. Mientras veas páginas en este listado, no podrás despublicar ni archivar el widget.
+- **Nombre**: Permite cambiar el nombre del widget
+- **Tags**: Permite añadir tags a un widget. Los tag son de uso administrativo y sirven para buscar y filtrar los widgets y así poder encontrarlos rápidamente.
+- **Páginas que usan este widget**: Verás un listado de páginas que están usando este widget. Mientras veas páginas en este listado, no podrás despublicar ni archivar el widget.
 
 :::warning Atención
 Si eliminas un widget de una página y publicas, seguirás viendo esa página en este listado dado que el widget sigue referenciado en los respaldos de esa página. Desde la versión 9.1.10 en adelante, puedes despublicar cualquier widget publicado, incluso si está en uso. Las referencias activas en las páginas quedarán inactivas, por lo que no verás el widget en el sitio si lo despublicaste. Además, podrás archivar cualquier widget que no esté publicado, de tal forma que si aun existen referencias en algunas páginas del widget que quieres archivar, estas se eliminarán al momento de archivar el widget.
@@ -205,7 +205,7 @@ Para agregar un idioma nuevo al sitio, simplemente creamos un archivo **JSON** e
 │   │   └── es-CL.json
 ```
 :::warning Atención
-La estructura del archivo de idioma tiene que ser un objeto **json:**
+La estructura del archivo de idioma tiene que ser un objeto **json**:
 :::
 
 ### Validación de formularios

--- a/docs/es/platform/content/README.md
+++ b/docs/es/platform/content/README.md
@@ -12,13 +12,13 @@ version: 9.2
 {{ $frontmatter.meta[0].content }}
 
 ### Beneficios
-- **Segmentación:** Muestra entradas a usuarios específicos mediante la integración con channels y customers.
-- **Arquitectura Headless:** Consume contenido a través de una API HTTP desde Modyo channels o sistemas externos.
-- **Rendimiento:** Aloja contenido en CDNs para mayor disponibilidad y velocidad de acceso, sin importar la ubicación geográfica.
+- **Segmentación**: Muestra entradas a usuarios específicos mediante la integración con channels y customers.
+- **Arquitectura Headless**: Consume contenido a través de una API HTTP desde Modyo channels o sistemas externos.
+- **Rendimiento**: Aloja contenido en CDNs para mayor disponibilidad y velocidad de acceso, sin importar la ubicación geográfica.
 
 ### Funcionalidades principales
 
-- **[Espacios](/es/platform/content/spaces.html):** Organiza contenidos y equipos que los administren.
-- **[Tipos de contenido](/es/platform/content/types.html):** Define estructuras personalizadas.
-- **[Gestor de archivos](/es/platform/content/asset-manager.html):** Organiza los archivos usados en los contenidos como imágenes o videos.
-- **[API y SDKs](/es/platform/content/public-api-reference.html):** Accede a los repositorios de contenidos, dentro y fuera de la plataforma.
+- **[Espacios](/es/platform/content/spaces.html)**: Organiza contenidos y equipos que los administren.
+- **[Tipos de contenido](/es/platform/content/types.html)**: Define estructuras personalizadas.
+- **[Gestor de archivos](/es/platform/content/asset-manager.html)**: Organiza los archivos usados en los contenidos como imágenes o videos.
+- **[API y SDKs](/es/platform/content/public-api-reference.html)**: Accede a los repositorios de contenidos, dentro y fuera de la plataforma.

--- a/docs/es/platform/content/asset-manager.md
+++ b/docs/es/platform/content/asset-manager.md
@@ -14,16 +14,16 @@ En Media puedes asignar permisos de edición y eliminación de imágenes a trav�
 Puedes cargar diversos tipos de media a este espacio, considerando las siguientes restricciones de tamaño por archivo:
 
 
-- **Imágenes:** 6 MB
-- **Videos:** 10 MB
-- **Audios:** 10 MB
-- **Archivos:** 10 MB
+- **Imágenes**: 6 MB
+- **Videos**: 10 MB
+- **Audios**: 10 MB
+- **Archivos**: 10 MB
 
 Los tipos de archivos permitidos son:
-- **Imágenes:** apng, avif, bmp, gif, ico, jpeg, jpg, png, tif, tiff, webp
-- **Videos:** av, avi, f4v, flv, mkv, mov, mp4, mpeg, webm, wmv
-- **Audios:** 3gp, aac, alac, dsd, flac, mp3, pcm, wav, m4a, ogg, wma
-- **Archivos:** 7z, ai, apk, css, csv, doc, docx, fon, ico, iso, jar, js, msi, ods, odt, otf, pdf, ppt, pptx, rar, rss, rtf, scss, tar, tex, ttf, txt, vcf, wdp, xhtml, xls, xlsm, xlsx, xml, zip, one, ecf, pub, xps, json, svg, woff, woff2, ics
+- **Imágenes**: apng, avif, bmp, gif, ico, jpeg, jpg, png, tif, tiff, webp
+- **Videos**: av, avi, f4v, flv, mkv, mov, mp4, mpeg, webm, wmv
+- **Audios**: 3gp, aac, alac, dsd, flac, mp3, pcm, wav, m4a, ogg, wma
+- **Archivos**: 7z, ai, apk, css, csv, doc, docx, fon, ico, iso, jar, js, msi, ods, odt, otf, pdf, ppt, pptx, rar, rss, rtf, scss, tar, tex, ttf, txt, vcf, wdp, xhtml, xls, xlsm, xlsx, xml, zip, one, ecf, pub, xps, json, svg, woff, woff2, ics
 
 
 
@@ -36,20 +36,20 @@ En la parte superior derecha de la pantalla puedes ver el porcentaje de espacio 
 Modyo muestra 30 archivos por página. En la parte inferior puedes navegar entre las páginas de archivos.
 
 Puedes filtrar el contenido por:
-- **Extensiones:** Filtra por tipo de archivo.
-- **Autor:** Filtra por nombre de usuario que subió el contenido.
-- **Tags:** Muestra todos los archivos asociados a una etiqueta.
-- **Barra de búsqueda:** Escribe una palabra para desplegar los archivos que contengan esa palabra en su nombre o metadata.
+- **Extensiones**: Filtra por tipo de archivo.
+- **Autor**: Filtra por nombre de usuario que subió el contenido.
+- **Tags**: Muestra todos los archivos asociados a una etiqueta.
+- **Barra de búsqueda**: Escribe una palabra para desplegar los archivos que contengan esa palabra en su nombre o metadata.
 
 Las etiquetas te permiten organizar y agrupar tus archivos. Para modificar las etiquetas de más de un archivo, selecciona los archivos que desees y da click en el botón **Agregar o quitar etiquetas** que aparece en la parte inferior del listado.
 
 En esta vista, las columnas son:
-- **Previsualizar:** Si la plataforma identifica que el archivo es una imagen, puedes ver una imagen en miniatura del archivo. Si no lo es, el espacio aparece en blanco.
-- **Nombre:** Nombre del archivo y su extensión. El ordenamiento es alfabético.
-- **Tipo:** Tipo y extensión del archivo. El ordenamiento es alfabético, primero por tipo y después por el nombre de la extensión.
-- **Tamaño:** Tamaño en kilobytes del archivo.
-- **Creado el:** Fecha de subida o creación dentro de la plataforma, sin considerar si el archivo fue creado en una fecha distinta en otro servicio.
-- **Autor:** Nombre del usuario que subió el archivo, solo cuando el usuario tiene asignado un nombre.
+- **Previsualizar**: Si la plataforma identifica que el archivo es una imagen, puedes ver una imagen en miniatura del archivo. Si no lo es, el espacio aparece en blanco.
+- **Nombre**: Nombre del archivo y su extensión. El ordenamiento es alfabético.
+- **Tipo**: Tipo y extensión del archivo. El ordenamiento es alfabético, primero por tipo y después por el nombre de la extensión.
+- **Tamaño**: Tamaño en kilobytes del archivo.
+- **Creado el**: Fecha de subida o creación dentro de la plataforma, sin considerar si el archivo fue creado en una fecha distinta en otro servicio.
+- **Autor**: Nombre del usuario que subió el archivo, solo cuando el usuario tiene asignado un nombre.
 
 
 ## Subir un archivo
@@ -76,12 +76,12 @@ Modyo permite subir 10 archivos a la vez. Si necesitas subir más elementos, rep
 ## Editar un archivo
 En la interfaz de archivos, da click en el nombre de un archivo para abrir la interfaz de edición de las propiedades del archivo y ver:
 
-- **URL del Archivo:** Muestra la URL pública del archivo. Da click en el ícono junto a la URL para copiarla. No es modificable.
-- **Tag de liquid:** Muestra el tag de liquid del archivo, da click en el ícono para copiar y usarlo en los contenidos de la plataforma. No es modificable.
-- **Título:** Muestra el título del archivo. Esta sección es distinta al nombre del archivo, el cual no se puede cambiar.
-- **Texto alternativo:** Muestra el alt text del elemento. Solo para imágenes y videos.
-- **Descripción:** Descripción del elemento, recomendamos escribir un texto corto referente a la imagen.
-- **Etiquetas:** Muestra las etiquetas asociadas al archivo. Puedes buscar y agregar más etiquetas, así como eliminar etiquetas existentes.
+- **URL del Archivo**: Muestra la URL pública del archivo. Da click en el ícono junto a la URL para copiarla. No es modificable.
+- **Tag de liquid**: Muestra el tag de liquid del archivo, da click en el ícono para copiar y usarlo en los contenidos de la plataforma. No es modificable.
+- **Título**: Muestra el título del archivo. Esta sección es distinta al nombre del archivo, el cual no se puede cambiar.
+- **Texto alternativo**: Muestra el alt text del elemento. Solo para imágenes y videos.
+- **Descripción**: Descripción del elemento, recomendamos escribir un texto corto referente a la imagen.
+- **Etiquetas**: Muestra las etiquetas asociadas al archivo. Puedes buscar y agregar más etiquetas, así como eliminar etiquetas existentes.
 
 Da click en **Actualizar información** para confirmar los cambios o en **Cerrar** para cancelarlos.
 

--- a/docs/es/platform/content/entries.md
+++ b/docs/es/platform/content/entries.md
@@ -17,21 +17,21 @@ En la interfaz de entradas, puedes ver una lista con todos los contenidos genera
 
 Las columnas para ordenar la lista de entradas son:
 
-- **Estado:** Borrador, publicado, programado o archivado.
-- **Nombre:** Nombre del contenido.
-- **Tipo:** [Tipo](/es/platform/content/types.html) de contenido.
-- **Actualizado:** Fecha de la última actualización guardada del contenido.
-- **Autor:** Nombre del autor del contenido.
+- **Estado**: Borrador, publicado, programado o archivado.
+- **Nombre**: Nombre del contenido.
+- **Tipo**: [Tipo](/es/platform/content/types.html) de contenido.
+- **Actualizado**: Fecha de la última actualización guardada del contenido.
+- **Autor**: Nombre del autor del contenido.
 
 También puedes filtrar la vista con filtros predeterminados:
 
-- **Tipo:** [Tipo](/es/platform/content/types.html) de contenido.
-- **Estado:** Borrador, publicado, programado y archivado.
-- **Categoría:** Categoría asignada a las entradas.
+- **Tipo**: [Tipo](/es/platform/content/types.html) de contenido.
+- **Estado**: Borrador, publicado, programado y archivado.
+- **Categoría**: Categoría asignada a las entradas.
 - **Idioma** Idioma del contenido.
-- **Traducción:** Estado de traducción de la entrada. Si una entrada no tiene versión en el idioma seleccionado, se considera "no traducida".
-- **Tags:** Etiquetas disponibles en la cuenta.
-- **Barra de búsqueda:** Filtra por el contenido del título de las entradas.
+- **Traducción**: Estado de traducción de la entrada. Si una entrada no tiene versión en el idioma seleccionado, se considera "no traducida".
+- **Tags**: Etiquetas disponibles en la cuenta.
+- **Barra de búsqueda**: Filtra por el contenido del título de las entradas.
 
 :::tip Tip
 Da click en el menú de Filters en la parte superior derecha de la lista de entradas para agregar o eliminar cualquiera de las opciones de filtrado del encabezado.
@@ -42,7 +42,7 @@ Da click en el menú de Filters en la parte superior derecha de la lista de entr
 
 Selecciona una o más entradas y da click en el recuadro de Acciones masivas para:
 
-- **Editar masivamente:** Esta opción abre una interfaz donde puedes modificar múltiples entradas a la vez, seleccionando los campos que deseas sobrescribir y aplicando los cambios.
+- **Editar masivamente**: Esta opción abre una interfaz donde puedes modificar múltiples entradas a la vez, seleccionando los campos que deseas sobrescribir y aplicando los cambios.
 
 :::warning Importante
 La opción de editar masivamente entradas solo esta disponible para entradas del mismo tipo y solo es visible si filtras las entradas por tipo.
@@ -59,10 +59,10 @@ Al usar la edición masiva de entradas estás sobreescribiendo los valores para 
 Para recuperar un valor específico de una entrada, accede a la vista de edición de entradas y selecciona la opción **Diferencias** para revisar los valores previos de una entrada.
 :::
 
-- **Publicar:**  Publica las entradas seleccionadas que tengan cambios pendientes o estén en estado borrador.
-- **Forzar publicación:** Si está habilitada la revisión en equipo, los administradores del espacio pueden usar esta acción para forzar la publicación de entradas que tienen cambios pendientes o estén en estado borrador, sin necesidad de pasar por el proceso de revisión.
+- **Publicar**:  Publica las entradas seleccionadas que tengan cambios pendientes o estén en estado borrador.
+- **Forzar publicación**: Si está habilitada la revisión en equipo, los administradores del espacio pueden usar esta acción para forzar la publicación de entradas que tienen cambios pendientes o estén en estado borrador, sin necesidad de pasar por el proceso de revisión.
 - **Despublicar**
-- **Archivar:** Archivar en masa solo tiene efecto en las entradas seleccionadas que no estén publicadas. Si intentas archivar una entrada publicada, la acción no tendrá efecto.
+- **Archivar**: Archivar en masa solo tiene efecto en las entradas seleccionadas que no estén publicadas. Si intentas archivar una entrada publicada, la acción no tendrá efecto.
 
 :::tip Tip
 Las acciones masivas se ejecutan en segundo plano y es posible que no veas los cambios inmediatamente, por lo que deberás esperar un momento y refrescar la vista luego de ejecutar una acción masiva.
@@ -264,8 +264,8 @@ Habilita la opción de contenido privado para que tu contenido sea exclusivo par
 
 Dependiendo de como estés consumiendo el contenido, es posible que debas seguir algunos pasos adicionales para acceder a él:
 
-- **A través de la API pública:** Consulta la sección sobre contenido privado en la API.
-- **A través de Liquid:** Al iniciar sesión en tu sitio, tus usuarios podrán visualizar el contenido privado.
+- **A través de la API pública**: Consulta la sección sobre contenido privado en la API.
+- **A través de Liquid**: Al iniciar sesión en tu sitio, tus usuarios podrán visualizar el contenido privado.
 
 
 ### Segmentos

--- a/docs/es/platform/content/spaces.md
+++ b/docs/es/platform/content/spaces.md
@@ -51,15 +51,15 @@ En esta sección puedes personalizar y ajustar las opciones disponibles para tu 
 
 En esta sección puedes:
 - **Cambiar el nombre del espacio**
-- **Mostrar el autor de las entradas:** Habilitar esta opción permite que el autor del contenido este visible en la API pública y en el SDK de Liquid. Si está deshabilitada, el autor se verá en blanco.
+- **Mostrar el autor de las entradas**: Habilitar esta opción permite que el autor del contenido este visible en la API pública y en el SDK de Liquid. Si está deshabilitada, el autor se verá en blanco.
 
 :::warning Atención
 Al guardar esta opción, se reindexan todas las entradas del espacio. Los cambios se reflejarán una vez el proceso haya concluido.
 :::
 
-- **Modificar el reino del espacio:** Al cambiar el reino de usuarios, perderás todas las configuraciones de privacidad.
-- **Modificar el identificador del espacio:** El identificador o UID del espacio es el atributo con el cual accedes desde la API pública de contenido, el SDK de Javascript y el SDK de Liquid. Asegúrate de que sea único y sin tildes ni caracteres especiales, ya que será usado en las URL para acceder al contenido.
-- **Eliminar el espacio:** Elimina definitivamente el espacio y todos sus elementos.
+- **Modificar el reino del espacio**: Al cambiar el reino de usuarios, perderás todas las configuraciones de privacidad.
+- **Modificar el identificador del espacio**: El identificador o UID del espacio es el atributo con el cual accedes desde la API pública de contenido, el SDK de Javascript y el SDK de Liquid. Asegúrate de que sea único y sin tildes ni caracteres especiales, ya que será usado en las URL para acceder al contenido.
+- **Eliminar el espacio**: Elimina definitivamente el espacio y todos sus elementos.
 :::danger Peligro
 Al seleccionar **Borrar**, debes ingresar el nombre textual del espacio para confirmar la acción. Una vez confirmada, no podrás volver a acceder al espacio ni a sus elementos.
 :::
@@ -100,8 +100,8 @@ Nginx: set $cache_key "$http_x_forwarded_proto://$host$request_uri-$http_accept-
 ```
 :::tip Tip
 Al decidir el uso de SSL, considera:
--  **SSL:** No se permiten certificados wildcards.
-- **NO SSL:** Si se permiten wildcards en estos entornos, pero debes habilitarlos manualmente a través de un ticket enviado al área de [soporte de Modyo](https://support.modyo.com/hc/en-us). Por defecto, Modyo utiliza SSL.
+-  **SSL**: No se permiten certificados wildcards.
+- **NO SSL**: Si se permiten wildcards en estos entornos, pero debes habilitarlos manualmente a través de un ticket enviado al área de [soporte de Modyo](https://support.modyo.com/hc/en-us). Por defecto, Modyo utiliza SSL.
 
 Para más información, revisa la sección de [Seguridad](https://docs.modyo.com/es/platform/channels/sites.html#security-headers)  de la documentación de Modyo.
 :::
@@ -111,11 +111,11 @@ Para más información, revisa la sección de [Seguridad](https://docs.modyo.com
 
 La revisión en equipo es una herramienta que permite a varios usuarios confirmar y corregir el contenido antes de enviarlo a través de la API.
 Las opciones de configuración de la revisión en equipo son las siguientes:
-- **Habilitar revisión en equipo:** Activa o desactiva la revisión en equipo. Si está activada, todos los elementos que se envíen a través de la API requerirán la aprobación de uno o más revisores.
-- **Número de aprobaciones:** Especifica el número de aprobaciones que se requieren para que un elemento se publique.
-- **Restringir la selección de revisores:** Permite especificar qué usuarios pueden revisar el contenido. Solo quien envía a revisión puede seleccionar revisores.
-- **Forzar revisión:** Obliga a que al menos un usuario específico revise el contenido.
-- **Requerir todos:** Obliga a que todos los usuarios seleccionados aprueben el elemento antes de que se publique.
+- **Habilitar revisión en equipo**: Activa o desactiva la revisión en equipo. Si está activada, todos los elementos que se envíen a través de la API requerirán la aprobación de uno o más revisores.
+- **Número de aprobaciones**: Especifica el número de aprobaciones que se requieren para que un elemento se publique.
+- **Restringir la selección de revisores**: Permite especificar qué usuarios pueden revisar el contenido. Solo quien envía a revisión puede seleccionar revisores.
+- **Forzar revisión**: Obliga a que al menos un usuario específico revise el contenido.
+- **Requerir todos**: Obliga a que todos los usuarios seleccionados aprueben el elemento antes de que se publique.
 
 Para más información sobre cómo configurar esta opción, revisa la sección de
  [Team Review](/es/platform/core/key-concepts.html)

--- a/docs/es/platform/core/security.md
+++ b/docs/es/platform/core/security.md
@@ -106,10 +106,10 @@ Si has activado la opción de forzar autenticación, la próxima vez que el usua
 ## Mejores Prácticas
 
 ### Conceptos importantes
-* **Limitar accesos:** Reducir las posibilidades de que un actor malicioso obtenga acceso al sistema.
-* **Contención:** Configurar el sistema de manera que minimice el daño posible en caso de ser vulnerado por un actor malintencionado.
-* **Preparación y conocimiento:**  Mantener copias de seguridad y procedimientos para estar preparados en el caso de posibles desastres.
-* **Fuentes confiables:** Evitar implementar widgets o código de fuentes poco confiables. Asegurar que todas las dependencias cargadas en el sitio provengan de fuentes confiables.
+* **Limitar accesos**: Reducir las posibilidades de que un actor malicioso obtenga acceso al sistema.
+* **Contención**: Configurar el sistema de manera que minimice el daño posible en caso de ser vulnerado por un actor malintencionado.
+* **Preparación y conocimiento**:  Mantener copias de seguridad y procedimientos para estar preparados en el caso de posibles desastres.
+* **Fuentes confiables**: Evitar implementar widgets o código de fuentes poco confiables. Asegurar que todas las dependencias cargadas en el sitio provengan de fuentes confiables.
 
 ### Vulnerabilidades Locales
 * Asegúrate que los equipos de cómputo de todos los usuarios administradores estén libres de spyware, malware o virus.

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -14,24 +14,24 @@ Aquí puedes modificar tanto la experiencia visual del usuario como la configura
 En esta sección puedes configurar aspectos generales del reino, como:
 
 - **Título**
-- **Identificador:** La URL de las vistas de perfil, inicio de sesión, registro y recuperación de contraseña del reino.
-- **Deshabilitar credenciales:** Al marcar esta casilla, desactivas las credenciales de Modyo en el reino y permites únicamente el acceso a través de SSO.
+- **Identificador**: La URL de las vistas de perfil, inicio de sesión, registro y recuperación de contraseña del reino.
+- **Deshabilitar credenciales**: Al marcar esta casilla, desactivas las credenciales de Modyo en el reino y permites únicamente el acceso a través de SSO.
 
 :::danger Peligro
 Antes de habilitar la opción de deshabilitar las credenciales de Modyo en el reino, asegúrate de tener configurado un proveedor de identidad SSO para el reino. De lo contrario, los usuarios no podrán iniciar sesión.
 :::
 
-- **Después de iniciar sesión, redirigir a:** Te permite elegir una URL específica a la cual dirigir al usuario, una vez que haya ingresado al reino. Si no activas la opción de "Forzar redirección", el usuario será redirigido a la URL ingresada solo si no es posible volver a la URL desde la que inició sesión.
-- **Forzar la redirección a:** Al activar esta opción, el usuario siempre será redirigido a la URL especificada en el campo de redirección del inicio de sesión, sin importar desde dónde inició la sesión.
-- **Activación de la cuenta:**
+- **Después de iniciar sesión, redirigir a**: Te permite elegir una URL específica a la cual dirigir al usuario, una vez que haya ingresado al reino. Si no activas la opción de "Forzar redirección", el usuario será redirigido a la URL ingresada solo si no es posible volver a la URL desde la que inició sesión.
+- **Forzar la redirección a**: Al activar esta opción, el usuario siempre será redirigido a la URL especificada en el campo de redirección del inicio de sesión, sin importar desde dónde inició la sesión.
+- **Activación de la cuenta**:
   - Directa: Los usuarios que se registren pueden iniciar sesión directamente.
   - E-mail de activación: Los usuarios que se registren deben activar su cuenta mediante un enlace enviado a su correo electrónico previo a poder iniciar sesión.
   - Moderada: Los usuarios que se registren deberán esperar a que un administrador del reino active su cuenta para poder iniciar sesión.
   - Deshabilitada: No se pueden registrar nuevos usuarios en el reino. Los usuarios ya registrados y activados aún pueden iniciar sesión.
-- **Imagen de Avatar por defecto:** Imagen que se muestra en el avatar de los usuarios que no tienen una imagen personalizada.
-- **Habilitar Soft login:** Activando esta opción puedes acceder a tu cuenta sin introducir tus credenciales cada vez. Recibirás un código de seguridad en tu email para ingresar fácilmente sin necesidad de contraseñas.
-- **Formulario de registro:** Aquí puedes habilitar o deshabilitar diferentes atributos en el formulario de registro, como el segundo apellido, confirmación de correo electrónico, avatar de usuario, fecha de nacimiento, género y número de teléfono.
-- **Eliminar reino:** Elimina el reino. Este proceso se realiza en segundo plano y es posible que no veas el reino desaparecer inmediatamente después de ejecutar la acción. Para confirmar la eliminación, debes ingresar el nombre completo del reino.
+- **Imagen de Avatar por defecto**: Imagen que se muestra en el avatar de los usuarios que no tienen una imagen personalizada.
+- **Habilitar Soft login**: Activando esta opción puedes acceder a tu cuenta sin introducir tus credenciales cada vez. Recibirás un código de seguridad en tu email para ingresar fácilmente sin necesidad de contraseñas.
+- **Formulario de registro**: Aquí puedes habilitar o deshabilitar diferentes atributos en el formulario de registro, como el segundo apellido, confirmación de correo electrónico, avatar de usuario, fecha de nacimiento, género y número de teléfono.
+- **Eliminar reino**: Elimina el reino. Este proceso se realiza en segundo plano y es posible que no veas el reino desaparecer inmediatamente después de ejecutar la acción. Para confirmar la eliminación, debes ingresar el nombre completo del reino.
 
 
 ## Redireccionar Login ##
@@ -101,15 +101,15 @@ Aquí puedes también habilitar, deshabilitar y personalizar el envío de los co
  En caso de activarlas, se envía un correo cuando:
 
 
-- **Correo de Activación:**  Un usuario ha completado su registro, para que confirme sus datos.
-- **Correo de Bienvenida:** Un usuario se ha registrado en un sitio específico.
-- **Agregado por el Admin:** Un administrador crea un usuario manualmente.
-- **Recuperación de Contraseña:** Un usuario solicita recuperar su contraseña.
-- **Esperando Confirmación:** El usuario ha sido confirmado, pero requiere activación manual por parte de un administrador.
-- **Confirmación:** El usuario ha sido confirmado y activado.
-- **Verificación de actualizaciones de correo:** Se ha llevado a cabo un cambio en la dirección de correo.
+- **Correo de Activación**:  Un usuario ha completado su registro, para que confirme sus datos.
+- **Correo de Bienvenida**: Un usuario se ha registrado en un sitio específico.
+- **Agregado por el Admin**: Un administrador crea un usuario manualmente.
+- **Recuperación de Contraseña**: Un usuario solicita recuperar su contraseña.
+- **Esperando Confirmación**: El usuario ha sido confirmado, pero requiere activación manual por parte de un administrador.
+- **Confirmación**: El usuario ha sido confirmado y activado.
+- **Verificación de actualizaciones de correo**: Se ha llevado a cabo un cambio en la dirección de correo.
 
-**Footer personalizado:** Permite personalizar el pie de página de todos los correos mencionados anteriormente.
+**Footer personalizado**: Permite personalizar el pie de página de todos los correos mencionados anteriormente.
 
 Para habilitar o deshabilitar el envío de un correo, haz click en el botón Habilitado/Deshabilitado junto a cada función y da click en el botón **Guardar**.
 
@@ -215,10 +215,10 @@ Puedes además vincular otros campos. Toma en consideración que:
 - Puedes vincular campos personalizados o custom de Modyo. Para ello, primero debes crear el campo custom en Modyo y el campo tiene que estar habilitado para ser utilizado en la sincronización.
 
 Una vez que hayas vinculado los campos, selecciona el tipo de sincronización:
-- **Siempre usar Salesforce:** Esta opción usa los datos desde Salesforce para actualizar (crear, actualizar, borrar) los usuarios de Modyo. En este caso, no se envía información de usuario de Modyo a Salesforce. La sincronización es unidireccional, y la información fluye únicamente desde Salesforce hacia Modyo.
-- **Siempre usar Modyo:** Al seleccionar esta opción se envían datos de usuarios de Modyo a Salesforce para actualizar contactos en Salesforce. No se actualizan usuarios de Modyo con información de Salesforce. La sincronización es unidireccional y la información fluye únicamente desde Modyo hacia Salesforce.
-- **Bidireccional:** Esta opción envía información de Modyo a Salesforce y se usa información de Salesforce en Modyo, lo que permite actualizar contactos y usuarios respectivamente. En este caso, los usuarios y contactos se mantienen actualizados con la información más reciente disponible.
-- **No sincronizar:** Al seleccionar esta opción, desactivas la integración, evitando que se sincronicen usuarios y contactos entre Modyo y Salesforce. Esta opción puede ser útil si necesitas pausar la sincronización por alguna razón.
+- **Siempre usar Salesforce**: Esta opción usa los datos desde Salesforce para actualizar (crear, actualizar, borrar) los usuarios de Modyo. En este caso, no se envía información de usuario de Modyo a Salesforce. La sincronización es unidireccional, y la información fluye únicamente desde Salesforce hacia Modyo.
+- **Siempre usar Modyo**: Al seleccionar esta opción se envían datos de usuarios de Modyo a Salesforce para actualizar contactos en Salesforce. No se actualizan usuarios de Modyo con información de Salesforce. La sincronización es unidireccional y la información fluye únicamente desde Modyo hacia Salesforce.
+- **Bidireccional**: Esta opción envía información de Modyo a Salesforce y se usa información de Salesforce en Modyo, lo que permite actualizar contactos y usuarios respectivamente. En este caso, los usuarios y contactos se mantienen actualizados con la información más reciente disponible.
+- **No sincronizar**: Al seleccionar esta opción, desactivas la integración, evitando que se sincronicen usuarios y contactos entre Modyo y Salesforce. Esta opción puede ser útil si necesitas pausar la sincronización por alguna razón.
 
 :::warning Attention
 Si seleccionas la modalidad de vinculación **Siempre usar Modyo** o **bidireccional**, pero no completas el segundo paso que se explica a continuación, los usuarios de Modyo no se enviarán a Salesforce.
@@ -291,8 +291,8 @@ Para modificar el rol de un miembro del equipo:
 
 Puedes elegir entre dos roles:
 
-- **Realm User:** Puede añadir usuarios, crear, modificar y enviar a revisión campañas, formularios y segmentos.
-- **Realm Admin:**  Tiene acceso a todas las configuraciones y secciones del reino, puede añadir y eliminar usuarios y miembros del equipo.  Puede también eliminar el reino.
+- **Realm User**: Puede añadir usuarios, crear, modificar y enviar a revisión campañas, formularios y segmentos.
+- **Realm Admin**:  Tiene acceso a todas las configuraciones y secciones del reino, puede añadir y eliminar usuarios y miembros del equipo.  Puede también eliminar el reino.
 
 Para eliminar a un administrador del reino, selecciona la casilla a la izquierda de su nombre y haz click en el botón **Borrar** en la parte inferior.
 
@@ -318,12 +318,12 @@ Puedes crear un máximo de 20 campos personalizados en cada reino.
 
 Los campos personalizados tienen propiedades estándar que debes tener en cuenta:
 
-- **Debe ser una respuesta única:** El valor debe ser único para cada usuario, evitando duplicados.
-- **Este es un campo requerido:** Debe completarse al modificar o crear un usuario. Si el campo es visible y editable para los usuarios, se mostrará en el formulario de registro y será obligatorio para crear nuevos usuarios.
-- **Visible para los usuarios de los sitios:** Será visible en el perfil del usuario.
-    - **Editable por usuarios de los sitios:** Los usuarios podrán ver y modificar el valor.
-- **Buscable por administradores:** El valor estará indexado y los administradores podrán realizar búsquedas de usuarios en el índice de usuarios del administrador de Modyo, por el valor de este campo.
-- **Texto de sugerencia:** Proporciona un ejemplo o guía para el campo.
+- **Debe ser una respuesta única**: El valor debe ser único para cada usuario, evitando duplicados.
+- **Este es un campo requerido**: Debe completarse al modificar o crear un usuario. Si el campo es visible y editable para los usuarios, se mostrará en el formulario de registro y será obligatorio para crear nuevos usuarios.
+- **Visible para los usuarios de los sitios**: Será visible en el perfil del usuario.
+    - **Editable por usuarios de los sitios**: Los usuarios podrán ver y modificar el valor.
+- **Buscable por administradores**: El valor estará indexado y los administradores podrán realizar búsquedas de usuarios en el índice de usuarios del administrador de Modyo, por el valor de este campo.
+- **Texto de sugerencia**: Proporciona un ejemplo o guía para el campo.
 - **Valor por defecto**.
 
 Los campos personalizables pueden estar habilitados o deshabilitados. Si están habilitados, un administrador puede usarlos y, dependiendo de su configuración, pueden también estar disponibles para los usuarios.
@@ -363,9 +363,9 @@ Puedes habilitar o no reCAPTCHA en el reino, una vez habilitado ingresa:
 
 Al habilitar la función de pago en tu reino, tienes acceso a las siguientes opciones:
 
-- **Formato de moneda:** Modifica el tipo de puntuación usado.
-- **Configuración de pago:** Selecciona la unidad monetaria que deseas mostrar. Esta unidad se refleja en las órdenes y reportes. Si no indicas una unidad monetaria, Modyo utiliza la moneda predeterminada según el idioma configurado para el sitio.
-- **Activar el envío de correo electrónico:** Cuando esta opción está seleccionada, el usuario recibe un correo al pagar una orden.
-- **Asunto del correo:** Encabezado del correo enviado a los usuarios.
-- **Cuerpo del correo:** Contenido del mensaje enviado a los usuarios.
+- **Formato de moneda**: Modifica el tipo de puntuación usado.
+- **Configuración de pago**: Selecciona la unidad monetaria que deseas mostrar. Esta unidad se refleja en las órdenes y reportes. Si no indicas una unidad monetaria, Modyo utiliza la moneda predeterminada según el idioma configurado para el sitio.
+- **Activar el envío de correo electrónico**: Cuando esta opción está seleccionada, el usuario recibe un correo al pagar una orden.
+- **Asunto del correo**: Encabezado del correo enviado a los usuarios.
+- **Cuerpo del correo**: Contenido del mensaje enviado a los usuarios.
 

--- a/docs/es/platform/customers/users.md
+++ b/docs/es/platform/customers/users.md
@@ -11,11 +11,11 @@ La vista principal muestra una tabla con todos los usuarios registrados, que se 
 
 Puedes utilizar los filtros en la parte superior de la tabla para encontrar grupos de usuarios rápidamente. Los filtros disponibles son:
 
-- **Estado:** Usuarios activos e inactivos.
-- **Verificación:** Usuarios que han confirmado sus datos en la plataforma.
+- **Estado**: Usuarios activos e inactivos.
+- **Verificación**: Usuarios que han confirmado sus datos en la plataforma.
 - **Segmentos**: Usuarios que pertenecen a un [segmento](/es/platform/customers/segments.html) específico.
 - **Etiquetas**: Usuarios asignados a etiquetas específicas en la plataforma.
-- **Búsqueda:** Filtra usuarios por nombre, apellido, email o nombre de usuario.
+- **Búsqueda**: Filtra usuarios por nombre, apellido, email o nombre de usuario.
 
 Puedes ordenar los usuarios en la tabla por nombre, fecha de inscripción, último ingreso o cantidad de sesiones iniciadas haciendo clic en las cabeceras de las columnas.
 
@@ -39,7 +39,7 @@ Para agregar un nuevo usuario, haz clic en el botón **+ Nuevo Usuario** y compl
 - **Email**: **[Requerido]**
 - **Contraseña**: **[Requerido]**. Debe contener al menos 8 caracteres.
 - **Confirmación de contraseña**: **[Requerido]**
-- **Tags:** Etiquetas para identificar al usuario.
+- **Tags**: Etiquetas para identificar al usuario.
 
 :::tip Tip
 Para enviar la contraseña al correo del usuario, marca la casilla debajo del campo de correo electrónico. El usuario puede cambiar la contraseña una vez que acceda a la plataforma.

--- a/docs/es/platform/training.md
+++ b/docs/es/platform/training.md
@@ -21,10 +21,10 @@ A continuación, te contaremos cómo podrás acceder a todo la información y ac
 Modyo es una plataforma de experiencia digital de siguiente generación que potencia soluciones para la interacción con clientes digitales, acelerando el desarrollo Web y móvil de forma segura y eficiente, creando un espacio centralizado para gobernar tus canales digitales.
 
 Modyo cuenta con los siguientes módulos principales, los que irás conociendo en tu proceso de entrenamiento:
-- [**Modyo Content:**](/es/platform/content) Aplicación de arquitectura headless que permite la creación de espacios de contenidos que podrás consumir a través de una API tanto dentro como fuera de Modyo. Dentro de los conceptos principales se encuentran: espacios, tipos, entradas, gestor de archivos, team review, entre otros.
-- [**Modyo Channels:**](/es/platform/channels) Aplicación que permite la construcción y gestión de múltiples canales digitales de forma centralizada. Dentro de los conceptos principales se encuentran: pages, widgets, templates, PWA, Liquid markup, CLI, entre otros.
-- [**Modyo Customers:**](/es/platform/customers) Aplicación que permite habilitar autenticación de usuarios en los sitios en Modyo, ya sea por medio de su sistema interno de registro de cuentas como de sus integraciones empresariales a sistemas de Single Sign On (SSO). Dentro de los conceptos principales se encuentran: usuarios, segmentos, formularios, mensajería (campañas y notificaciones), personalización, entre otros.
-- [**Modyo Insights:**](/es/platform/insights) Aplicación especializada en la representación de datos estadísticos tanto de los usuarios de tus sitios, como del equipo de trabajo que crea el contenido y los canales digitales.
+- [**Modyo Content**:](/es/platform/content) Aplicación de arquitectura headless que permite la creación de espacios de contenidos que podrás consumir a través de una API tanto dentro como fuera de Modyo. Dentro de los conceptos principales se encuentran: espacios, tipos, entradas, gestor de archivos, team review, entre otros.
+- [**Modyo Channels**:](/es/platform/channels) Aplicación que permite la construcción y gestión de múltiples canales digitales de forma centralizada. Dentro de los conceptos principales se encuentran: pages, widgets, templates, PWA, Liquid markup, CLI, entre otros.
+- [**Modyo Customers**:](/es/platform/customers) Aplicación que permite habilitar autenticación de usuarios en los sitios en Modyo, ya sea por medio de su sistema interno de registro de cuentas como de sus integraciones empresariales a sistemas de Single Sign On (SSO). Dentro de los conceptos principales se encuentran: usuarios, segmentos, formularios, mensajería (campañas y notificaciones), personalización, entre otros.
+- [**Modyo Insights**:](/es/platform/insights) Aplicación especializada en la representación de datos estadísticos tanto de los usuarios de tus sitios, como del equipo de trabajo que crea el contenido y los canales digitales.
 
 #### Tutoriales
 Los [tutoriales](https://help.modyo.com/es/collections/4032221-tutoriales) son la forma más fácil de iniciarte en la Plataforma Modyo. Sólo se requiere de un [ambiente de pruebas](/es/platform/training.html#ambiente-de-pruebas) y algo de tiempo para ir paso por paso aprendiendo los conceptos fundamentales.
@@ -34,7 +34,7 @@ Te recomendamos realizar los tutoriales en orden, siguiendo todos los pasos que 
 Modyo cuenta con distintos [Learning Paths](https://help.modyo.com/es/articles/6928873-como-aprender-a-usar-modyo) para clientes y socios de negocio. Consisten en alternativas más dinámicas para aprender a usar nuestras herramientas a tu ritmo.
 
 Toma los cursos que necesites según tus necesidades de acuerdo al rol que desempeñas o tómalos todos para convertirte en un autentico especialista en Modyo. El único requisito para empezar nuestros Learning Paths es un ambiente.
- 
+
 
 #### Ambiente de pruebas
 Para entender cómo funciona la Plataforma Modyo es muy importante que puedas tener acceso a todas las funcionalidades que proveemos. Para ello, tendrás acceso a crear una cuenta temporal donde podrás implementar un proyecto de ejemplo para conocer la plataforma a profundidad.
@@ -52,13 +52,13 @@ Para reportar un problema o consultas deberás:
 1. Ingresa a nuestro Centro de Soporte: https://support.modyo.com/hc/es
 2. Crea una cuenta vinculada a tu correo corporativo
 3. Selecciona el tipo de caso a reportar:
-    - **Incidencia:** Problemas que afecten el correcto funcionamiento del ambiente o del producto desarrollado sobre la plataforma indicando nivel de severidad (caídas de ambientes, problemas de rendimiento, entre otros).
-    - **Consulta:** Cualquier duda acerca de funcionalidades de la plataforma o del producto desarrollado sobre ésta.
-    - **Requerimiento:** Solicitudes de configuración de ambientes, dominios, VPN, ejecución de scripts, accesos a sistemas, entre otros.
+    - **Incidencia**: Problemas que afecten el correcto funcionamiento del ambiente o del producto desarrollado sobre la plataforma indicando nivel de severidad (caídas de ambientes, problemas de rendimiento, entre otros).
+    - **Consulta**: Cualquier duda acerca de funcionalidades de la plataforma o del producto desarrollado sobre ésta.
+    - **Requerimiento**: Solicitudes de configuración de ambientes, dominios, VPN, ejecución de scripts, accesos a sistemas, entre otros.
 4. Completa el formulario correspondiente según el caso seleccionado.
 
 #### ¿Qué información debes incluir para darte la atención adecuada?
 Para poder revisar lo que nos reportas es importante que puedas incluir en el campo "descripción" del ticket la siguiente información:
-- **Contexto:** indicar ruta de cuenta/sitio afectado, browser utilizado, versión de Modyo, rol del usuario en la plataforma (este último si aplica).
-- **Descripción:** indicar brevemente el paso a paso a seguir para poder replicar el caso.
-- **Archivos (opcional):** incluir capturas de pantalla o archivos que no contengan información sensible de clientes en el caso de sitios transaccionales.
+- **Contexto**: indicar ruta de cuenta/sitio afectado, browser utilizado, versión de Modyo, rol del usuario en la plataforma (este último si aplica).
+- **Descripción**: indicar brevemente el paso a paso a seguir para poder replicar el caso.
+- **Archivos (opcional)**: incluir capturas de pantalla o archivos que no contengan información sensible de clientes en el caso de sitios transaccionales.


### PR DESCRIPTION
Este PR estandariza el uso de dos puntos ":" en los listados de Modyo para prevenir potenciales errores en la traducción de Transifex. 

Todos los cambios fueron probados localmente en español, ningún archivo en inglés fue modificado.