### PR TITLE
Ocultar link cancelar por configuracion en la pagina de originación

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -435,7 +435,9 @@ By selecting the **Edit** option in the context menu of your origination, you ca
 - **Default submission assignee**: Specifies the person who will be automatically assigned when receiving a new origination.
 - **Due in**: Sets a maximum deadline for completing the origination.
 - **Completion rules**: Defines the completion behavior for each submission.
-- **Cancellation rules**: Defines who can cancel a submission from the origination page: **Everyone can cancel the submission** (default option) or **Only administrators can cancel the submission**. With the second option, the **Cancel** button is no longer shown to the user on the origination page, and cancellation remains available only to administrators.
+- **Cancellation rules**: Defines who can cancel a submission from the origination page:
+  - **Everyone can cancel the submission**: Default option.
+  - **Only administrators can cancel the submission**: The **Cancel** button is no longer shown to the user on the origination page, and cancellation remains available only to administrators.
 - **Privacy**: Allows you to restrict access to the origination flow to certain predefined user segments.
 
 #### Delete origination

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -435,6 +435,7 @@ By selecting the **Edit** option in the context menu of your origination, you ca
 - **Default submission assignee**: Specifies the person who will be automatically assigned when receiving a new origination.
 - **Due in**: Sets a maximum deadline for completing the origination.
 - **Completion rules**: Defines the completion behavior for each submission.
+- **Cancellation rules**: Defines who can cancel a submission from the origination page: **Everyone can cancel the submission** (default option) or **Only administrators can cancel the submission**. With the second option, the **Cancel** button is no longer shown to the user on the origination page, and cancellation remains available only to administrators.
 - **Privacy**: Allows you to restrict access to the origination flow to certain predefined user segments.
 
 #### Delete origination

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -428,7 +428,7 @@ Considera cómo la lógica condicional puede afectar la experiencia del usuario 
 
 ### Editar configuración de la originación
 
-Al seleccionar la opción **Editar** en el menu contextual de tu orignación puedes editar sus propiedades.
+Al seleccionar la opción **Editar** en el menú contextual de tu originación puedes editar sus propiedades.
 
 - **Nombre**: Define el nombre de la originación, visible para los usuarios en la interfaz.
 - **Descripción**: Incluye un breve texto explicativo sobre el propósito de la originación.
@@ -436,7 +436,9 @@ Al seleccionar la opción **Editar** en el menu contextual de tu orignación pue
 - **Asignado por defecto de la respuesta**: especifica la persona que será asignada automáticamente al recibir una nueva originación.
 - **Vence en**:  Establece un plazo máximo para completar la originación.
 - **Reglas de completado**:  Define el comportamiento de completado para cada respuesta.
-- **Reglas de cancelación**: Define quién puede cancelar una respuesta desde la página de originación: **Cualquiera puede cancelar la respuesta** (opción por defecto) o **Solo los administradores pueden cancelar la respuesta**. Con la segunda opción, el botón **Cancelar** deja de mostrarse al usuario en la página de originación y la cancelación queda disponible solo para los administradores.
+- **Reglas de cancelación**: Define quién puede cancelar una respuesta desde la página de originación:
+  - **Cualquiera puede cancelar la respuesta**: Opción por defecto.
+  - **Solo los administradores pueden cancelar la respuesta**: El botón **Cancelar** deja de mostrarse al usuario en la página de originación y la cancelación queda disponible solo para los administradores.
 - **Privacidad**: Permite restringir el acceso al flujo de originación a ciertos segmentos de usuarios predefinidos.
 
 #### Eliminar originación

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -436,6 +436,7 @@ Al seleccionar la opción **Editar** en el menu contextual de tu orignación pue
 - **Asignado por defecto de la respuesta**: especifica la persona que será asignada automáticamente al recibir una nueva originación.
 - **Vence en**:  Establece un plazo máximo para completar la originación.
 - **Reglas de completado**:  Define el comportamiento de completado para cada respuesta.
+- **Reglas de cancelación**: Define quién puede cancelar una respuesta desde la página de originación: **Cualquiera puede cancelar la respuesta** (opción por defecto) o **Solo los administradores pueden cancelar la respuesta**. Con la segunda opción, el botón **Cancelar** deja de mostrarse al usuario en la página de originación y la cancelación queda disponible solo para los administradores.
 - **Privacidad**: Permite restringir el acceso al flujo de originación a ciertos segmentos de usuarios predefinidos.
 
 #### Eliminar originación


### PR DESCRIPTION
Documenta las reglas de cancelación de la originación, introducidas en modyo/modyo#19874.

## Cambios propuestos

Se actualiza la sección **Editar configuración de la originación** de la documentación de Origination (`docs/es/platform/customers/origination.md` y su versión en inglés):

- Se agrega la nueva opción **Reglas de cancelación** con sus dos valores: **Cualquiera puede cancelar la respuesta** (por defecto) y **Solo los administradores pueden cancelar la respuesta**.
- Se documenta el efecto de la restricción: el botón **Cancelar** deja de mostrarse al usuario en la página de originación y la cancelación queda disponible solo para los administradores.

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)