### PR TITLE
Originación multi usuario

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -19,7 +19,7 @@ To create a new origination, follow these steps:
 - In the side menu, navigate to **Customers** > **Realms** and select the Realm you want to work in.
 - Go to the **Origination** option.
 - Click the **+ New origination** button.
-- Assign a name and select the type of origination you want to create.
+- Assign a name to the origination.
 - Click **Create** to finish and begin configuring the steps of the new origination flow.
 
 
@@ -393,11 +393,25 @@ Whether or not to allow the use of previous data is defined when adding the orig
 
 ### Invitation
 
-The Invitation task is what enables multi-user origination flows.
-To create an invitation task, you must first create roles in the origination editing. There you choose if the main user can have that role, if it requires invitation, and if it has an invitation limit.
-Having at least one role unlocks the use of the invitation task.
-The invitation can only be for tasks or steps prior to the invitation task.
-In the task, you select the role, the email that is sent, and which tasks the role must complete.
+The Invitation task enables **multi-user** origination flows: the main user of the submission invites other people to complete specific tasks in the flow.
+
+To create an invitation task, you must first create at least one [role](#roles) in the origination editing. Each role can be used in only one invitation task of the origination.
+
+When configuring the task, you define:
+
+- **Role**: The role that invited users will assume.
+- **Email template**: The HTML/Liquid code of the invitation email. Liquid variables such as `invitation.first_name`, `invitation.last_name`, `invitation.email`, `invitation_url`, `submission`, `task`, `origination`, and `site` are available.
+- **Target tasks**: The tasks that invited users will be able to complete. You can only select tasks prior to the invitation task; other invitation tasks and origination process tasks are not selectable.
+
+In addition, the properties of each task included in an invitation task have the option **Show this task to the main user**, which controls whether the main user also sees that task in their flow.
+
+On the origination page, the main user can invite new people (first name, last name, and email address) or users already invited in other tasks, and can resend or cancel pending invitations. Each invitee receives an email with an access link and, upon entering, only sees the tasks assigned to them; if they have more than one role, they see the union of the tasks of all their roles. The invited user cannot cancel the submission.
+
+The invitation task is completed when all invitees finish their tasks. If the role does not require invitations and the main user does not invite anyone, the task is automatically completed when continuing. The number of active invitations is limited by the role's **Maximum number of users**.
+
+:::tip Template for invited users
+The origination page includes the **Resume (Invited)** template, which is the view invited users see when they return to the submission. You can customize it like the rest of the page templates.
+:::
 
 ### Conditional Logic
 
@@ -436,6 +450,14 @@ By selecting the **Edit** option in the context menu of your origination, you ca
 - **Due in**: Sets a maximum deadline for completing the origination.
 - **Completion rules**: Defines the completion behavior for each submission.
 - **Privacy**: Allows you to restrict access to the origination flow to certain predefined user segments.
+
+#### Roles
+
+In the origination editing, you will find the **Roles** section, where you define the roles used by the [invitation tasks](#invitation) of multi-user flows. To create a role, press the **Add Role** button and complete:
+
+- **Name**: The name of the role, unique within the origination.
+- **Require invitations**: If enabled, the main user must invite at least one person to complete the invitation task that uses this role.
+- **Maximum number of users**: The maximum number of users that can have this role in the same submission.
 
 #### Delete origination
 
@@ -480,6 +502,8 @@ In the details view, you will find the following main sections:
 - **Activity**: Record of activities and changes made to the submission, useful for monitoring and auditing.
 
 This structure provides you with a comprehensive and detailed view of each submission, allowing you to effectively manage all aspects related to the submissions.
+
+In multi-user submissions, the **Tasks**, **Reviews**, and **Validations** tabs include the **Viewing tasks for** selector, which allows you to switch between the **Main User** and each invited user to review the individual progress of their tasks.
 
 :::tip Tip
 From the submission view in the actions menu (identified with ...), you can [impersonate](/en/platform/customers/users) the user to help them answer the origination. This depends on the user's roles.

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -19,7 +19,7 @@ Para crear una nueva originación, sigue estos pasos:
 - En el menú lateral, navega a **Customers** > **Reinos** y selecciona el Reino en el que deseas trabajar.
 - Dirígete a la opción **Origination**.
 - Haz clic en el botón **+ Nueva originación**.
-- Asigna un nombre y selecciona el tipo de originación que deseas crear.
+- Asigna un nombre a la originación.
 - Haz clic en **Crear** para finalizar y comenzar a configurar los pasos del nuevo flujo de originación.
 
 
@@ -394,11 +394,25 @@ Permitir o no el uso de datos anteriores se define al agregar la tarea de proces
 
 ### Invitación
 
-La tarea de Invitación es la que permite tener flujos de originación multiusuario.
-Para poder crear una tarea de invitación, primero tienes que crear roles en la edición de la originación. Allí eliges si el usuario principal puede tener ese rol si requiere invitación y si tiene límite de invitaciones.
-Al tener al menos un rol se desbloquea el uso de la tarea de invitación.
-La invitación solo puede ser para tareas o pasos anteriores a la tarea de invitación.
-En la tarea se elige el rol, el correo que se envía y cuales son las tareas que tiene que realizar el rol.
+La tarea de Invitación permite crear flujos de originación **multiusuario**: el usuario principal de la respuesta invita a otras personas para que completen tareas específicas del flujo.
+
+Para poder crear una tarea de invitación, primero debes crear al menos un [rol](#roles) en la edición de la originación. Cada rol puede usarse en una sola tarea de invitación de la originación.
+
+Al configurar la tarea defines:
+
+- **Rol**: El rol que asumirán los usuarios invitados.
+- **Plantilla de correo**: El código HTML/Liquid del correo de invitación. Tienes disponibles variables de Liquid como `invitation.first_name`, `invitation.last_name`, `invitation.email`, `invitation_url`, `submission`, `task`, `origination` y `site`.
+- **Tareas objetivo**: Las tareas que los usuarios invitados podrán completar. Solo puedes seleccionar tareas anteriores a la tarea de invitación; otras tareas de invitación y las tareas de proceso de originación no son seleccionables.
+
+Además, en las propiedades de cada tarea incluida en una tarea de invitación encontrarás la opción **Mostrar esta tarea al usuario principal**, que controla si el usuario principal también ve esa tarea en su flujo.
+
+En la página de originación, el usuario principal puede invitar a personas nuevas (nombre, apellido y correo electrónico) o a usuarios ya invitados en otras tareas, y puede reenviar o cancelar las invitaciones pendientes. Cada invitado recibe un correo con un enlace de acceso y, al ingresar, solo ve las tareas que le fueron asignadas; si tiene más de un rol, ve la unión de las tareas de todos sus roles. El usuario invitado no puede cancelar la respuesta.
+
+La tarea de invitación se completa cuando todos los invitados terminan sus tareas. Si el rol no requiere invitaciones y el usuario principal no invita a nadie, la tarea se completa automáticamente al continuar. La cantidad de invitaciones activas está limitada por el **Número máximo de usuarios** del rol.
+
+:::tip Plantilla para usuarios invitados
+La página de la originación incluye la plantilla **Reanudar (Invitado)**, que es la vista que ven los usuarios invitados al volver a ingresar a la respuesta. Puedes personalizarla como el resto de las plantillas de la página.
+:::
 
 ### Lógica Condicional
 
@@ -437,6 +451,14 @@ Al seleccionar la opción **Editar** en el menu contextual de tu orignación pue
 - **Vence en**:  Establece un plazo máximo para completar la originación.
 - **Reglas de completado**:  Define el comportamiento de completado para cada respuesta.
 - **Privacidad**: Permite restringir el acceso al flujo de originación a ciertos segmentos de usuarios predefinidos.
+
+#### Roles
+
+En la edición de la originación encontrarás la sección **Roles**, donde defines los roles que usarán las [tareas de invitación](#invitacion) de los flujos multiusuario. Para crear un rol, presiona el botón **Agregar Rol** y completa:
+
+- **Nombre**: El nombre del rol, único dentro de la originación.
+- **Requiere invitaciones**: Si está activo, el usuario principal debe invitar al menos a una persona para completar la tarea de invitación que use este rol.
+- **Número máximo de usuarios**: La cantidad máxima de usuarios que pueden tener este rol en una misma respuesta.
 
 #### Eliminar originación
 
@@ -481,6 +503,8 @@ En la vista de detalles, encontrarás las siguientes secciones principales:
 - **Actividad**: Registro de actividades y cambios realizados en la respuesta, útil para seguimiento y auditoría.
 
 Esta estructura te brinda una visión integral y detallada de cada respuesta, permitiéndote gestionar de manera efectiva todos los aspectos relacionados con las respuestas.
+
+En las respuestas multiusuario, las pestañas **Tareas**, **Revisiones** y **Validaciones** incluyen el selector **Viendo tareas de**, que te permite alternar entre el **Usuario Principal** y cada usuario invitado para revisar el avance individual de sus tareas.
 
 :::tip Tip
 Desde la vista de una respuesta en el menú de acciones (identificado con …) se puede [impersonar](/es/platform/customers/users) al usuario para ayudarlo a contestar la originación. Esto depende de los roles del usuario


### PR DESCRIPTION
Documenta la originación multi usuario introducida en modyo/modyo#18704.

## Cambios propuestos

Se actualiza la documentación de Origination (`docs/es/platform/customers/origination.md` y su versión en inglés):

- **Invitación**: se expande la sección de la tarea de invitación con su configuración completa (rol, plantilla de correo con variables Liquid disponibles, tareas objetivo y sus restricciones), la opción **Mostrar esta tarea al usuario principal**, el flujo del usuario principal (invitar personas nuevas o ya invitadas, reenviar y cancelar invitaciones), la experiencia del usuario invitado (correo con enlace de acceso, ve solo sus tareas, no puede cancelar la respuesta), las reglas de completado de la tarea y un tip sobre la plantilla **Reanudar (Invitado)**.
- **Roles**: nueva subsección en la configuración de la originación documentando la creación de roles (Nombre, Requiere invitaciones, Número máximo de usuarios).
- **Gestión de Respuestas**: se documenta el selector **Viendo tareas de** para revisar el avance individual del usuario principal y cada invitado.
- Se corrige el paso de creación de una originación: ya no se selecciona un tipo (los tipos Persona/Organización fueron eliminados).

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)