### PR TITLE
Flujo de reintentos de una task ya completada

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -547,6 +547,16 @@ To delete an individual submission, select the menu in the actions column and pr
 
 To delete several submissions at the same time, select each entry by checking the corresponding box and press the delete button.
 
+#### Reopen tasks of a submission
+
+Through the [administration API](/en/platform/core/api.html), you can individually manage the task responses of a submission: view them, transition their status (start, complete, or **reopen** an already completed task so the user can answer it again), and delete them individually or in bulk.
+
+Consider the following:
+
+- Changing the status of a task response requires the **Change Status of Task Response** permission; deleting them requires the delete submissions permission.
+- These operations are only available while the submission is in **Not started** or **Pending** status.
+- All operations are recorded in the platform activity.
+
 #### Invite users
 
 You can invite users to enter information in an origination. When inviting a user, you will need to enter their basic information:

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -553,7 +553,7 @@ Through the [administration API](/en/platform/core/api.html), you can individual
 
 Consider the following:
 
-- Changing the status of a task response requires the **Change Status of Task Response** permission; deleting them requires the delete submissions permission.
+- Changing the status of a task response requires the **Change Status of Task Response** permission; deleting task responses requires the **Delete Submissions** permission.
 - These operations are only available while the submission is in **Not started** or **Pending** status.
 - All operations are recorded in the platform activity.
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -554,7 +554,7 @@ A través de la [API de administración](/es/platform/core/api.html) puedes gest
 
 Considera lo siguiente:
 
-- Cambiar el estado de una respuesta a tarea requiere el permiso **Cambiar estado de la Respuesta de una Tarea**; eliminarlas requiere el permiso de eliminar respuestas.
+- Cambiar el estado de una respuesta a tarea requiere el permiso **Cambiar estado de la Respuesta de una Tarea**; eliminar respuestas a tareas requiere el permiso **Eliminar Respuestas**.
 - Estas operaciones solo están disponibles mientras la respuesta está en estado **No Iniciada** o **Pendiente**.
 - Todas las operaciones quedan registradas en la actividad de la plataforma.
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -548,6 +548,16 @@ Para eliminar una respuesta individual, selecciona el menú en la columna action
 
 Para eliminar varias respuestas al mismo tiempo, selecciona cada entrada marcando la casilla correspondiente y presiona el botón eliminar.
 
+#### Reabrir tareas de una respuesta
+
+A través de la [API de administración](/es/platform/core/api.html) puedes gestionar individualmente las respuestas a tareas de una respuesta: consultarlas, cambiarlas de estado (iniciar, completar o **reabrir** una tarea ya completada para que el usuario vuelva a responderla) y eliminarlas de forma individual o masiva.
+
+Considera lo siguiente:
+
+- Cambiar el estado de una respuesta a tarea requiere el permiso **Cambiar estado de la Respuesta de una Tarea**; eliminarlas requiere el permiso de eliminar respuestas.
+- Estas operaciones solo están disponibles mientras la respuesta está en estado **No Iniciada** o **Pendiente**.
+- Todas las operaciones quedan registradas en la actividad de la plataforma.
+
 #### Invitar usuarios
 
 Puedes invitar a usuarios para que ingresen información en una originación. Al invitar a un usuario, deberás ingresar su información básica


### PR DESCRIPTION
Documenta el flujo de reintentos de tareas ya completadas, introducido en modyo/modyo#19419.

## Cambios propuestos

Se agrega la subsección **Reabrir tareas de una respuesta** en Gestión de Respuestas de la documentación de Origination (`docs/es/platform/customers/origination.md` y su versión en inglés):

- Se documenta la gestión individual de respuestas a tareas vía API de administración: consulta, transiciones de estado (iniciar, completar, reabrir) y eliminación individual o masiva.
- Se documentan las reglas: permiso **Cambiar estado de la Respuesta de una Tarea** para las transiciones, permiso de eliminación para los borrados, disponibilidad solo con la respuesta en estado No Iniciada o Pendiente, y registro en la actividad de la plataforma.

Los nombres de la interfaz y permisos fueron validados contra los locales de la rama master de modyo/modyo. El detalle de los endpoints queda en la documentación Swagger del producto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)