### PR TITLE
Activar/Desactivar redirecciones

### DIFF
--- a/docs/en/platform/channels/sites.md
+++ b/docs/en/platform/channels/sites.md
@@ -572,6 +572,14 @@ In this view, you will find a table with all the redirects that currently exist 
 
 To create a new redirect, click on the **New** button in the upper right corner of the view. Fill in the **_Source URL_** and **_Destination URL_** fields and the redirection code, then save the changes.
 
+#### Enable and disable redirects
+
+Each redirect has a switch in the **Enabled** column that allows you to temporarily disable it without deleting it, and re-enable it when you need it. You can also enable or disable several redirects at once by selecting them and using the **Enable** and **Disable** bulk actions.
+
+A disabled redirect stops applying immediately: its source URL resolves again as a normal site resource (an existing page or a 404 error). When re-enabled, it redirects again immediately, preserving the configured 301 or 302 code.
+
+New redirects, including those imported via CSV, are created enabled.
+
 :::warning Attention
 The redirects table is the second to last in precedence, so if there is a URL on the site that points to a [page](/en/platform/channels/pages) or a default view, you will see that view instead of being redirected through the custom redirects table.
 :::

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -572,6 +572,14 @@ En esta vista encuentras una tabla con todas las redirecciones que existen actua
 
 Para crear una nueva redirección, haz click en el botón **Nuevo** en la esquina superior derecha de la vista. Completa los campos **_URL_ de Origen** y **_URL_ de destino** y código de redirección y luego guarda los cambios.
 
+#### Activar y desactivar redirecciones
+
+Cada redirección cuenta con un interruptor en la columna **Activa** que te permite desactivarla temporalmente sin borrarla, y volver a activarla cuando la necesites. También puedes activar o desactivar varias redirecciones a la vez seleccionándolas y usando las acciones masivas **Activar** y **Desactivar**.
+
+Una redirección desactivada deja de aplicar de inmediato: su URL de origen vuelve a resolverse como un recurso normal del sitio (una página existente o un error 404). Al reactivarla, vuelve a redirigir de inmediato conservando el código 301 o 302 configurado.
+
+Las redirecciones nuevas, incluidas las importadas por CSV, se crean activadas.
+
 :::warning Atención
 La tabla de redirecciones es la penúltima en precedencia, de tal forma que si existe una URL en el sitio que apunta a una [página](/es/platform/channels/pages) o una vista por defecto, verás esa vista en vez de ser redirigido mediante la tabla de redirecciones personalizadas.
 :::

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -576,7 +576,7 @@ Para crear una nueva redirección, haz click en el botón **Nuevo** en la esquin
 
 Cada redirección cuenta con un interruptor en la columna **Activa** que te permite desactivarla temporalmente sin borrarla, y volver a activarla cuando la necesites. También puedes activar o desactivar varias redirecciones a la vez seleccionándolas y usando las acciones masivas **Activar** y **Desactivar**.
 
-Una redirección desactivada deja de aplicar de inmediato: su URL de origen vuelve a resolverse como un recurso normal del sitio (una página existente o un error 404). Al reactivarla, vuelve a redirigir de inmediato conservando el código 301 o 302 configurado.
+Una redirección desactivada deja de aplicarse de inmediato: su URL de origen vuelve a resolverse como un recurso normal del sitio (una página existente o un error 404). Al reactivarla, vuelve a redirigir de inmediato conservando el código 301 o 302 configurado.
 
 Las redirecciones nuevas, incluidas las importadas por CSV, se crean activadas.
 


### PR DESCRIPTION
Documenta la activación y desactivación de redirecciones personalizadas, introducida en modyo/modyo#19602.

## Cambios propuestos

Se agrega la subsección **Activar y desactivar redirecciones** en la sección de Redirecciones personalizadas de Aplicaciones Web (`docs/es/platform/channels/sites.md` y su versión en inglés):

- El interruptor de la columna **Activa** para desactivar temporalmente una redirección sin borrarla, y las acciones masivas **Activar** y **Desactivar**.
- El comportamiento: la desactivación aplica de inmediato (la URL de origen vuelve a resolverse como recurso normal del sitio), la reactivación también es inmediata y conserva el código 301/302 configurado.
- Las redirecciones nuevas, incluidas las importadas por CSV, nacen activadas.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)