### PR TITLE
Branding a nivel de cuenta

### DIFF
--- a/docs/en/platform/core/configuration.md
+++ b/docs/en/platform/core/configuration.md
@@ -26,8 +26,8 @@ If the time zone you choose is subject to time changes, these will be automatica
 ### Visualization
 
 - **Don't show the first steps page**: Enabling this option hides the first steps button for all users.
-- **Account logo**: Personalize the platform by uploading a logo for all users. The logo is also displayed on the platform login, password recovery, and transactional emails.
-- **Account favicon**: Favicon for the account pages and default in the apps.
+- **Account logo**: Personalize the platform by uploading a logo for all users. The logo is also displayed on the platform login page, password recovery, and transactional emails.
+- **Account favicon**: Favicon displayed on the account pages and used by default in the apps.
 - **Google API key**: The API key used to connect the Google Maps API to the location-type fields in the Content module.
 
 #### Theme colors

--- a/docs/en/platform/core/configuration.md
+++ b/docs/en/platform/core/configuration.md
@@ -26,8 +26,20 @@ If the time zone you choose is subject to time changes, these will be automatica
 ### Visualization
 
 - **Don't show the first steps page**: Enabling this option hides the first steps button for all users.
-- **Account logo and favicon**: Personalize the platform by uploading a logo and favicon for all users. These elements will also be used on default pages and sites.
+- **Account logo**: Personalize the platform by uploading a logo for all users. The logo is also displayed on the platform login, password recovery, and transactional emails.
+- **Account favicon**: Favicon for the account pages and default in the apps.
 - **Google API key**: The API key used to connect the Google Maps API to the location-type fields in the Content module.
+
+#### Theme colors
+
+In this section, you can customize the color palette of the entire account administration interface, including the login page. The colors you can define are:
+
+- **Primary color** and **Primary hover color**: Colors for the main buttons and elements.
+- **Accent color** and **Accent hover color**: Colors for secondary elements and links.
+- **Navigation selected text** and **Navigation selected background**: Colors of the active element in the navigation.
+- **Page background**: General background color of the interface.
+
+When saving a color change, the page reloads to apply the new theme across the entire interface. The **Reset to default** button returns you to the original Modyo palette.
 
 ## Profile Settings
 

--- a/docs/es/platform/core/configuration.md
+++ b/docs/es/platform/core/configuration.md
@@ -26,8 +26,20 @@ Si la zona horaria que eliges está sujeta a cambios de horarios, estos se refle
 ### Visualización
 
 - **No mostrar la página de primeros pasos**: Al habilitar esta opción ocultas el botón de primeros pasos para todos los usuarios.
-- **Logo y favicon de la cuenta**: Personaliza la plataforma subiendo un logo y favicon para todos los usuarios. Estos elementos también serán usados en las páginas y sitios por defecto.
+- **Logo de la cuenta**: Personaliza la plataforma subiendo un logo para todos los usuarios. El logo se muestra también en el inicio de sesión de la plataforma, en la recuperación de contraseña y en los correos transaccionales.
+- **Favicon de la cuenta**: Favicon para las páginas de la cuenta y por defecto en las aplicaciones.
 - **API key de Google**: La API key utilizada para conectar la API de Google Maps en los campos de tipo ubicación en el módulo Content.
+
+#### Colores del tema
+
+En esta sección puedes personalizar la paleta de colores de toda la interfaz de administración de la cuenta, incluida la página de inicio de sesión. Los colores que puedes definir son:
+
+- **Color principal** y **Color principal al pasar el cursor**: Colores de los botones y elementos principales.
+- **Color de acento** y **Color de acento al pasar el cursor**: Colores de los elementos secundarios y enlaces.
+- **Texto de navegación seleccionado** y **Fondo de navegación seleccionado**: Colores del elemento activo en la navegación.
+- **Fondo de página**: Color de fondo general de la interfaz.
+
+Al guardar un cambio de color, la página se recarga para aplicar el nuevo tema en toda la interfaz. Con el botón **Restablecer a predeterminado** vuelves a la paleta original de Modyo.
 
 ## Configuración de Perfil
 

--- a/docs/es/platform/core/configuration.md
+++ b/docs/es/platform/core/configuration.md
@@ -27,7 +27,7 @@ Si la zona horaria que eliges está sujeta a cambios de horarios, estos se refle
 
 - **No mostrar la página de primeros pasos**: Al habilitar esta opción ocultas el botón de primeros pasos para todos los usuarios.
 - **Logo de la cuenta**: Personaliza la plataforma subiendo un logo para todos los usuarios. El logo se muestra también en el inicio de sesión de la plataforma, en la recuperación de contraseña y en los correos transaccionales.
-- **Favicon de la cuenta**: Favicon para las páginas de la cuenta y por defecto en las aplicaciones.
+- **Favicon de la cuenta**: Favicon que se muestra en las páginas de la cuenta y se usa por defecto en las aplicaciones.
 - **API key de Google**: La API key utilizada para conectar la API de Google Maps en los campos de tipo ubicación en el módulo Content.
 
 #### Colores del tema


### PR DESCRIPTION
Documenta el branding a nivel de cuenta (modyo/modyo#18062, trabajo mergeado vía modyo/modyo#18433).

## Cambios propuestos

Se actualiza la sección **Visualización** de la configuración general de la cuenta (`docs/es/platform/core/configuration.md` y su versión en inglés):

- Se separan y detallan el **Logo de la cuenta** (visible también en el inicio de sesión, recuperación de contraseña y correos transaccionales) y el **Favicon de la cuenta**.
- Nueva subsección **Colores del tema** con los 7 colores personalizables de la interfaz de administración (principal, acento, navegación seleccionada y fondo de página, con sus variantes hover), el comportamiento de recarga al guardar y el botón **Restablecer a predeterminado**.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)