### PR TITLE
CHORE: Actualizar menu de customers , tag manager y link a home

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -24,7 +24,7 @@ module.exports = {
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-MW9VKMC');
   `,
       ]
@@ -133,13 +133,15 @@ module.exports = {
                         path: "/en/platform/customers/",
                         collapsable: true,
                         children: [
-                            "/en/platform/customers/realms",
-                            "/en/platform/customers/profile",
+                            "/en/platform/customers/overview",
+                            "/en/platform/customers/users",
                             "/en/platform/customers/events",
                             "/en/platform/customers/segments",
                             "/en/platform/customers/forms",
                             "/en/platform/customers/origination",
                             "/en/platform/customers/messaging",
+                            "/en/platform/customers/settings",
+                            "/en/platform/customers/profile",
                             "/en/platform/customers/api",
                         ],
                       },

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -3,7 +3,7 @@
     <div class="theme-default-content">
       <h1>404</h1>
       <blockquote>{{ getMsg() }}</blockquote>
-      <router-link to="/">Take me home.</router-link>
+      <a href="/en">Back to Modyo Docs.</a>
     </div>
   </div>
 </template>

--- a/docs/.vuepress/theme/layouts/Layout.vue
+++ b/docs/.vuepress/theme/layouts/Layout.vue
@@ -114,7 +114,7 @@ export default {
 
   beforeMount() {
     let gtmScript = document.createElement('noscript')
-    gtmScript.innerHTML = '<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MW9VKMC" height="0" width="0" style="display:none;visibility:hidden"></iframe>'
+    gtmScript.innerHTML = '<iframe src="//www.googletagmanager.com/ns.html?id=GTM-MW9VKMC" height="0" width="0" style="display:none;visibility:hidden"></iframe>'
     document.body.appendChild(gtmScript)
   },
 


### PR DESCRIPTION
Este PR:
- Actualiza el menú en inglés de customers para que refleje las nuevas traducciones ( se incluye luego de terminar la traducción para evitar issues de compilación)
- Actualiza el formato en que se invoca el tag manager que  genera un error 400 (Bad Request) a `https://www.googletagmanager.com/gtm.js?id=` generando latencia en todas las páginas
- Reemplaza el enlace  `take me home` en el documento de error 404 que viene por default en vuepress y no estaba cargando el home de modyo docs