### PR TITLE
Mejoras al buscador de submissions

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -489,7 +489,7 @@ From the submission view in the actions menu (identified with ...), you can [imp
 
 The submission list includes a search box that allows you to find submissions by the user's data, the values of their custom fields, the answers entered in the flow fields, and the content of the tasks.
 
-The search requires a minimum of 3 characters, is case- and accent-insensitive, and finds partial matches. For example, `lau` finds "Claudio" and `peres` finds "Pérez".
+The search requires a minimum of 3 characters, is case- and accent-insensitive, and finds partial matches. For example, `lau` finds "Claudio" and `perez` finds "Pérez".
 
 You can search in two ways, which you can also combine in the same query:
 

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -485,6 +485,54 @@ This structure provides you with a comprehensive and detailed view of each submi
 From the submission view in the actions menu (identified with ...), you can [impersonate](/en/platform/customers/users) the user to help them answer the origination. This depends on the user's roles.
 :::
 
+#### Search submissions
+
+The submission list includes a search box that allows you to find submissions by the user's data, the values of their custom fields, the answers entered in the flow fields, and the content of the tasks.
+
+The search requires a minimum of 3 characters, is case- and accent-insensitive, and finds partial matches. For example, `lau` finds "Claudio" and `peres` finds "Pérez".
+
+You can search in two ways, which you can also combine in the same query:
+
+- **Free text**: Type one or more terms and the search will find them in the user's data, the values of their custom fields, and the content of the answers.
+- **Key=value pairs**: Type the key of a field followed by `=` and the value to search for, to narrow the search down to that specific field.
+
+The available keys for `key=value` pairs are:
+
+- **User fields**: `first_name`, `last_name`, `second_last_name`, `email`, `username`, `uuid`, and `id`.
+- **User custom fields**: The custom field key, with or without the `_ucf_` prefix. For example, `pais=Chile` and `_ucf_pais=Chile` are equivalent.
+- **Flow questions**: The question identifier defined in the origination flow. For example, `rut=18301757`.
+
+When using `key=value` pairs, keep the following in mind:
+
+- The key must be written in full, while the value does allow partial matches.
+- To search for values or phrases with spaces, use double quotes. For example, `first_name="Jean Pierre"` or `"crédito hipotecario"`.
+- All conditions are combined together, so a submission must satisfy every term and pair in the query to appear in the results.
+- If the key does not exist or the value is empty, the term is searched as free text without generating errors.
+
+Some search examples:
+
+| Search | Result |
+|---|---|
+| `Claudio` | Submissions whose user or content includes "Claudio". |
+| `first_name=Claudio` | Submissions whose user contains "Claudio" in their name. |
+| `pais=Chile` | Submissions whose user has "Chile" in the `pais` custom field. |
+| `rut=18301757` | Submissions where the question with identifier `rut` contains "18301757". |
+| `first_name="Jean Pierre"` | Submissions whose user contains "Jean Pierre" in their name. |
+| `pais=Chile rut=18301757 hipotecario` | Submissions that meet all three conditions at once. |
+
+:::tip Results update
+Recent changes to a submission may take a few seconds to be reflected in the search results. Changes to the user's data, the values of their custom fields, and segments are reflected in a deferred manner.
+:::
+
+#### Filter submissions
+
+In addition to the search, you can narrow down the submission list with the following filters, which can be combined with each other and with the search:
+
+- **Date range**: Filters by the creation date of the submission.
+- **Status**: Filters by the current status of the submission: **Not started**, **Pending**, **Completed**, or **Canceled**.
+- **Assigned**: Shows the submissions assigned to the selected administrator.
+- **Segment**: Shows the submissions of users who belong to the selected [segment](/en/platform/customers/segments.html).
+
 #### Assign submission
 
 In the list of submissions, select the actions menu and press the **Assign** option. In the context menu, select an administrator for this submission.

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -490,7 +490,7 @@ Desde la vista de una respuesta en el menú de acciones (identificado con …) s
 
 El listado de respuestas incluye una caja de búsqueda que te permite encontrar respuestas por los datos del usuario, los valores de sus campos personalizados, las respuestas ingresadas en los campos del flujo y el contenido de las tareas.
 
-La búsqueda requiere un mínimo de 3 caracteres, no distingue mayúsculas ni acentos y encuentra coincidencias parciales. Por ejemplo, `lau` encuentra a "Claudio" y `peres` encuentra a "Pérez".
+La búsqueda requiere un mínimo de 3 caracteres, no distingue mayúsculas ni acentos y encuentra coincidencias parciales. Por ejemplo, `lau` encuentra a "Claudio" y `perez` encuentra a "Pérez".
 
 Puedes buscar de dos formas, que además puedes combinar en una misma consulta:
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -486,6 +486,54 @@ Esta estructura te brinda una visión integral y detallada de cada respuesta, pe
 Desde la vista de una respuesta en el menú de acciones (identificado con …) se puede [impersonar](/es/platform/customers/users) al usuario para ayudarlo a contestar la originación. Esto depende de los roles del usuario
 :::
 
+#### Buscar respuestas
+
+El listado de respuestas incluye una caja de búsqueda que te permite encontrar respuestas por los datos del usuario, los valores de sus campos personalizados, las respuestas ingresadas en los campos del flujo y el contenido de las tareas.
+
+La búsqueda requiere un mínimo de 3 caracteres, no distingue mayúsculas ni acentos y encuentra coincidencias parciales. Por ejemplo, `lau` encuentra a "Claudio" y `peres` encuentra a "Pérez".
+
+Puedes buscar de dos formas, que además puedes combinar en una misma consulta:
+
+- **Texto libre**: Escribe uno o más términos y la búsqueda los encontrará en los datos del usuario, los valores de sus campos personalizados y el contenido de las respuestas.
+- **Pares clave=valor**: Escribe la clave de un campo seguida de `=` y el valor a buscar para acotar la búsqueda a ese campo específico.
+
+Las claves disponibles para los pares `clave=valor` son:
+
+- **Campos del usuario**: `first_name`, `last_name`, `second_last_name`, `email`, `username`, `uuid` e `id`.
+- **Campos personalizados del usuario**: La clave del campo personalizado, con o sin el prefijo `_ucf_`. Por ejemplo, `pais=Chile` y `_ucf_pais=Chile` son equivalentes.
+- **Preguntas del flujo**: El identificador de la pregunta definido en el flujo de originación. Por ejemplo, `rut=18301757`.
+
+Al usar pares `clave=valor` ten en cuenta lo siguiente:
+
+- La clave debe escribirse completa, mientras que el valor sí admite coincidencias parciales.
+- Para buscar valores o frases con espacios usa comillas dobles. Por ejemplo, `first_name="Jean Pierre"` o `"crédito hipotecario"`.
+- Todas las condiciones se combinan entre sí, por lo que una respuesta debe cumplir todos los términos y pares de la consulta para aparecer en los resultados.
+- Si la clave no existe o el valor está vacío, el término se busca como texto libre sin generar errores.
+
+Algunos ejemplos de búsquedas:
+
+| Búsqueda | Resultado |
+|---|---|
+| `Claudio` | Respuestas cuyo usuario o contenido incluye "Claudio". |
+| `first_name=Claudio` | Respuestas cuyo usuario contiene "Claudio" en su nombre. |
+| `pais=Chile` | Respuestas cuyo usuario tiene "Chile" en el campo personalizado `pais`. |
+| `rut=18301757` | Respuestas donde la pregunta con identificador `rut` contiene "18301757". |
+| `first_name="Jean Pierre"` | Respuestas cuyo usuario contiene "Jean Pierre" en su nombre. |
+| `pais=Chile rut=18301757 hipotecario` | Respuestas que cumplen las tres condiciones a la vez. |
+
+:::tip Actualización de los resultados
+Los cambios recientes en una respuesta pueden tardar unos segundos en reflejarse en los resultados de la búsqueda. Los cambios en los datos del usuario, en los valores de sus campos personalizados y en los segmentos se reflejan de forma diferida.
+:::
+
+#### Filtrar respuestas
+
+Además de la búsqueda, puedes acotar el listado de respuestas con los siguientes filtros, combinables entre sí y con la búsqueda:
+
+- **Rango de fechas**: Filtra por la fecha de creación de la respuesta.
+- **Estado**: Filtra por el estado actual de la respuesta: **No Iniciada**, **Pendiente**, **Completada** o **Cancelada**.
+- **Asignado**: Muestra las respuestas asignadas al administrador seleccionado.
+- **Segmento**: Muestra las respuestas de los usuarios que pertenecen al [segmento](/es/platform/customers/segments.html) seleccionado.
+
 #### Asignar respuesta
 
 En el listado de respuestas, selecciona el menú acciones y presiona la opción **Asignar**. En el menú contextual selecciona a un administrador para esta respuesta.


### PR DESCRIPTION
Documenta las mejoras al buscador de respuestas (submissions) de Origination introducidas en modyo/modyo#19888.

## Cambios propuestos

Se agregan dos subsecciones nuevas dentro de **Gestión de Respuestas** en `docs/es/platform/customers/origination.md`, junto con su traducción en `docs/en/platform/customers/origination.md`:

- **Buscar respuestas**: documenta la caja de búsqueda del listado de respuestas: búsqueda por texto libre y por pares `clave=valor` (campos del usuario, campos personalizados con o sin prefijo `_ucf_`, y preguntas del flujo), reglas de uso (mínimo 3 caracteres, coincidencias parciales sin distinción de mayúsculas ni acentos, comillas para valores con espacios, combinación de condiciones), tabla de ejemplos y un tip sobre la actualización diferida de los resultados.
- **Filtrar respuestas**: documenta los filtros del listado, incluyendo el nuevo estado **No Iniciada** y el nuevo filtro de **Segmento**.

Los nombres de la interfaz y el comportamiento del buscador fueron validados contra los locales y el código de la rama master de modyo/modyo.