### PR TITLE
Permitir configurar en el reino acción por defecto (login o signup)

### DIFF
--- a/docs/en/platform/customers/settings.md
+++ b/docs/en/platform/customers/settings.md
@@ -23,6 +23,7 @@ Before enabling the option to disable Modyo credentials in the realm, make sure 
 
 - **After logging in, redirect to**: Allows you to choose a specific URL to direct the user to, once they have entered the realm. If you don't activate the “Force Redirect” option, the user will be redirected to the URL entered only if it is not possible to return to the URL from which they logged in.
 - **Force redirection to**: By activating this option, the user will always be redirected to the URL specified in the login redirect field, regardless of where they started the session.
+- **On session required redirect to**: Defines where a visitor without a session is sent when trying to access content that requires authentication: to the **Login page** (default option) or to the realm's **Signup page**. In both cases, after authenticating, the user returns to the URL they were trying to access.
 - **Account Activation**:
   - Direct: Users who register can log in directly.
   - Activation email: Users who register must activate their account by clicking on a link sent to their email before being able to log in.

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -23,7 +23,7 @@ Antes de habilitar la opción de deshabilitar las credenciales de Modyo en el re
 
 - **Después de iniciar sesión, redirigir a**: Te permite elegir una URL específica a la cual dirigir al usuario, una vez que haya ingresado al reino. Si no activas la opción de "Forzar redirección", el usuario será redirigido a la URL ingresada solo si no es posible volver a la URL desde la que inició sesión.
 - **Forzar la redirección a**: Al activar esta opción, el usuario siempre será redirigido a la URL especificada en el campo de redirección del inicio de sesión, sin importar desde dónde inició la sesión.
-- **Cuando se requiere iniciar sesión, redirigir a**: Define a dónde se dirige a un visitante sin sesión cuando intenta acceder a contenido que requiere autenticación: a la **Página de inicio de sesión** (opción por defecto) o a la **Página de registro** del reino. En ambos casos, tras autenticarse, el usuario vuelve a la URL a la que intentaba acceder.
+- **Cuando se requiere iniciar sesión, redirigir a**: Define a dónde se redirige a un visitante sin sesión cuando intenta acceder a contenido que requiere autenticación: a la **Página de inicio de sesión** (opción por defecto) o a la **Página de registro** del reino. En ambos casos, tras autenticarse, el usuario vuelve a la URL a la que intentaba acceder.
 - **Activación de la cuenta**:
   - Directa: Los usuarios que se registren pueden iniciar sesión directamente.
   - E-mail de activación: Los usuarios que se registren deben activar su cuenta mediante un enlace enviado a su correo electrónico previo a poder iniciar sesión.

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -23,6 +23,7 @@ Antes de habilitar la opción de deshabilitar las credenciales de Modyo en el re
 
 - **Después de iniciar sesión, redirigir a**: Te permite elegir una URL específica a la cual dirigir al usuario, una vez que haya ingresado al reino. Si no activas la opción de "Forzar redirección", el usuario será redirigido a la URL ingresada solo si no es posible volver a la URL desde la que inició sesión.
 - **Forzar la redirección a**: Al activar esta opción, el usuario siempre será redirigido a la URL especificada en el campo de redirección del inicio de sesión, sin importar desde dónde inició la sesión.
+- **Cuando se requiere iniciar sesión, redirigir a**: Define a dónde se dirige a un visitante sin sesión cuando intenta acceder a contenido que requiere autenticación: a la **Página de inicio de sesión** (opción por defecto) o a la **Página de registro** del reino. En ambos casos, tras autenticarse, el usuario vuelve a la URL a la que intentaba acceder.
 - **Activación de la cuenta**:
   - Directa: Los usuarios que se registren pueden iniciar sesión directamente.
   - E-mail de activación: Los usuarios que se registren deben activar su cuenta mediante un enlace enviado a su correo electrónico previo a poder iniciar sesión.


### PR DESCRIPTION
Documenta la configuración de la acción por defecto del reino cuando se requiere sesión, introducida en modyo/modyo#19405.

## Cambios propuestos

Se actualiza la sección **General** de la configuración de reino (`docs/es/platform/customers/settings.md` y su versión en inglés):

- Se agrega la nueva opción **Cuando se requiere iniciar sesión, redirigir a**, que permite elegir entre la **Página de inicio de sesión** (por defecto) y la **Página de registro** del reino para los visitantes sin sesión que acceden a contenido protegido, aclarando que en ambos casos el usuario vuelve a la URL original tras autenticarse.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)