### PR TITLE
Grupos y administradores con segmentos en reinos

### DIFF
--- a/docs/en/platform/customers/messaging.md
+++ b/docs/en/platform/customers/messaging.md
@@ -33,7 +33,7 @@ If you delete a campaign, you will not be able to recover it, and its record wil
 :::
 
 :::tip Segment scope
-If your role in the realm is [restricted by segments](/en/platform/customers/settings.html#restrict-scope-with-segments), you can only target campaigns to segments within your scope. Campaigns targeting segments outside your scope are displayed in **Read only** mode: you can see their metadata, but not their metrics or recipients, and you cannot edit, send, duplicate, or delete them.
+If your access to the realm is [restricted by segments](/en/platform/customers/settings.html#restrict-scope-with-segments), you can only target campaigns to segments within your scope. Campaigns targeting segments outside your scope are displayed in **Read only** mode: you can see their metadata, but not their metrics or recipients, and you cannot edit, send, duplicate, or delete them.
 :::
 
 ## Create a campaign

--- a/docs/en/platform/customers/messaging.md
+++ b/docs/en/platform/customers/messaging.md
@@ -32,6 +32,10 @@ Each campaign row includes a menu with the following actions:
 If you delete a campaign, you will not be able to recover it, and its record will be deleted from the system.
 :::
 
+:::tip Segment scope
+If your role in the realm is [restricted by segments](/en/platform/customers/settings.html#restrict-scope-with-segments), you can only target campaigns to segments within your scope. Campaigns targeting segments outside your scope are displayed in **Read only** mode: you can see their metadata, but not their metrics or recipients, and you cannot edit, send, duplicate, or delete them.
+:::
+
 ## Create a campaign
 Campaigns allow you to contact your users directly via email or direct notifications, including support for WebPush notifications. To create a new campaign, click the **New Campaign** button.
 

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -485,6 +485,10 @@ This structure provides you with a comprehensive and detailed view of each submi
 From the submission view in the actions menu (identified with ...), you can [impersonate](/en/platform/customers/users) the user to help them answer the origination. This depends on the user's roles.
 :::
 
+:::tip Segment scope
+If your role in the realm is [restricted by segments](/en/platform/customers/settings.html#restrict-scope-with-segments), you will only see the submissions of the users within your scope. Submissions assigned to you remain visible and operable even if the user belongs to segments outside your scope.
+:::
+
 #### Search submissions
 
 The submission list includes a search box that allows you to find submissions by the user's data, the values of their custom fields, the answers entered in the flow fields, and the content of the tasks.

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -486,7 +486,7 @@ From the submission view in the actions menu (identified with ...), you can [imp
 :::
 
 :::tip Segment scope
-If your role in the realm is [restricted by segments](/en/platform/customers/settings.html#restrict-scope-with-segments), you will only see the submissions of the users within your scope. Submissions assigned to you remain visible and operable even if the user belongs to segments outside your scope.
+If your access to the realm is [restricted by segments](/en/platform/customers/settings.html#restrict-scope-with-segments), you will only see the submissions of the users within your scope. Submissions assigned to you remain visible and operable even if the user belongs to segments outside your scope.
 :::
 
 #### Search submissions

--- a/docs/en/platform/customers/segments.md
+++ b/docs/en/platform/customers/segments.md
@@ -30,6 +30,10 @@ To create a segment, follow these steps:
 Make sure each customer's profile is complete, as incomplete data will prevent a user from being included in a segment based on those criteria.
 :::
 
+:::warning Restricted scope
+If your access to the realm is [restricted by segments](/en/platform/customers/settings.html#restrict-scope-with-segments), you cannot create new segments, since these start from the realm's entire universe of users. You can edit and delete the segments within your scope.
+:::
+
 ## Filters
 
 Filters allow you to create segments based on user profile information and their activity on the site. You can include users who meet certain criteria or exclude those who do not.

--- a/docs/en/platform/customers/settings.md
+++ b/docs/en/platform/customers/settings.md
@@ -308,6 +308,35 @@ You can choose between two roles:
 
 To remove an administrator from the realm, check the box to the left of their name and click the **Delete** button at the bottom.
 
+#### Restrict scope with segments
+
+When adding or editing a realm team member, you can assign one or more [segments](/en/platform/customers/segments.html) to their role using the **Segments** field. The role defines which actions the member can perform, while the segments limit which realm users they can apply them to:
+
+- **Without segments**: The role grants access to all users in the realm.
+- **With segments**: The member only sees and operates on the users that belong to those segments.
+
+This applies both to roles assigned directly to a member and to those assigned through their [groups](/en/platform/core/roles.html#groups). In the team members list, the **Segments** column shows the segments assigned to each member or group.
+
+The effective scope of a member considers all the roles they have in the realm:
+
+- Account-level roles with full access to realms (such as **Owner** or **Full Admin**) are not restricted by segments.
+- If any of their roles in the realm has no segments assigned, the member has access to all users in the realm.
+- If all of their roles in the realm have segments assigned, their scope is the union of the segments of all of them.
+
+The scope is enforced in every realm section that displays or operates on users: the user list and their profiles, bulk actions and exports, form responses, origination submissions, payment orders, business events, notes, direct messaging, and campaigns.
+
+A member restricted by segments also has the following considerations:
+
+- **Users**: They cannot access the profile of a user outside their scope.
+- **Segments**: They cannot create new segments, since these start from the realm's entire universe of users. They can edit and delete the segments within their scope.
+- **Campaigns**: They can only target campaigns to segments within their scope. Campaigns targeting segments outside their scope are displayed in **Read only** mode: they can see their metadata (name, status, author, dates, and segments), but not their metrics or recipients, and they cannot edit, send, duplicate, or delete them.
+- **Origination submissions**: Submissions assigned to them remain visible and operable even if the user belongs to segments outside their scope.
+- **Team members**: They can only assign segments within their scope and cannot leave realm roles without segments. Members whose segments are outside their scope are displayed with the **Out of your scope** label and cannot be edited.
+
+:::tip Scope updates
+User membership in segments is updated in a background process, so segment changes may take a few minutes to be reflected in the members' scope. You can learn more in the [Segments](/en/platform/customers/segments.html#filters) section.
+:::
+
 ### Custom fields
 
 In this section, you can create custom fields to distinguish the user's profile. For best use, it is important that these fields are correctly identified.

--- a/docs/en/platform/customers/users.md
+++ b/docs/en/platform/customers/users.md
@@ -19,7 +19,7 @@ You can use the filters at the top of the table to quickly find user groups. The
 You can sort the users in the table by name, registration date, last login, or number of sessions started by clicking on the column headers.
 
 :::tip Segment scope
-If your role in the realm has segments assigned, this list only shows the users that belong to those segments. Learn more in [Restrict scope with segments](/en/platform/customers/settings.html#restrict-scope-with-segments).
+If your access to the realm is restricted by segments, this list only shows the users that belong to the segments within your scope. Learn more in [Restrict scope with segments](/en/platform/customers/settings.html#restrict-scope-with-segments).
 :::
 
 ### Bulk actions

--- a/docs/en/platform/customers/users.md
+++ b/docs/en/platform/customers/users.md
@@ -18,6 +18,10 @@ You can use the filters at the top of the table to quickly find user groups. The
 
 You can sort the users in the table by name, registration date, last login, or number of sessions started by clicking on the column headers.
 
+:::tip Segment scope
+If your role in the realm has segments assigned, this list only shows the users that belong to those segments. Learn more in [Restrict scope with segments](/en/platform/customers/settings.html#restrict-scope-with-segments).
+:::
+
 ### Bulk actions
 
 Check the box next to one or more users' names and click the **Bulk Actions** button below the list to perform the following actions:

--- a/docs/es/platform/customers/messaging.md
+++ b/docs/es/platform/customers/messaging.md
@@ -33,7 +33,7 @@ Si borras una campaña, no podrás recuperarla, y su registro se eliminará del 
 :::
 
 :::tip Alcance por segmentos
-Si tu rol en el reino está [restringido por segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos), solo puedes dirigir campañas a segmentos dentro de tu alcance. Las campañas dirigidas a segmentos fuera de tu alcance se muestran en modo **Solo lectura**: puedes ver sus metadatos, pero no sus métricas ni destinatarios, y no puedes editarlas, enviarlas, duplicarlas ni borrarlas.
+Si tu acceso al reino está [restringido por segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos), solo puedes dirigir campañas a segmentos dentro de tu alcance. Las campañas dirigidas a segmentos fuera de tu alcance se muestran en modo **Solo lectura**: puedes ver sus metadatos, pero no sus métricas ni destinatarios, y no puedes editarlas, enviarlas, duplicarlas ni borrarlas.
 :::
 
 ## Crear una campaña

--- a/docs/es/platform/customers/messaging.md
+++ b/docs/es/platform/customers/messaging.md
@@ -32,6 +32,10 @@ En cada fila de campaña, encontrarás un menú con las siguientes acciones:
 Si borras una campaña, no podrás recuperarla, y su registro se eliminará del sistema.
 :::
 
+:::tip Alcance por segmentos
+Si tu rol en el reino está [restringido por segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos), solo puedes dirigir campañas a segmentos dentro de tu alcance. Las campañas dirigidas a segmentos fuera de tu alcance se muestran en modo **Solo lectura**: puedes ver sus metadatos, pero no sus métricas ni destinatarios, y no puedes editarlas, enviarlas, duplicarlas ni borrarlas.
+:::
+
 ## Crear una campaña
 Las campañas te permiten contactar directamente a tus usuarios mediante correo electrónico o notificaciones directas, incluyendo soporte para notificaciones WebPush. Para generar una nueva campaña haz click en el botón **Nueva Campaña**
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -487,7 +487,7 @@ Desde la vista de una respuesta en el menú de acciones (identificado con …) s
 :::
 
 :::tip Alcance por segmentos
-Si tu rol en el reino está [restringido por segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos), solo verás las respuestas de los usuarios de tu alcance. Las respuestas que tengas asignadas siguen visibles y operables aunque el usuario pertenezca a segmentos fuera de tu alcance.
+Si tu acceso al reino está [restringido por segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos), solo verás las respuestas de los usuarios de tu alcance. Las respuestas que tengas asignadas siguen visibles y operables aunque el usuario pertenezca a segmentos fuera de tu alcance.
 :::
 
 #### Buscar respuestas

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -486,6 +486,10 @@ Esta estructura te brinda una visión integral y detallada de cada respuesta, pe
 Desde la vista de una respuesta en el menú de acciones (identificado con …) se puede [impersonar](/es/platform/customers/users) al usuario para ayudarlo a contestar la originación. Esto depende de los roles del usuario
 :::
 
+:::tip Alcance por segmentos
+Si tu rol en el reino está [restringido por segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos), solo verás las respuestas de los usuarios de tu alcance. Las respuestas que tengas asignadas siguen visibles y operables aunque el usuario pertenezca a segmentos fuera de tu alcance.
+:::
+
 #### Buscar respuestas
 
 El listado de respuestas incluye una caja de búsqueda que te permite encontrar respuestas por los datos del usuario, los valores de sus campos personalizados, las respuestas ingresadas en los campos del flujo y el contenido de las tareas.

--- a/docs/es/platform/customers/segments.md
+++ b/docs/es/platform/customers/segments.md
@@ -30,6 +30,10 @@ Para crear un segmento, sigue estos pasos:
 Asegúrate de que la ficha de cada cliente esté completa, ya que los datos incompletos impedirán que un usuario sea incluido en un segmento basado en esos criterios.
 :::
 
+:::warning Alcance restringido
+Si tu acceso al reino está [restringido por segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos), no puedes crear segmentos nuevos, ya que estos parten del universo total de usuarios del reino. Sí puedes editar y borrar los segmentos de tu alcance.
+:::
+
 ## Filtros
 
 Los filtros te permiten crear segmentos basados en la información de las fichas de usuario y su actividad en el sitio. Puedes incluir usuarios que coincidan con ciertos criterios o excluir a los que no los cumplan.

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -308,6 +308,35 @@ Puedes elegir entre dos roles:
 
 Para eliminar a un administrador del reino, selecciona la casilla a la izquierda de su nombre y haz click en el botón **Borrar** en la parte inferior.
 
+#### Restringir el alcance con segmentos
+
+Al agregar o editar un miembro del equipo del reino, puedes asignar uno o más [segmentos](/es/platform/customers/segments.html) a su rol mediante el campo **Segmentos**. El rol define qué acciones puede ejecutar el miembro, mientras que los segmentos acotan sobre qué usuarios del reino puede aplicarlas:
+
+- **Sin segmentos**: El rol da acceso a todos los usuarios del reino.
+- **Con segmentos**: El miembro solo ve y opera los usuarios que pertenecen a esos segmentos.
+
+Esto aplica tanto a los roles asignados directamente a un miembro como a los asignados a través de sus [grupos](/es/platform/core/roles.html#grupos). En el listado de miembros del equipo, la columna **Segmentos** muestra los segmentos asignados a cada miembro o grupo.
+
+El alcance efectivo de un miembro considera todos los roles que tiene en el reino:
+
+- Los roles a nivel de cuenta con acceso total a los reinos (como **Owner** o **Full Admin**) no se restringen por segmentos.
+- Si alguno de sus roles en el reino no tiene segmentos asignados, el miembro tiene acceso a todos los usuarios del reino.
+- Si todos sus roles en el reino tienen segmentos asignados, su alcance es la unión de los segmentos de todos ellos.
+
+El alcance se aplica en todas las secciones del reino que muestran u operan sobre usuarios: el listado de usuarios y sus fichas, las acciones masivas y exportaciones, las respuestas de formularios, las respuestas de originaciones, las órdenes de pago, los eventos de negocio, las notas, la mensajería directa y las campañas.
+
+Un miembro restringido por segmentos tiene además las siguientes consideraciones:
+
+- **Usuarios**: No puede acceder a la ficha de un usuario fuera de su alcance.
+- **Segmentos**: No puede crear segmentos nuevos, ya que estos parten del universo total de usuarios del reino. Sí puede editar y borrar los segmentos de su alcance.
+- **Campañas**: Solo puede dirigir campañas a segmentos dentro de su alcance. Las campañas dirigidas a segmentos fuera de su alcance se muestran en modo **Solo lectura**: puede ver sus metadatos (nombre, estado, autor, fechas y segmentos), pero no sus métricas ni destinatarios, y no puede editarlas, enviarlas, duplicarlas ni borrarlas.
+- **Respuestas de originación**: Las respuestas que tenga asignadas siguen visibles y operables aunque el usuario pertenezca a segmentos fuera de su alcance.
+- **Miembros del equipo**: Solo puede asignar segmentos dentro de su alcance y no puede dejar roles del reino sin segmentos. Los miembros cuyos segmentos están fuera de su alcance se muestran con la etiqueta **Fuera de tu alcance** y no puede editarlos.
+
+:::tip Actualización del alcance
+La pertenencia de los usuarios a los segmentos se actualiza en un proceso en segundo plano, por lo que los cambios en los segmentos pueden tardar unos minutos en reflejarse en el alcance de los miembros. Puedes conocer más en la sección de [Segmentos](/es/platform/customers/segments.html#filtros).
+:::
+
 ### Custom fields
 
 En esta sección, puedes crear campos personalizados para distinguir el perfil del usuario. Es importante que estos campos estén correctamente identificados para su mejor uso.

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -323,7 +323,7 @@ El alcance efectivo de un miembro considera todos los roles que tiene en el rein
 - Si alguno de sus roles en el reino no tiene segmentos asignados, el miembro tiene acceso a todos los usuarios del reino.
 - Si todos sus roles en el reino tienen segmentos asignados, su alcance es la unión de los segmentos de todos ellos.
 
-El alcance se aplica en todas las secciones del reino que muestran u operan sobre usuarios: el listado de usuarios y sus fichas, las acciones masivas y exportaciones, las respuestas de formularios, las respuestas de originaciones, las órdenes de pago, los eventos de negocio, las notas, la mensajería directa y las campañas.
+El alcance se aplica en todas las secciones del reino que muestran u operan sobre usuarios: el listado de usuarios y sus fichas, las acciones masivas y exportaciones, las respuestas de formularios, las respuestas de originación, las órdenes de pago, los eventos de negocio, las notas, la mensajería directa y las campañas.
 
 Un miembro restringido por segmentos tiene además las siguientes consideraciones:
 

--- a/docs/es/platform/customers/users.md
+++ b/docs/es/platform/customers/users.md
@@ -19,7 +19,7 @@ Puedes utilizar los filtros en la parte superior de la tabla para encontrar grup
 Puedes ordenar los usuarios en la tabla por nombre, fecha de inscripción, último ingreso o cantidad de sesiones iniciadas haciendo clic en las cabeceras de las columnas.
 
 :::tip Alcance por segmentos
-Si tu rol en el reino tiene segmentos asignados, este listado solo muestra los usuarios que pertenecen a esos segmentos. Conoce más en [Restringir el alcance con segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos).
+Si tu acceso al reino está restringido por segmentos, este listado solo muestra los usuarios que pertenecen a los segmentos de tu alcance. Conoce más en [Restringir el alcance con segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos).
 :::
 
 ### Acciones masivas

--- a/docs/es/platform/customers/users.md
+++ b/docs/es/platform/customers/users.md
@@ -18,6 +18,10 @@ Puedes utilizar los filtros en la parte superior de la tabla para encontrar grup
 
 Puedes ordenar los usuarios en la tabla por nombre, fecha de inscripción, último ingreso o cantidad de sesiones iniciadas haciendo clic en las cabeceras de las columnas.
 
+:::tip Alcance por segmentos
+Si tu rol en el reino tiene segmentos asignados, este listado solo muestra los usuarios que pertenecen a esos segmentos. Conoce más en [Restringir el alcance con segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos).
+:::
+
 ### Acciones masivas
 
 Marca la casilla junto al nombre de uno o más usuarios y haz clic en el botón **Bulk Actions** debajo del listado para realizar las siguientes acciones:


### PR DESCRIPTION
Documenta la restricción de alcance por segmentos para administradores y grupos en reinos, introducida en modyo/modyo#19829.

## Cambios propuestos

Se agrega la sección principal **Restringir el alcance con segmentos** dentro de "Miembros del equipo" en `docs/es/platform/customers/settings.md`:

- Cómo asignar segmentos al rol de un miembro del equipo del reino, aplicando también a los roles heredados vía grupos.
- La regla de alcance efectivo: los roles de cuenta con acceso total no se restringen; si algún rol del reino no tiene segmentos el miembro ve todo el reino; si todos tienen segmentos, el alcance es la unión de ellos.
- Las secciones del reino donde se aplica el alcance y las consideraciones para un miembro restringido: no puede crear segmentos, campañas fuera de alcance en modo solo lectura, excepción de respuestas de originación asignadas y restricciones al editar otros miembros del equipo.

Además se agregan notas breves enlazando a la sección principal en las páginas afectadas: `users.md` (listado acotado por segmentos), `segments.md` (restricción de creación de segmentos), `messaging.md` (campañas en solo lectura y restricción de destinatarios) y `origination.md` (excepción de respuestas asignadas).

Todo replicado en la versión en inglés. Los nombres de la interfaz y el comportamiento fueron validados contra los locales y el código de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)