### PR TITLE
Dejar seleccionable el tipo de redirección para los dominios alternativos

### DIFF
--- a/docs/en/platform/channels/sites.md
+++ b/docs/en/platform/channels/sites.md
@@ -366,8 +366,13 @@ It is essential to inform all platform members about any changes you make in thi
 
 Activate the checkbox to make changes. The variables you can modify are:
 - **Host**: Location of the web application on the server.
-- **Primary domain**: Main address of the web application.
+- **Primary domain**: Main address of the web application. Alternative domains will be redirected to this domain.
 - **Alternative domain**: Secondary address to redirect in case of failure in the primary.
+- **Redirect type for alternative domains**: The HTTP code with which alternative domains redirect to the primary domain: **301 Moved Permanently**, which transfers SEO ranking to the new domain, or **302 Found (Temporary)**. New configurations use 301 by default; sites that already had alternative domains configured keep 302 until you choose to change it.
+
+:::tip Permanent redirects
+Browsers cache 301 redirects aggressively: if you later switch to 302, visitors who already received the permanent redirect may take a while to see the change.
+:::
 
 
 :::warning Attention

--- a/docs/en/platform/channels/sites.md
+++ b/docs/en/platform/channels/sites.md
@@ -367,8 +367,8 @@ It is essential to inform all platform members about any changes you make in thi
 Activate the checkbox to make changes. The variables you can modify are:
 - **Host**: Location of the web application on the server.
 - **Primary domain**: Main address of the web application. Alternative domains will be redirected to this domain.
-- **Alternative domain**: Secondary address to redirect in case of failure in the primary.
-- **Redirect type for alternative domains**: The HTTP code with which alternative domains redirect to the primary domain: **301 Moved Permanently**, which transfers SEO ranking to the new domain, or **302 Found (Temporary)**. New configurations use 301 by default; sites that already had alternative domains configured keep 302 until you choose to change it.
+- **Alternative domain**: Secondary address that automatically redirects to the primary domain.
+- **Redirect type for alternative domains**: The HTTP code with which alternative domains redirect to the primary domain: **301 Moved Permanently**, which signals search engines to transfer SEO ranking to the primary domain, or **302 Found (Temporary)**. New configurations use 301 by default; sites that already had alternative domains configured keep 302 until you choose to change it.
 
 :::tip Permanent redirects
 Browsers cache 301 redirects aggressively: if you later switch to 302, visitors who already received the permanent redirect may take a while to see the change.

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -366,8 +366,13 @@ Es esencial informar a todos los miembros de la plataforma sobre cualquier cambi
 
 Activa la casilla para realizar modificaciones. Las variables que puedes modificar son:
 - **Host**: Ubicación de la aplicación web en del servidor.
-- **Dominio primario**: Dirección principal de la aplicación web.
+- **Dominio primario**: Dirección principal de la aplicación web. Los dominios alternativos serán redirigidos a este dominio.
 - **Dominio alternativo**: Dirección secundaria para redireccionar en caso de fallo en el primario.
+- **Tipo de redirección para los dominios alternativos**: El código HTTP con el que los dominios alternativos redirigen al dominio primario: **301 Moved Permanently (permanente)**, que traspasa el posicionamiento SEO al nuevo dominio, o **302 Found (temporal)**. Las configuraciones nuevas usan 301 por defecto; los sitios que ya tenían dominios alternativos configurados conservan 302 hasta que elijas cambiarlo.
+
+:::tip Redirecciones permanentes
+Los navegadores guardan en caché las redirecciones 301 de forma agresiva: si luego cambias a 302, los visitantes que ya recibieron la redirección permanente pueden tardar en ver el cambio.
+:::
 
 
 :::warning Atención

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -365,10 +365,10 @@ Es esencial informar a todos los miembros de la plataforma sobre cualquier cambi
 :::
 
 Activa la casilla para realizar modificaciones. Las variables que puedes modificar son:
-- **Host**: Ubicación de la aplicación web en del servidor.
+- **Host**: Ubicación de la aplicación web en el servidor.
 - **Dominio primario**: Dirección principal de la aplicación web. Los dominios alternativos serán redirigidos a este dominio.
-- **Dominio alternativo**: Dirección secundaria para redireccionar en caso de fallo en el primario.
-- **Tipo de redirección para los dominios alternativos**: El código HTTP con el que los dominios alternativos redirigen al dominio primario: **301 Moved Permanently (permanente)**, que traspasa el posicionamiento SEO al nuevo dominio, o **302 Found (temporal)**. Las configuraciones nuevas usan 301 por defecto; los sitios que ya tenían dominios alternativos configurados conservan 302 hasta que elijas cambiarlo.
+- **Dominio alternativo**: Dirección secundaria que redirige automáticamente al dominio primario.
+- **Tipo de redirección para los dominios alternativos**: El código HTTP con el que los dominios alternativos redirigen al dominio primario: **301 Moved Permanently (permanente)**, que indica a los buscadores traspasar el posicionamiento SEO al dominio primario, o **302 Found (temporal)**. Las configuraciones nuevas usan 301 por defecto; los sitios que ya tenían dominios alternativos configurados conservan 302 hasta que elijas cambiarlo.
 
 :::tip Redirecciones permanentes
 Los navegadores guardan en caché las redirecciones 301 de forma agresiva: si luego cambias a 302, los visitantes que ya recibieron la redirección permanente pueden tardar en ver el cambio.


### PR DESCRIPTION
Documenta el tipo de redirección seleccionable para los dominios alternativos, introducido en modyo/modyo#19839.

## Cambios propuestos

Se actualiza la sección **Dominios** de Aplicaciones Web (`docs/es/platform/channels/sites.md` y su versión en inglés):

- Se agrega la opción **Tipo de redirección para los dominios alternativos** con sus valores **301 Moved Permanently (permanente)**, que traspasa el posicionamiento SEO, y **302 Found (temporal)**.
- Se documentan los valores por defecto: 301 para configuraciones nuevas y 302 conservado para los sitios que ya tenían dominios alternativos configurados.
- Se agrega un tip sobre el cacheo agresivo de las redirecciones 301 en los navegadores.
- Se aclara en el dominio primario que los dominios alternativos redirigen hacia él.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)