### PR TITLE
Integración Auronix

### DIFF
--- a/docs/en/platform/customers/settings.md
+++ b/docs/en/platform/customers/settings.md
@@ -29,7 +29,7 @@ Before enabling the option to disable Modyo credentials in the realm, make sure 
   - Moderate: Users who register must wait for a realm administrator to activate their account before they can log in.
   - Disabled: New users cannot be registered in the realm. Already registered and activated users can still log in.
 - **Default Avatar Image**: Image shown on the avatar of users who do not have a custom image.
-- **Enable Soft Login**: By activating this option you can access your account without entering your credentials each time. You will receive a security code in your email for easy login without the need for passwords.
+- **Enable Soft Login**: By activating this option you can access your account without entering your credentials each time. You will receive a security code through the configured delivery channel (email or WhatsApp) for easy login without the need for passwords.
 - **OTP delivery channel**: Default channel for the soft login security codes: **Email** sends the code to the user's address; **Phone** sends it via WhatsApp and requires an enabled messaging integration, such as [Auronix](#auronix).
 - **Registration form**: Here you can enable or disable different attributes in the registration form, such as the second surname, email confirmation, user avatar, date of birth, gender, and phone number.
 - **Delete realm**: Deletes the realm. This process is performed in the background, so you may not see the realm disappear immediately after executing the action. To confirm the deletion, you must enter the full name of the realm.

--- a/docs/en/platform/customers/settings.md
+++ b/docs/en/platform/customers/settings.md
@@ -287,13 +287,13 @@ The Auronix integration, of the messaging category, allows sending WhatsApp mess
 
 To enable it, the realm's registration form must have the phone field **enabled and required**. While the integration is enabled, those registration form options remain locked.
 
-In the **Credentials** section, complete:
+In the **Credentials** section, fill in the following fields:
 
 - **API Key**: Auronix API Key for authentication.
 - **WhatsApp Channel**: WhatsApp outgoing line number. It must be a valid Mexican phone number.
 - **Base URL**: Leave it blank to use the platform default; only override it for sandbox or custom environments.
 
-In the **OTP Configuration** section, complete:
+In the **OTP Configuration** section, fill in the following fields:
 
 - **OTP Template ID**: Template ID for OTP messages in Auronix.
 - **OTP Locale**: Locale code for the template. For example: `es_MX`, `en_US`, `pt_BR`.

--- a/docs/en/platform/customers/settings.md
+++ b/docs/en/platform/customers/settings.md
@@ -30,6 +30,7 @@ Before enabling the option to disable Modyo credentials in the realm, make sure 
   - Disabled: New users cannot be registered in the realm. Already registered and activated users can still log in.
 - **Default Avatar Image**: Image shown on the avatar of users who do not have a custom image.
 - **Enable Soft Login**: By activating this option you can access your account without entering your credentials each time. You will receive a security code in your email for easy login without the need for passwords.
+- **OTP delivery channel**: Default channel for the soft login security codes: **Email** sends the code to the user's address; **Phone** sends it via WhatsApp and requires an enabled messaging integration, such as [Auronix](#auronix).
 - **Registration form**: Here you can enable or disable different attributes in the registration form, such as the second surname, email confirmation, user avatar, date of birth, gender, and phone number.
 - **Delete realm**: Deletes the realm. This process is performed in the background, so you may not see the realm disappear immediately after executing the action. To confirm the deletion, you must enter the full name of the realm.
 
@@ -279,6 +280,30 @@ Use an authentication client to send your integration access tokens to your reso
 - Description
 - Confidential: There are two types of OAuth clients, confidential or public. Select the confidential option if your application can securely authenticate with the authentication server. Public clients are usually applications that run on mobile devices or browsers.
 - Scopes: If your OAuth2 authentication service uses multiple spaces or environments to separate users, and you want to use a specific one in this integration, define it in this field.
