### PR TITLE
Asignación a grupos / segmento / balanceo

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -101,6 +101,12 @@ When selecting a field, you can modify its properties by going to the **Edit** t
 The validation task requires manual review by the assigned agent. They must validate the data provided by the user to unlock the next task in the flow.
 The task is refreshed every 5 seconds so that the end user knows if the task has been validated.
 
+When configuring the task, you can define an **Assignee**: an administrator or a group of administrators responsible for the validations. When selecting a group, you can assign the whole group or a specific user within it. If you do not define an assignee, validations are assigned by default to the submission assignee.
+
+Assigned administrators receive an email when a validation is pending and can also review it from the **My tasks** view in the main menu, filtering by the **Validation review** task type. The user receives an internal notification when their task is approved or rejected.
+
+In a specific submission, you can reassign the validation from the **Validations** tab of the submission, once the user has completed the tasks to validate.
+
 ### Signature
 
 The signature task allows for a simple signature with a checkbox or an advanced one when a digital signature provider is installed in the realm integrations.
@@ -109,6 +115,8 @@ The signature task allows for a simple signature with a checkbox or an advanced 
 
 The pending review task pauses the origination process. It is used to trigger asynchronous processes, usually in external systems.
 The task is refreshed every 5 seconds so that the end user knows if the task has been reviewed.
+
+As with validation tasks, you can define an **Assignee** for the task: an administrator or a group of administrators. If you do not define one, the review is assigned by default to the submission assignee.
 
 
 ### Code Snippet
@@ -432,7 +440,7 @@ By selecting the **Edit** option in the context menu of your origination, you ca
 - **Name**: Defines the name of the origination, visible to users in the interface.
 - **Description**: Includes a brief explanatory text about the purpose of the origination.
 - **Completed message**: This is the message that will appear to the user at the end of the origination process.
-- **Default submission assignee**: Specifies the person who will be automatically assigned when receiving a new origination.
+- **Default submission assignee**: Specifies the administrator or group of administrators that will be automatically assigned to each new submission. When selecting a group, you can use the **Assign to whole group** option or choose a specific user within it.
 - **Due in**: Sets a maximum deadline for completing the origination.
 - **Completion rules**: Defines the completion behavior for each submission.
 - **Privacy**: Allows you to restrict access to the origination flow to certain predefined user segments.
@@ -535,7 +543,9 @@ In addition to the search, you can narrow down the submission list with the foll
 
 #### Assign submission
 
-In the list of submissions, select the actions menu and press the **Assign** option. In the context menu, select an administrator for this submission.
+In the list of submissions, select the actions menu and press the **Assign** option. In the modal, you can assign the submission to an administrator, to a whole group of administrators, or to a specific user within a group. You can also use the **Assign to me** option to assign the submission directly to yourself.
+
+When assigning to a whole group, all its members can view and manage the submission. The **Assigned** column of the list shows the assigned group or administrator; if the administrator was chosen from a group, the group name is also displayed.
 
 #### Cancel submission
 

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -105,7 +105,7 @@ When configuring the task, you can define an **Assignee**: an administrator or a
 
 Assigned administrators receive an email when a validation is pending and can also review it from the **My tasks** view in the main menu, filtering by the **Validation review** task type. The user receives an internal notification when their task is approved or rejected.
 
-In a specific submission, you can reassign the validation from the **Validations** tab of the submission, once the user has completed the tasks to validate.
+In a specific submission, you can reassign the validation from the **Validations** tab, once the user has completed the tasks to validate.
 
 ### Signature
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -99,13 +99,13 @@ Al seleccionar un campo, puedes modificar sus propiedades al dirigirte a  la pes
 ### Validación
 
 La tarea de validación requiere una revisión manual del agente asignado. Este debe validar los datos entregados por el usuario para desbloquear la siguiente tarea del flujo. 
-Se hace un refrezco de la tarea cada 5 segundo para que usuario final sepa si la tarea fue validada.
+Se hace un refresco de la tarea cada 5 segundos para que el usuario final sepa si la tarea fue validada.
 
