### PR TITLE
Mejoras al buscador

### DIFF
--- a/docs/en/platform/channels/sites.md
+++ b/docs/en/platform/channels/sites.md
@@ -51,6 +51,8 @@ If you click **publish** on a particular article (e.g., publish a page), the Rev
 
 When you create a web application with Modyo, your users can search your web apps and all their content using the search function. This can be done using the `/search` URL or by accessing the dedicated search page.
 
+The search engine also finds partial matches within words, starting at 3 characters: for example, a page named `GTCMujer` appears when searching for `GTC` or `Mujer`. Exact matches are still shown first in the results.
+
 ### Enable or disable search
 
 To enable or disable the search functionality, follow these steps:

--- a/docs/en/platform/channels/sites.md
+++ b/docs/en/platform/channels/sites.md
@@ -51,7 +51,7 @@ If you click **publish** on a particular article (e.g., publish a page), the Rev
 
 When you create a web application with Modyo, your users can search your web apps and all their content using the search function. This can be done using the `/search` URL or by accessing the dedicated search page.
 
-The search engine also finds partial matches within words, starting at 3 characters: for example, a page named `GTCMujer` appears when searching for `GTC` or `Mujer`. Exact matches are still shown first in the results.
+The search engine also finds partial matches within words, starting at 3 characters: for example, a page named `Sunflower` appears when searching for `sun` or `flower`. Exact matches are still shown first in the results.
 
 ### Enable or disable search
 

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -51,7 +51,7 @@ Si haces click en **publicar** en un artículo en particular (e.g. publicar una 
 
 Cuando creas una aplicación web con Modyo, tus usuarios pueden realizar búsquedas en tus web apps y en todo su contenido mediante la función de búsqueda. Esto puede hacerse utilizando la URL `/search` o accediendo a la página de búsqueda dedicada.
 
-El buscador encuentra también coincidencias parciales dentro de las palabras, a partir de 3 caracteres: por ejemplo, una página llamada `GTCMujer` aparece al buscar `GTC` o `Mujer`. Las coincidencias exactas siguen mostrándose primero en los resultados.
+El buscador encuentra también coincidencias parciales dentro de las palabras, a partir de 3 caracteres: por ejemplo, una página llamada `Sunflower` aparece al buscar `sun` o `flower`. Las coincidencias exactas siguen mostrándose primero en los resultados.
 
 ### Habilitar o deshabilitar búsqueda
 

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -51,6 +51,8 @@ Si haces click en **publicar** en un artículo en particular (e.g. publicar una 
 
 Cuando creas una aplicación web con Modyo, tus usuarios pueden realizar búsquedas en tus web apps y en todo su contenido mediante la función de búsqueda. Esto puede hacerse utilizando la URL `/search` o accediendo a la página de búsqueda dedicada.
 
+El buscador encuentra también coincidencias parciales dentro de las palabras, a partir de 3 caracteres: por ejemplo, una página llamada `GTCMujer` aparece al buscar `GTC` o `Mujer`. Las coincidencias exactas siguen mostrándose primero en los resultados.
+
 ### Habilitar o deshabilitar búsqueda
 
 Para habilitar o deshabilitar la funcionalidad de búsqueda, sigue estos pasos:


### PR DESCRIPTION
Documenta las mejoras al buscador del sitio, introducidas en modyo/modyo#19908.

## Cambios propuestos

Se actualiza la sección **Buscador** de Aplicaciones Web (`docs/es/platform/channels/sites.md` y su versión en inglés):

- Se documenta que el buscador ahora encuentra coincidencias parciales dentro de las palabras, a partir de 3 caracteres (ej: una página llamada `GTCMujer` aparece al buscar `GTC` o `Mujer`), y que las coincidencias exactas siguen mostrándose primero en los resultados.

Comportamiento validado contra el código de la rama master de modyo/modyo (subcampos ngram con mínimo de 3 caracteres y boost menor que las coincidencias exactas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)