+
+### Auronix
+
+The Auronix integration, of the messaging category, allows sending WhatsApp messages using Meta-approved templates. It is used to send the soft login OTP code via WhatsApp.
+
+To enable it, the realm's registration form must have the phone field **enabled and required**. While the integration is enabled, those registration form options remain locked.
+
+In the **Credentials** section, complete:
+
+- **API Key**: Auronix API Key for authentication.
+- **WhatsApp Channel**: WhatsApp outgoing line number. It must be a valid Mexican phone number.
+- **Base URL**: Leave it blank to use the platform default; only override it for sandbox or custom environments.
+
+In the **OTP Configuration** section, complete:
+
+- **OTP Template ID**: Template ID for OTP messages in Auronix.
+- **OTP Locale**: Locale code for the template. For example: `es_MX`, `en_US`, `pt_BR`.
+- **OTP Template Variables**: Comma-separated variables. The available ones are `otp_code`, `realm_name`, `user_name`, and `user_first_name`.
+
+Once the integration is enabled, select **Phone** in the **OTP delivery channel** of the General settings so that soft login codes are sent via WhatsApp. If WhatsApp delivery fails, the user can request the code by email with the **Send code by email instead** option.
+
+:::warning Attention
+You cannot disable or remove the Auronix integration while the realm's OTP delivery channel is set to Phone.
+:::
 
 ### Webhooks
 

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -30,6 +30,7 @@ Antes de habilitar la opción de deshabilitar las credenciales de Modyo en el re
   - Deshabilitada: No se pueden registrar nuevos usuarios en el reino. Los usuarios ya registrados y activados aún pueden iniciar sesión.
 - **Imagen de Avatar por defecto**: Imagen que se muestra en el avatar de los usuarios que no tienen una imagen personalizada.
 - **Habilitar Soft login**: Activando esta opción puedes acceder a tu cuenta sin introducir tus credenciales cada vez. Recibirás un código de seguridad en tu email para ingresar fácilmente sin necesidad de contraseñas.