-Al configurar la tarea puedes definir un **Asignado**: un administrador o un grupo de administradores responsable de las validaciones. Al seleccionar un grupo puedes asignar a todo el grupo o a un usuario específico dentro de él. Si no defines un asignado, las validaciones se asignan de forma predeterminada al asignado de la respuesta.
+Al configurar la tarea, puedes definir un **Asignado**: un administrador o un grupo de administradores responsable de las validaciones. Al seleccionar un grupo, puedes asignar a todo el grupo o a un usuario específico dentro de él. Si no defines un asignado, las validaciones se asignan de forma predeterminada al asignado de la respuesta.
 
 Los administradores asignados reciben un correo cuando una validación queda pendiente y también pueden revisarla desde la vista **Mis tareas** del menú principal, filtrando por el tipo de tarea **Revisión de validación**. El usuario recibe una notificación interna cuando su tarea es aprobada o rechazada.
 
-En una respuesta específica, puedes reasignar la validación desde la pestaña **Validaciones** de la respuesta, una vez que el usuario haya completado las tareas a validar.
+En una respuesta específica, puedes reasignar la validación desde la pestaña **Validaciones**, una vez que el usuario haya completado las tareas a validar.
 
 ### Firma
 
@@ -114,7 +114,7 @@ La tarea de firma permite una firma simple con un checkbox o una avanzada cuando
 ### Revisión pendiente
 
 La tarea de revisión pendiente pausa el proceso de originación. Se usa para gatillar procesos asíncronos, generalmente en sistemas externos.
-Se hace un refrezco de la tarea cada 5 segundo para que usuario final sepa si la tarea fue revisada.
+Se hace un refresco de la tarea cada 5 segundos para que el usuario final sepa si la tarea fue revisada.
 
 Al igual que en las tareas de validación, puedes definir un **Asignado** para la tarea: un administrador o un grupo de administradores. Si no defines uno, la revisión se asigna de forma predeterminada al asignado de la respuesta.
 
@@ -544,7 +544,7 @@ Además de la búsqueda, puedes acotar el listado de respuestas con los siguient
 
 #### Asignar respuesta
 
-En el listado de respuestas, selecciona el menú acciones y presiona la opción **Asignar**. En el modal puedes asignar la respuesta a un administrador, a un grupo de administradores completo o a un usuario específico dentro de un grupo. También puedes usar la opción **Asígname** para asignarte la respuesta directamente.
+En el listado de respuestas, selecciona el menú de acciones y presiona la opción **Asignar**. En el modal puedes asignar la respuesta a un administrador, a un grupo completo de administradores o a un usuario específico dentro de un grupo. También puedes usar la opción **Asígname** para asignarte la respuesta directamente.
 
 Al asignar a todo un grupo, todos sus miembros pueden ver y gestionar la respuesta. La columna **Asignado** del listado muestra el grupo o el administrador asignado; si el administrador fue elegido desde un grupo, se muestra también el nombre del grupo.
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -101,6 +101,12 @@ Al seleccionar un campo, puedes modificar sus propiedades al dirigirte a  la pes
 La tarea de validación requiere una revisión manual del agente asignado. Este debe validar los datos entregados por el usuario para desbloquear la siguiente tarea del flujo. 
 Se hace un refrezco de la tarea cada 5 segundo para que usuario final sepa si la tarea fue validada.
 
+Al configurar la tarea puedes definir un **Asignado**: un administrador o un grupo de administradores responsable de las validaciones. Al seleccionar un grupo puedes asignar a todo el grupo o a un usuario específico dentro de él. Si no defines un asignado, las validaciones se asignan de forma predeterminada al asignado de la respuesta.
+
+Los administradores asignados reciben un correo cuando una validación queda pendiente y también pueden revisarla desde la vista **Mis tareas** del menú principal, filtrando por el tipo de tarea **Revisión de validación**. El usuario recibe una notificación interna cuando su tarea es aprobada o rechazada.
+
+En una respuesta específica, puedes reasignar la validación desde la pestaña **Validaciones** de la respuesta, una vez que el usuario haya completado las tareas a validar.
+
 ### Firma
 
 La tarea de firma permite una firma simple con un checkbox o una avanzada cuando hay algun proveedor de firma digital instalado en las integraciones del reino.
