### PR TITLE
docs: add ES Module loading documentation for widgets

### DIFF
--- a/docs/en/platform/channels/widgets.md
+++ b/docs/en/platform/channels/widgets.md
@@ -135,6 +135,29 @@ To change how each widget loads, go to the edit view of the page containing the 
 You should consider that using very heavy widgets synchronously can decrease your page's performance, so you should carefully decide which widgets will load synchronously and which will load asynchronously.
 :::
 
+## ES Module loading
+
+:::warning Attention
+This is an experimental feature and may be subject to changes.
+:::
+
+You can load your widgets as ES Modules instead of traditional scripts. This enables modern JavaScript features like native `import`/`export` syntax and provides better scope isolation, preventing conflicts with global variables.
+
+To enable ES Module loading, go to the edit view of the page containing the widget, select the widget, and check the "Load as ES Module" option in the Properties panel.
+
+When enabled, the widget's JavaScript will be loaded with `type="module"`:
+
+- **Async mode** (default): The widget's script tag will include `type="module"` when loaded dynamically.
+- **Sync mode**: The inline script will be rendered with `type="module"`.
+
+:::tip Tip
+ES Module loading is especially useful for widgets built with modern frameworks that use native ES module syntax, such as those based on [Dynamic Framework](https://dynamicframework.dev).
+:::
+
+:::warning Attention
+ES Modules have strict CORS requirements and are always loaded in strict mode. Ensure your widget code is compatible with ES module semantics before enabling this option.
+:::
+
 ## Use Internationalization (i18n)
 
 With i18n, you can configure and add new languages to your widgets.

--- a/docs/es/platform/channels/widgets.md
+++ b/docs/es/platform/channels/widgets.md
@@ -135,6 +135,29 @@ Para cambiar la forma en que se carga cada widget, debes ir a la vista de edici�
 Debes tener en consideración que usar widgets muy pesados de forma sincrónica puede hacer que se vea disminuido el rendimiento de tu página, por lo que debes decidir con cuidado cuáles widgets se cargarán de forma síncrona y cuáles de forma asíncrona.
 :::
 
+## Carga como ES Module
+
+:::warning Atención
+Esta es una funcionalidad experimental y puede estar sujeta a cambios.
+:::
+
+Puedes cargar tus widgets como ES Modules en lugar de scripts tradicionales. Esto habilita características modernas de JavaScript como la sintaxis nativa de `import`/`export` y proporciona mejor aislamiento de scope, evitando conflictos con variables globales.
+
+Para habilitar la carga como ES Module, ve a la vista de edición de la página que contiene el widget, selecciona el widget y marca la opción "Cargar como ES Module" en el panel de Propiedades.
+
+Cuando está habilitado, el JavaScript del widget se cargará con `type="module"`:
+
+- **Modo asíncrono** (por defecto): La etiqueta script del widget incluirá `type="module"` cuando se cargue dinámicamente.
+- **Modo síncrono**: El script inline se renderizará con `type="module"`.
+
+:::tip Tip
+La carga como ES Module es especialmente útil para widgets construidos con frameworks modernos que usan sintaxis nativa de ES modules, como los basados en [Dynamic Framework](https://dynamicframework.dev).
+:::
+
+:::warning Atención
+Los ES Modules tienen requisitos estrictos de CORS y siempre se cargan en modo estricto. Asegúrate de que el código de tu widget sea compatible con la semántica de ES modules antes de habilitar esta opción.
+:::
+
 ## Usar Internacionalización (i18n)
 
 Con i18n puedes configurar y agregar nuevos idiomas a tus widgets.


### PR DESCRIPTION
Documenta la carga del javascript de widgets como módulos [#918](https://github.com/modyo/modyo-docs/issues/918)