### PR TITLE
Cancelar submission con comentario

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -539,7 +539,11 @@ In the list of submissions, select the actions menu and press the **Assign** opt
 
 #### Cancel submission
 
-Select a submission and press the context menu. Select the **Cancel** option to permanently change the status of a submission to canceled.
+To cancel a submission, open it and press the **Cancel** button in the submission view. In the modal, you can optionally enter a **Cancellation reason** and then confirm the action. Canceling permanently changes the status of the submission to canceled.
+
+You can cancel submissions in **Not started**, **Pending**, or **Completed** status.
+
+The details of a canceled submission show the cancellation date in the **Canceled at** field and the **Cancellation reason** entered. If no reason was entered, the field shows `--`.
 
 #### Delete submission
 

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -539,7 +539,7 @@ In the list of submissions, select the actions menu and press the **Assign** opt
 
 #### Cancel submission
 
-To cancel a submission, open it and press the **Cancel** button in the submission view. In the modal, you can optionally enter a **Cancellation reason** and then confirm the action. Canceling permanently changes the status of the submission to canceled.
+To cancel a submission, open it and press the **Cancel** button in the submission view. In the modal, you can optionally enter a **Cancellation reason** and then confirm the action. Canceling permanently changes the status of the submission to **Canceled**.
 
 You can cancel submissions in **Not started**, **Pending**, or **Completed** status.
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -540,7 +540,11 @@ En el listado de respuestas, selecciona el menú acciones y presiona la opción 
 
 #### Cancelar respuesta
 
-Selecciona una respuesta y presiona el menu contextual. Al seleccionar la opción **Cancelar** para modificar permanentemente el estatus de una respuesta a cancelado.
+Para cancelar una respuesta, ábrela y presiona el botón **Cancelar** en la vista de la respuesta. En el modal puedes ingresar de manera opcional una **Razón de cancelación** y luego confirmar la acción. La cancelación modifica permanentemente el estado de la respuesta a cancelada.
+
+Puedes cancelar respuestas en estado **No Iniciada**, **Pendiente** o **Completada**.
+
+En los detalles de una respuesta cancelada se muestra la fecha de cancelación en el campo **Cancelada el** y la **Razón de cancelación** ingresada. Si no se ingresó una razón, el campo muestra `--`.
 
 #### Eliminar respuesta
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -540,7 +540,7 @@ En el listado de respuestas, selecciona el menú acciones y presiona la opción 
 
 #### Cancelar respuesta
 
-Para cancelar una respuesta, ábrela y presiona el botón **Cancelar** en la vista de la respuesta. En el modal puedes ingresar de manera opcional una **Razón de cancelación** y luego confirmar la acción. La cancelación modifica permanentemente el estado de la respuesta a cancelada.
+Para cancelar una respuesta, ábrela y presiona el botón **Cancelar** en la vista de la respuesta. En el modal puedes ingresar de manera opcional una **Razón de cancelación** y luego confirmar la acción. La cancelación modifica permanentemente el estado de la respuesta a **Cancelada**.
 
 Puedes cancelar respuestas en estado **No Iniciada**, **Pendiente** o **Completada**.
 


### PR DESCRIPTION
Documenta la cancelación de respuestas con razón de cancelación, introducida en modyo/modyo#19387.

## Cambios propuestos

Se actualiza la sección **Cancelar respuesta** de la documentación de Origination (`docs/es/platform/customers/origination.md` y su versión en inglés):

- La cancelación ahora se realiza desde la vista de la respuesta mediante un modal que permite ingresar de manera opcional una **Razón de cancelación**.
- Se documenta que pueden cancelarse respuestas en estado No Iniciada, Pendiente o Completada.
- Se documenta que los detalles de una respuesta cancelada muestran la fecha de cancelación (**Cancelada el**) y la razón ingresada.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)