### PR TITLE
Agregar bulk create para entries

### DIFF
--- a/docs/en/platform/content/entries.md
+++ b/docs/en/platform/content/entries.md
@@ -96,7 +96,7 @@ Content-Type: application/json
 
 Consider the following:
 
-- Creation is **asynchronous**: the endpoint responds `202` with a `job_id`, and you can check the progress and results at `GET /api/admin/background_jobs/{uuid}`. The result includes the `uuid` of the created entries and the validation errors per index.
+- Creation is **asynchronous**: the endpoint responds `202` with a `job_id`, which is the background job UUID and the value to use in `GET /api/admin/background_jobs/{uuid}` to check the progress and results. The result includes the `uuid` of the created entries and the validation errors per index.
 - Invalid entries are reported in the results without aborting the rest of the batch.
 - Entries are created as **drafts**: to publish them, use the bulk publish action with the created `uuid`s.
 - If you omit `target_locale`, the space's default locale is used. To create the **translation** of an existing entry, send its `uuid` along with a different `target_locale`.

--- a/docs/en/platform/content/entries.md
+++ b/docs/en/platform/content/entries.md
@@ -68,6 +68,40 @@ To retrieve a specific value from an entry, access the entry editing view and se
 Bulk actions run in the background, and you may not see the changes immediately. You will need to wait a moment and refresh your view after executing a bulk action.
 :::
 
+### Bulk creation via API
+
+Through the [administration API](/en/platform/core/api.html), you can create up to **100 entries** in a single request, for example, to feed a space from an external source:
+
+```
+POST /api/admin/content/spaces/{space_id}/entries/bulk?bulk_action=create
+Content-Type: application/json
+```
+
+```json
+{
+  "target_locale": "es-cl",
+  "entries": [
+    {
+      "content_type_id": 123,
+      "name": "My first entry",
+      "slug": "my-first-entry",
+      "tags": ["alpha"],
+      "field_values": [
+        { "field_id": 10, "type": "string", "value": "hello" }
+      ]
+    }
+  ]
+}
+```
+
+Consider the following:
+
+- Creation is **asynchronous**: the endpoint responds `202` with a `job_id`, and you can check the progress and results at `GET /api/admin/background_jobs/{uuid}`. The result includes the `uuid` of the created entries and the validation errors per index.
+- Invalid entries are reported in the results without aborting the rest of the batch.
+- Entries are created as **drafts**: to publish them, use the bulk publish action with the created `uuid`s.
+- If you omit `target_locale`, the space's default locale is used. To create the **translation** of an existing entry, send its `uuid` along with a different `target_locale`.
+- The `field_values` support the same field types as individual entry creation.
+
 
 
 ## Create and Publish an Entry

--- a/docs/es/platform/content/entries.md
+++ b/docs/es/platform/content/entries.md
@@ -68,6 +68,40 @@ Para recuperar un valor específico de una entrada, accede a la vista de edició
 Las acciones masivas se ejecutan en segundo plano y es posible que no veas los cambios inmediatamente, por lo que deberás esperar un momento y refrescar la vista luego de ejecutar una acción masiva.
 :::
 
+### Creación masiva vía API
+
+A través de la [API de administración](/es/platform/core/api.html) puedes crear hasta **100 entradas** en una sola solicitud, por ejemplo para alimentar un espacio desde una fuente externa:
+
+```
+POST /api/admin/content/spaces/{space_id}/entries/bulk?bulk_action=create
+Content-Type: application/json
+```
+
+```json
+{
+  "target_locale": "es-cl",
+  "entries": [
+    {
+      "content_type_id": 123,
+      "name": "Mi primera entrada",
+      "slug": "mi-primera-entrada",
+      "tags": ["alpha"],
+      "field_values": [
+        { "field_id": 10, "type": "string", "value": "hola" }
+      ]
+    }
+  ]
+}
+```
+
+Considera lo siguiente:
+
+- La creación es **asíncrona**: el endpoint responde `202` con un `job_id`, y puedes consultar el progreso y los resultados en `GET /api/admin/background_jobs/{uuid}`. El resultado incluye los `uuid` de las entradas creadas y los errores de validación por índice.
+- Las entradas inválidas se reportan en los resultados sin abortar el resto del lote.
+- Las entradas se crean como **borradores**: para publicarlas usa la acción masiva de publicación con los `uuid` creados.
+- Si omites `target_locale`, se usa el idioma por defecto del espacio. Para crear la **traducción** de una entrada existente, envía su `uuid` junto con otro `target_locale`.
+- Los `field_values` soportan los mismos tipos de campos que la creación individual de entradas.
+
 
 
 ## Crear y publicar una entrada

--- a/docs/es/platform/content/entries.md
+++ b/docs/es/platform/content/entries.md
@@ -96,7 +96,7 @@ Content-Type: application/json
 
 Considera lo siguiente:
 
-- La creación es **asíncrona**: el endpoint responde `202` con un `job_id`, y puedes consultar el progreso y los resultados en `GET /api/admin/background_jobs/{uuid}`. El resultado incluye los `uuid` de las entradas creadas y los errores de validación por índice.
+- La creación es **asíncrona**: el endpoint responde `202` con un `job_id`, que es el UUID del background job y el valor que debes usar en `GET /api/admin/background_jobs/{uuid}` para consultar el progreso y los resultados. El resultado incluye los `uuid` de las entradas creadas y los errores de validación por índice.
 - Las entradas inválidas se reportan en los resultados sin abortar el resto del lote.
 - Las entradas se crean como **borradores**: para publicarlas usa la acción masiva de publicación con los `uuid` creados.
 - Si omites `target_locale`, se usa el idioma por defecto del espacio. Para crear la **traducción** de una entrada existente, envía su `uuid` junto con otro `target_locale`.


### PR DESCRIPTION
Documenta la creación masiva de entradas vía API, introducida en modyo/modyo#19889.

## Cambios propuestos

Se agrega la subsección **Creación masiva vía API** en la documentación de Entradas (`docs/es/platform/content/entries.md` y su versión en inglés):

- Endpoint `POST /api/admin/content/spaces/{space_id}/entries/bulk?bulk_action=create` con payload de ejemplo.
- Límite de 100 entradas por solicitud, procesamiento asíncrono con `job_id` y consulta de progreso/resultados en el endpoint de background jobs (uuids creados y errores por índice).
- Comportamiento best-effort (los ítems inválidos no abortan el lote), creación como borradores con publicación posterior mediante la acción masiva, manejo de `target_locale` y creación de traducciones con el `uuid` existente.

Validado contra la documentación Swagger y el código de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)