+- **Canal de envío del OTP**: Canal por defecto para los códigos de seguridad del soft login: **Email** envía el código al correo del usuario; **Phone** lo envía por WhatsApp y requiere una integración de mensajería habilitada, como [Auronix](#auronix).
 - **Formulario de registro**: Aquí puedes habilitar o deshabilitar diferentes atributos en el formulario de registro, como el segundo apellido, confirmación de correo electrónico, avatar de usuario, fecha de nacimiento, género y número de teléfono.
 - **Eliminar reino**: Elimina el reino. Este proceso se realiza en segundo plano y es posible que no veas el reino desaparecer inmediatamente después de ejecutar la acción. Para confirmar la eliminación, debes ingresar el nombre completo del reino.
 
@@ -279,6 +280,30 @@ Utiliza un cliente de autenticación para enviar los tokens de acceso de tu inte
 - Descripción
 - Confidencial: Existen dos tipos de clientes OAuth, confidencial o públicos. Selecciona la opción confidencial si tu aplicación puede autenticarse de manera segura con el servidor de autenticación. Los clientes públicos suelen ser aplicaciones que se ejecutan en dispositivos móviles o navegadores.
 - Scopes: Si tu servicio de autenticación OAuth2 usa múltiples espacios o ambientes para separar a los usuarios y quieres usar uno en específico en esta integración, defínelo en este campo.
+
+### Auronix
+
+La integración de Auronix, de la categoría de mensajería, permite el envío de mensajes de WhatsApp mediante templates pre-aprobados por Meta. Se utiliza para enviar el código OTP del soft login por WhatsApp.
+
+Para habilitarla, el formulario de registro del reino debe tener el campo de teléfono **habilitado y requerido**. Mientras la integración esté habilitada, esas opciones del formulario de registro quedan bloqueadas.
+
+En la sección **Credenciales** completa:
+
+- **API Key**: API Key de Auronix para autenticación.
+- **Canal WhatsApp**: Número de la línea de salida de WhatsApp. Debe ser un número de teléfono mexicano válido.
+- **URL Base**: Déjala en blanco para usar el valor por defecto de la plataforma; úsala solo para sandbox o ambientes a medida.
+
+En la sección **Configuración OTP** completa:
+
+- **Template OTP ID**: ID del template para mensajes OTP en Auronix.
+- **Locale OTP**: Código de locale del template. Por ejemplo: `es_MX`, `en_US`, `pt_BR`.
+- **Variables del Template OTP**: Variables separadas por coma. Las disponibles son `otp_code`, `realm_name`, `user_name` y `user_first_name`.
+
+Una vez habilitada la integración, selecciona **Phone** en el **Canal de envío del OTP** de la configuración General para que los códigos del soft login se envíen por WhatsApp. Si el envío por WhatsApp falla, el usuario puede solicitar el código a su correo con la opción **Enviar código al correo**.
+
+:::warning Atención
+No puedes deshabilitar ni eliminar la integración de Auronix mientras el canal de envío OTP del reino esté configurado como Phone.
+:::
 
 ### Webhooks
 

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -29,7 +29,7 @@ Antes de habilitar la opción de deshabilitar las credenciales de Modyo en el re
   - Moderada: Los usuarios que se registren deberán esperar a que un administrador del reino active su cuenta para poder iniciar sesión.
   - Deshabilitada: No se pueden registrar nuevos usuarios en el reino. Los usuarios ya registrados y activados aún pueden iniciar sesión.
 - **Imagen de Avatar por defecto**: Imagen que se muestra en el avatar de los usuarios que no tienen una imagen personalizada.
-- **Habilitar Soft login**: Activando esta opción puedes acceder a tu cuenta sin introducir tus credenciales cada vez. Recibirás un código de seguridad en tu email para ingresar fácilmente sin necesidad de contraseñas.
+- **Habilitar Soft login**: Activando esta opción puedes acceder a tu cuenta sin introducir tus credenciales cada vez. Recibirás un código de seguridad por el canal de envío configurado (email o WhatsApp) para ingresar fácilmente sin necesidad de contraseñas.
 - **Canal de envío del OTP**: Canal por defecto para los códigos de seguridad del soft login: **Email** envía el código al correo del usuario; **Phone** lo envía por WhatsApp y requiere una integración de mensajería habilitada, como [Auronix](#auronix).
 - **Formulario de registro**: Aquí puedes habilitar o deshabilitar diferentes atributos en el formulario de registro, como el segundo apellido, confirmación de correo electrónico, avatar de usuario, fecha de nacimiento, género y número de teléfono.
 - **Eliminar reino**: Elimina el reino. Este proceso se realiza en segundo plano y es posible que no veas el reino desaparecer inmediatamente después de ejecutar la acción. Para confirmar la eliminación, debes ingresar el nombre completo del reino.
@@ -283,7 +283,7 @@ Utiliza un cliente de autenticación para enviar los tokens de acceso de tu inte
 
 ### Auronix
 
-La integración de Auronix, de la categoría de mensajería, permite el envío de mensajes de WhatsApp mediante templates pre-aprobados por Meta. Se utiliza para enviar el código OTP del soft login por WhatsApp.
+La integración de Auronix, de la categoría de mensajería, permite el envío de mensajes de WhatsApp mediante plantillas preaprobadas por Meta. Se utiliza para enviar el código OTP del soft login por WhatsApp.
 
 Para habilitarla, el formulario de registro del reino debe tener el campo de teléfono **habilitado y requerido**. Mientras la integración esté habilitada, esas opciones del formulario de registro quedan bloqueadas.
 

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -302,7 +302,7 @@ En la sección **Configuración OTP** completa:
 Una vez habilitada la integración, selecciona **Phone** en el **Canal de envío del OTP** de la configuración General para que los códigos del soft login se envíen por WhatsApp. Si el envío por WhatsApp falla, el usuario puede solicitar el código a su correo con la opción **Enviar código al correo**.
 
 :::warning Atención
-No puedes deshabilitar ni eliminar la integración de Auronix mientras el canal de envío OTP del reino esté configurado como Phone.
+No puedes deshabilitar ni eliminar la integración de Auronix mientras el canal de envío del OTP del reino esté configurado como Phone.
 :::
 
 ### Webhooks


### PR DESCRIPTION
Documenta la integración de Auronix para el envío del OTP del soft login por WhatsApp, introducida en modyo/modyo#19539.

## Cambios propuestos

Se actualiza la configuración de reino (`docs/es/platform/customers/settings.md` y su versión en inglés):

- **General**: se agrega la opción **Canal de envío del OTP** (Email/Phone), enlazada a la integración de mensajería requerida.
- **Integraciones**: nueva sección **Auronix** documentando el prerequisito del campo de teléfono habilitado y requerido en el formulario de registro (y su bloqueo mientras la integración está activa), los campos de **Credenciales** (API Key, Canal WhatsApp con número mexicano válido, URL Base opcional) y de **Configuración OTP** (Template OTP ID, Locale OTP, variables disponibles), el flujo para activar el canal Phone, la opción **Enviar código al correo** como respaldo ante fallas de WhatsApp, y la restricción de no poder deshabilitar la integración mientras el canal OTP sea Phone.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)