### PR TITLE
Cancelar submission por vencimiento

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -434,8 +434,13 @@ By selecting the **Edit** option in the context menu of your origination, you ca
 - **Completed message**: This is the message that will appear to the user at the end of the origination process.
 - **Default submission assignee**: Specifies the person who will be automatically assigned when receiving a new origination.
 - **Due in**: Sets a maximum deadline for completing the origination.
+- **Automatically cancel submissions that exceed the due date**: Available only if you have configured a due date. When this option is enabled, pending submissions that exceed their due date are automatically canceled.
 - **Completion rules**: Defines the completion behavior for each submission.
 - **Privacy**: Allows you to restrict access to the origination flow to certain predefined user segments.
+
+:::tip Automatic cancellation by due date
+Automatic cancellation runs in a background process once a day, so it may not happen immediately when the submission becomes overdue. It only cancels submissions in **Pending** status and records **Auto-Cancelled Overdue** as the cancellation reason, visible in the submission details.
+:::
 
 #### Delete origination
 

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -434,7 +434,7 @@ By selecting the **Edit** option in the context menu of your origination, you ca
 - **Completed message**: This is the message that will appear to the user at the end of the origination process.
 - **Default submission assignee**: Specifies the person who will be automatically assigned when receiving a new origination.
 - **Due in**: Sets a maximum deadline for completing the origination.
-- **Automatically cancel submissions that exceed the due date**: Available only if you have configured a due date. When this option is enabled, pending submissions that exceed their due date are automatically canceled.
+- **Automatically cancel submissions that exceed the due date**: Available only if you have configured a due date. When this option is enabled, submissions in **Pending** status that exceed their due date are automatically canceled.
 - **Completion rules**: Defines the completion behavior for each submission.
 - **Privacy**: Allows you to restrict access to the origination flow to certain predefined user segments.
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -435,8 +435,13 @@ Al seleccionar la opción **Editar** en el menu contextual de tu orignación pue
 - **Mensaje de completado**: Es el mensaje que aparecerá al usuario al finalizar el proceso de originación.
 - **Asignado por defecto de la respuesta**: especifica la persona que será asignada automáticamente al recibir una nueva originación.
 - **Vence en**:  Establece un plazo máximo para completar la originación.
+- **Cancelar automáticamente las respuestas que excedan la fecha de vencimiento**: Disponible solo si configuraste un vencimiento. Al activar esta opción, las respuestas pendientes que superen su fecha de vencimiento se cancelan automáticamente.
 - **Reglas de completado**:  Define el comportamiento de completado para cada respuesta.
 - **Privacidad**: Permite restringir el acceso al flujo de originación a ciertos segmentos de usuarios predefinidos.
+
+:::tip Cancelación automática por vencimiento
+La cancelación automática se ejecuta en un proceso en segundo plano una vez al día, por lo que puede no ser inmediata al momento del vencimiento. Solo cancela respuestas en estado **Pendiente** y registra **Auto-cancelada por vencimiento** como razón de cancelación, visible en los detalles de la respuesta.
+:::
 
 #### Eliminar originación
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -435,7 +435,7 @@ Al seleccionar la opción **Editar** en el menu contextual de tu orignación pue
 - **Mensaje de completado**: Es el mensaje que aparecerá al usuario al finalizar el proceso de originación.
 - **Asignado por defecto de la respuesta**: especifica la persona que será asignada automáticamente al recibir una nueva originación.
 - **Vence en**:  Establece un plazo máximo para completar la originación.
-- **Cancelar automáticamente las respuestas que excedan la fecha de vencimiento**: Disponible solo si configuraste un vencimiento. Al activar esta opción, las respuestas pendientes que superen su fecha de vencimiento se cancelan automáticamente.
+- **Cancelar automáticamente las respuestas que excedan la fecha de vencimiento**: Disponible solo si configuraste un vencimiento. Al activar esta opción, las respuestas en estado **Pendiente** que superen su fecha de vencimiento se cancelan automáticamente.
 - **Reglas de completado**:  Define el comportamiento de completado para cada respuesta.
 - **Privacidad**: Permite restringir el acceso al flujo de originación a ciertos segmentos de usuarios predefinidos.
 


### PR DESCRIPTION
Documenta la cancelación automática de respuestas por vencimiento, introducida en modyo/modyo#19455.

## Cambios propuestos

Se actualiza la sección **Editar configuración de la originación** de la documentación de Origination (`docs/es/platform/customers/origination.md` y su versión en inglés):

- Se agrega la nueva opción **Cancelar automáticamente las respuestas que excedan la fecha de vencimiento**, disponible solo cuando la originación tiene configurado un vencimiento.
- Se agrega un tip con el comportamiento esperado: la cancelación corre en un proceso en segundo plano una vez al día, solo aplica a respuestas en estado Pendiente y registra **Auto-cancelada por vencimiento** como razón de cancelación visible en los detalles de la respuesta.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)