### PR TITLE
Bookmarks para crear links directos a secciones del admin

### DIFF
--- a/docs/en/platform/core/README.md
+++ b/docs/en/platform/core/README.md
@@ -46,7 +46,17 @@ The access and permission management system implements a role-based security mod
 
 The user experience is optimized for operational productivity, incorporating features such as configurable dashboards with real-time metrics, contextual search tools with advanced filters, batch operations for mass content management, and adaptive navigation that presents relevant options according to the user's context and permissions. The interface abstracts the platform's technical complexity while exposing advanced configuration capabilities, allowing both business users and developers to fully leverage the digital platform's capabilities.
 
+### Bookmarks
 
+Bookmarks allow you to create shortcuts to the sections of the platform you use the most. They are personal: each administrator manages their own bookmarks.
+
+To create a bookmark, click the bookmark icon with the **Add Bookmark** tooltip that appears next to the items in the side menus of each module and next to the pages of a site. The icon fills in to indicate that the section has been bookmarked; click it again to remove the bookmark.
+
+To use your bookmarks, click the **Bookmarks** icon at the top of the main sidebar. The **My Bookmarks** window opens with your saved shortcuts, sorted with the most used first. Click a bookmark to navigate to that section, or use the trash icon to delete it.
+
+:::tip Tip
+Bookmarking the same section twice does not create duplicates: if the bookmark already exists, the original is kept.
+:::
 
 ## Versioning
 

--- a/docs/es/platform/core/README.md
+++ b/docs/es/platform/core/README.md
@@ -45,6 +45,17 @@ El sistema de gestión de accesos y permisos implementa un modelo de seguridad b
 
 La experiencia de usuario está optimizada para la productividad operativa, incorporando funcionalidades como dashboards configurables con métricas en tiempo real, herramientas de búsqueda contextual con filtros avanzados, operaciones batch para gestión masiva de contenidos, y navegación adaptativa que presenta opciones relevantes según el contexto y permisos del usuario. La interfaz abstrae la complejidad técnica de la plataforma mientras expone capacidades avanzadas de configuración, permitiendo que tanto usuarios de negocio como desarrolladores puedan aprovechar completamente las capacidades de la plataforma digital.
 
+### Marcadores
+
+Los marcadores te permiten crear accesos directos a las secciones de la plataforma que más utilizas. Son personales: cada administrador gestiona sus propios marcadores.
+
+Para crear un marcador, haz clic en el ícono de marcador con el tooltip **Añadir Marcador** que aparece junto a los ítems de los menús laterales de cada módulo y junto a las páginas de un sitio. El ícono se rellena para indicar que la sección quedó marcada; haz clic nuevamente para quitar el marcador.
+
+Para usar tus marcadores, haz clic en el ícono **Marcadores** en la parte superior de la barra lateral principal. Se abre la ventana **Mis Marcadores** con tus accesos guardados, ordenados con los más utilizados primero. Haz clic en un marcador para navegar a esa sección, o usa el ícono de papelera para eliminarlo.
+
+:::tip Tip
+Marcar dos veces la misma sección no crea duplicados: si el marcador ya existe, se conserva el original.
+:::
 
 ## Versionado
 


### PR DESCRIPTION
Documenta los marcadores del admin para crear accesos directos a secciones de la plataforma (modyo/modyo#18138).

## Cambios propuestos

Se agrega la sección **Marcadores** dentro de "Sobre la Interfaz" en la documentación de plataforma (`docs/es/platform/core/README.md` y su versión en inglés):

- Cómo crear un marcador con el ícono **Añadir Marcador** junto a los ítems de los menús laterales y las páginas de un sitio, y cómo quitarlo.
- Cómo usar los marcadores desde el ícono **Marcadores** de la barra lateral principal y la ventana **Mis Marcadores** (orden por uso, navegación y eliminación).
- Se aclara que los marcadores son personales por administrador y que no se crean duplicados.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)