@@ -109,6 +115,8 @@ La tarea de firma permite una firma simple con un checkbox o una avanzada cuando
 
 La tarea de revisión pendiente pausa el proceso de originación. Se usa para gatillar procesos asíncronos, generalmente en sistemas externos.
 Se hace un refrezco de la tarea cada 5 segundo para que usuario final sepa si la tarea fue revisada.
+
+Al igual que en las tareas de validación, puedes definir un **Asignado** para la tarea: un administrador o un grupo de administradores. Si no defines uno, la revisión se asigna de forma predeterminada al asignado de la respuesta.
 
 
 ### Snippet de código
@@ -433,7 +441,7 @@ Al seleccionar la opción **Editar** en el menu contextual de tu orignación pue
 - **Nombre**: Define el nombre de la originación, visible para los usuarios en la interfaz.
 - **Descripción**: Incluye un breve texto explicativo sobre el propósito de la originación.
 - **Mensaje de completado**: Es el mensaje que aparecerá al usuario al finalizar el proceso de originación.
-- **Asignado por defecto de la respuesta**: especifica la persona que será asignada automáticamente al recibir una nueva originación.
+- **Asignado por defecto de la respuesta**: Especifica el administrador o grupo de administradores que será asignado automáticamente a cada nueva respuesta. Al seleccionar un grupo, puedes usar la opción **Asignar a todo el grupo** o elegir un usuario específico dentro de él.
 - **Vence en**:  Establece un plazo máximo para completar la originación.
 - **Reglas de completado**:  Define el comportamiento de completado para cada respuesta.
 - **Privacidad**: Permite restringir el acceso al flujo de originación a ciertos segmentos de usuarios predefinidos.
@@ -536,7 +544,9 @@ Además de la búsqueda, puedes acotar el listado de respuestas con los siguient
 
 #### Asignar respuesta
 
-En el listado de respuestas, selecciona el menú acciones y presiona la opción **Asignar**. En el menú contextual selecciona a un administrador para esta respuesta.
+En el listado de respuestas, selecciona el menú acciones y presiona la opción **Asignar**. En el modal puedes asignar la respuesta a un administrador, a un grupo de administradores completo o a un usuario específico dentro de un grupo. También puedes usar la opción **Asígname** para asignarte la respuesta directamente.
+
+Al asignar a todo un grupo, todos sus miembros pueden ver y gestionar la respuesta. La columna **Asignado** del listado muestra el grupo o el administrador asignado; si el administrador fue elegido desde un grupo, se muestra también el nombre del grupo.
 
 #### Cancelar respuesta
 


### PR DESCRIPTION
Documenta la asignación de respuestas y tareas de originación a grupos de administradores, introducida en modyo/modyo#18742.

## Cambios propuestos

Se actualiza la documentación de Origination (`docs/es/platform/customers/origination.md` y su versión en inglés):

- **Asignar respuesta**: el modal ahora permite asignar a un administrador, a un grupo completo o a un usuario específico dentro de un grupo, con la opción **Asígname**; se documenta la visibilidad para los miembros del grupo y cómo se muestra la columna **Asignado**.
- **Asignado por defecto de la respuesta**: se documenta la selección de grupo o usuario dentro de un grupo con la opción **Asignar a todo el grupo**.
- **Validación**: se documenta el campo **Asignado** de la tarea (administrador o grupo), el default al asignado de la respuesta, el correo a los asignados, la vista **Mis tareas** con el tipo **Revisión de validación**, la notificación interna al usuario al aprobar/rechazar, y la reasignación desde la pestaña Validaciones de una respuesta.
- **Revisión pendiente**: se documenta el campo **Asignado** con el mismo comportamiento.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)