### PR TITLE
ConfirmationTask

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -66,6 +66,7 @@ The available task types are:
 - **Code snippet**: Allows adding custom code.
 - **Origination process**: Calls another origination flow within this one.
 - **Invitation**: Allows inviting other users to fill in necessary data in the flow.
+- **Confirmation**: Asks the user to confirm the answers provided in previous tasks.
 
 ##### Task properties
 
@@ -398,6 +399,16 @@ To create an invitation task, you must first create roles in the origination edi
 Having at least one role unlocks the use of the invitation task.
 The invitation can only be for tasks or steps prior to the invitation task.
 In the task, you select the role, the email that is sent, and which tasks the role must complete.
+
+### Confirmation
+
+The Confirmation task shows the user a summary of the answers they provided in previous Input tasks, so they can review and confirm them before continuing with the flow.
+
+When configuring the task, in **Select items to confirm** you choose the tasks whose answers will be included in the summary, grouped by step. You can only select **Input** type tasks prior to the confirmation task.
+
+The user sees each selected task with its answers and an **Edit** link that takes them directly to that task to correct it. Pressing **Confirm** completes the task and the flow continues. To complete the task, all configured items must be confirmed.
+
+In the details of a submission, completed confirmation tasks show the list of **Confirmed Tasks**.
 
 ### Conditional Logic
 

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -66,7 +66,7 @@ The available task types are:
 - **Code snippet**: Allows adding custom code.
 - **Origination process**: Calls another origination flow within this one.
 - **Invitation**: Allows inviting other users to fill in necessary data in the flow.
-- **Confirmation**: Asks the user to confirm the answers provided in previous tasks.
+- **Confirmation**: Asks the user to confirm the answers provided in previous Input tasks.
 
 ##### Task properties
 
@@ -404,7 +404,7 @@ In the task, you select the role, the email that is sent, and which tasks the ro
 
 The Confirmation task shows the user a summary of the answers they provided in previous Input tasks, so they can review and confirm them before continuing with the flow.
 
-When configuring the task, in **Select items to confirm** you choose the tasks whose answers will be included in the summary, grouped by step. You can only select **Input** type tasks prior to the confirmation task.
+When configuring the task, in **Select items to confirm** you choose the tasks whose answers will be included in the summary, grouped by step. You can only select **Input** tasks prior to the confirmation task.
 
 The user sees each selected task with its answers and an **Edit** link that takes them directly to that task to correct it. Pressing **Confirm** completes the task and the flow continues. To complete the task, all configured items must be confirmed.
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -66,7 +66,7 @@ Los tipos de tareas disponibles son:
 - **Snippet de código**: Permiten agregar código a la medida.
 - **Proceso de originación**: Llaman a otro flujo de originación dentro de este.
 - **Invitación**: Permiten invitar a otros usuarios a llenar datos necesarios en el flujo.
-- **Confirmación**: Solicitan al usuario confirmar las respuestas entregadas en tareas anteriores.
+- **Confirmación**: Solicitan al usuario confirmar las respuestas entregadas en tareas Input anteriores.
 
 ##### Propiedades de la tarea
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -66,6 +66,7 @@ Los tipos de tareas disponibles son:
 - **Snippet de código**: Permiten agregar código a la medida.
 - **Proceso de originación**: Llaman a otro flujo de originación dentro de este.
 - **Invitación**: Permiten invitar a otros usuarios a llenar datos necesarios en el flujo.
+- **Confirmación**: Solicitan al usuario confirmar las respuestas entregadas en tareas anteriores.
 
 ##### Propiedades de la tarea
 
@@ -399,6 +400,16 @@ Para poder crear una tarea de invitación, primero tienes que crear roles en la 
 Al tener al menos un rol se desbloquea el uso de la tarea de invitación.
 La invitación solo puede ser para tareas o pasos anteriores a la tarea de invitación.
 En la tarea se elige el rol, el correo que se envía y cuales son las tareas que tiene que realizar el rol.
+
+### Confirmación
+
+La tarea de Confirmación muestra al usuario un resumen de las respuestas que entregó en tareas Input anteriores, para que las revise y confirme antes de continuar con el flujo.
+
+Al configurar la tarea, en **Seleccionar ítems a confirmar** eliges las tareas cuyas respuestas se incluirán en el resumen, agrupadas por paso. Solo puedes seleccionar tareas de tipo **Input** anteriores a la tarea de confirmación.
+
+El usuario ve cada tarea seleccionada con sus respuestas y un enlace **Editar** que lo lleva directamente a esa tarea para corregirla. Al presionar **Confirmar**, la tarea se completa y el flujo continúa. Para completar la tarea, todos los ítems configurados deben estar confirmados.
+
+En los detalles de una respuesta, las tareas de confirmación completadas muestran el listado de **Tareas confirmadas**.
 
 ### Lógica Condicional
 


### PR DESCRIPTION
Documenta la tarea de Confirmación de originaciones, introducida en modyo/modyo#19173.

## Cambios propuestos

Se actualiza la documentación de Origination (`docs/es/platform/customers/origination.md` y su versión en inglés):

- Se agrega **Confirmación** al listado de tipos de tareas.
- Nueva sección **Confirmación** documentando: el resumen de respuestas de tareas Input anteriores, la configuración con **Seleccionar ítems a confirmar** (solo tareas Input anteriores, agrupadas por paso), el enlace **Editar** para corregir respuestas, el botón **Confirmar**, la regla de que todos los ítems configurados deben confirmarse, y el listado de **Tareas confirmadas** visible en los detalles de la respuesta.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)