### PR TITLE
Incorporar las respuestas de una originación como base para crear segmentos

### DIFF
--- a/docs/en/platform/customers/segments.md
+++ b/docs/en/platform/customers/segments.md
@@ -84,7 +84,7 @@ The **Submission status** and **Task status** filters allow you to segment users
 - **Submission status**: Select an origination and the status of the submission: **Not started**, **Pending**, **Completed**, or **Canceled**. If the origination allows multiple submissions per user, you also define a condition: **All** (all of the user's submissions must meet the status) or **Any** (one is enough).
 - **Task status**: Select an origination and then a specific task within its steps, along with the status of that task: **Not started**, **Pending**, or **Completed**.
 
-Both filters include the **since [X] days or more** field, which narrows the segment down to users who have been in the selected status for at least that many days. For example, you can create a segment with the users who have had a pending task for more than 3 days and send them a reminder campaign.
+Both filters include the **since [X] days or more** field, which narrows the segment down to users who have been in the selected status for at least that many days. For example, you can create a segment with the users who have had a pending task for at least 3 days and send them a reminder campaign.
 
 To exclude users who meet the condition, use the filter's **Users who don't match** option.
 

--- a/docs/en/platform/customers/segments.md
+++ b/docs/en/platform/customers/segments.md
@@ -38,6 +38,8 @@ The default filters available on the platform include:
 
 - Activation status
 - Age
+- Submission status (of an origination)
+- Task status (of an origination)
 - Form responses
 - Birth date
 - Custom field value
@@ -75,6 +77,16 @@ The update of segments to which a user belongs is performed as a background proc
 The speed of the update depends on the system load, so some users might not see segmented content immediately after performing actions that include or exclude them from a segment.
 :::
 
+### Origination filters
+
+The **Submission status** and **Task status** filters allow you to segment users according to their progress in the realm's [originations](/en/platform/customers/origination.html):
+
+- **Submission status**: Select an origination and the status of the submission: **Not started**, **Pending**, **Completed**, or **Canceled**. If the origination allows multiple submissions per user, you also define a condition: **All** (all of the user's submissions must meet the status) or **Any** (one is enough).
+- **Task status**: Select an origination and then a specific task within its steps, along with the status of that task: **Not started**, **Pending**, or **Completed**.
+
+Both filters include the **since [X] days or more** field, which narrows the segment down to users who have been in the selected status for at least that many days. For example, you can create a segment with the users who have had a pending task for more than 3 days and send them a reminder campaign.
+
+To exclude users who meet the condition, use the filter's **Users who don't match** option.
 
 ## Delete a segment
 

--- a/docs/es/platform/customers/segments.md
+++ b/docs/es/platform/customers/segments.md
@@ -38,6 +38,8 @@ Los filtros predeterminados en la plataforma incluyen:
 
 - Estado de activación
 - Edad
+- Estado de respuesta (de una originación)
+- Estado de tarea (de una originación)
 - Respuestas de formulario
 - Fecha de nacimiento
 - Valor de custom field
@@ -75,6 +77,16 @@ La actualización de segmentos a los que pertenece un usuario se realiza en un p
 La velocidad de la actualización depende de la carga del sistema, por lo que algunos usuarios podrían no ver contenido segmentado de inmediato tras realizar acciones que los incluyen o excluyen de un segmento.
 :::
 
+### Filtros de originación
+
+Los filtros **Estado de respuesta** y **Estado de tarea** te permiten segmentar usuarios según su avance en las [originaciones](/es/platform/customers/origination.html) del reino:
+
+- **Estado de respuesta**: Selecciona una originación y el estado de la respuesta: **No Iniciada**, **Pendiente**, **Completada** o **Cancelada**. Si la originación permite múltiples respuestas por usuario, defines además una condición: **Todos** (todas las respuestas del usuario deben cumplir el estado) o **Cualquiera** (basta con que una lo cumpla).
+- **Estado de tarea**: Selecciona una originación y luego una tarea específica dentro de sus pasos, junto con el estado de esa tarea: **No Iniciada**, **Pendiente** o **Completada**.
+
+Ambos filtros incluyen el campo **desde [X] o más días**, que acota el segmento a los usuarios que llevan al menos esa cantidad de días en el estado seleccionado. Por ejemplo, puedes crear un segmento con los usuarios que llevan más de 3 días con una tarea pendiente y enviarles una campaña de recordatorio.
+
+Para excluir usuarios que cumplen la condición, usa la opción **Usuarios que no coinciden** del filtro.
 
 ## Borrar un Segmento
 

--- a/docs/es/platform/customers/segments.md
+++ b/docs/es/platform/customers/segments.md
@@ -84,7 +84,7 @@ Los filtros **Estado de respuesta** y **Estado de tarea** te permiten segmentar 
 - **Estado de respuesta**: Selecciona una originación y el estado de la respuesta: **No Iniciada**, **Pendiente**, **Completada** o **Cancelada**. Si la originación permite múltiples respuestas por usuario, defines además una condición: **Todos** (todas las respuestas del usuario deben cumplir el estado) o **Cualquiera** (basta con que una lo cumpla).
 - **Estado de tarea**: Selecciona una originación y luego una tarea específica dentro de sus pasos, junto con el estado de esa tarea: **No Iniciada**, **Pendiente** o **Completada**.
 
-Ambos filtros incluyen el campo **desde [X] o más días**, que acota el segmento a los usuarios que llevan al menos esa cantidad de días en el estado seleccionado. Por ejemplo, puedes crear un segmento con los usuarios que llevan más de 3 días con una tarea pendiente y enviarles una campaña de recordatorio.
+Ambos filtros incluyen el campo **desde [X] o más días**, que acota el segmento a los usuarios que llevan al menos esa cantidad de días en el estado seleccionado. Por ejemplo, puedes crear un segmento con los usuarios que llevan al menos 3 días con una tarea pendiente y enviarles una campaña de recordatorio.
 
 Para excluir usuarios que cumplen la condición, usa la opción **Usuarios que no coinciden** del filtro.
 


### PR DESCRIPTION
Documenta los filtros de segmentos basados en respuestas de originación, introducidos en modyo/modyo#18662.

## Cambios propuestos

Se actualiza la documentación de Segmentos (`docs/es/platform/customers/segments.md` y su versión en inglés):

- Se agregan **Estado de respuesta** y **Estado de tarea** al listado de filtros disponibles.
- Nueva subsección **Filtros de originación** documentando: la selección de originación y estados disponibles por filtro, la condición **Todos/Cualquiera** para originaciones con múltiples respuestas, el selector jerárquico de paso/tarea, el campo de temporalidad **desde [X] o más días** con un ejemplo de uso (recordatorios a usuarios con tareas pendientes), y la exclusión mediante **Usuarios que no coinciden**.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)