### PR TITLE
Bloquear la edición del identificador de un field/task/step en las originaciones

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -75,6 +75,10 @@ In this section, you can edit the values of the selected task. You can find thes
 - **Identifier**: A unique identifier that will be included in the origination URL.
 - **Description**: A brief explanatory text about the task, which will be visible to the user.
 
+:::warning Editing identifiers
+When editing an already saved step, task, or field, the **Identifier** field appears locked with a padlock. To modify it, you must press the padlock and confirm the **Unlock Identifier field** warning: changing an identifier breaks references to it from external systems or through the Liquid SDK and, in the case of fields, submissions can no longer be searched by that field. The identifier is only generated automatically from the name during creation; when editing, changing the name no longer modifies it.
+:::
+
 ### Input
 
 In Input tasks, you can incorporate a wide variety of fields in your forms to customize the collection of data from your users.

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -76,7 +76,7 @@ In this section, you can edit the values of the selected task. You can find thes
 - **Description**: A brief explanatory text about the task, which will be visible to the user.
 
 :::warning Editing identifiers
-When editing an already saved step, task, or field, the **Identifier** field appears locked with a padlock. To modify it, you must press the padlock and confirm the **Unlock Identifier field** warning: changing an identifier breaks references to it from external systems or through the Liquid SDK and, in the case of fields, submissions can no longer be searched by that field. The identifier is only generated automatically from the name during creation; when editing, changing the name no longer modifies it.
+When editing an already saved step, task, or field, the **Identifier** field appears locked with a padlock. To modify it, you must press the padlock and confirm the **Unlock Identifier field** warning: changing an identifier breaks references to it from external systems or through the Liquid SDK and, in the case of fields, submissions can no longer be searched by that field. The identifier is only generated automatically from the name during creation; when editing, changing the name doesn't modify it.
 :::
 
 ### Input

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -75,6 +75,10 @@ En este apartado se pueden editar los valores de la tarea seleccionada, puedes e
 - **Identificador**: Un identificador único que se incluirá en la URL de la originación.
 - **Descripción**: Un breve texto explicativo sobre la tarea, que será visible para el usuario.
 
+:::warning Edición de identificadores
+Al editar un paso, una tarea o un campo ya guardados, el campo **Identificador** aparece bloqueado con un candado. Para modificarlo debes presionar el candado y confirmar la advertencia **Desbloquear campo identificador**: cambiar un identificador rompe las referencias desde sistemas externos o mediante el SDK de Liquid y, en el caso de los campos, las respuestas dejan de poder buscarse por ese campo. El identificador solo se genera automáticamente a partir del nombre durante la creación; al editar, cambiar el nombre ya no lo modifica.
+:::
+
 ### Input
 
 En las tareas Input puedes incorporar una amplia variedad de campos en tus formularios para personalizar la recolección de datos de tus usuarios.

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -76,7 +76,7 @@ En este apartado se pueden editar los valores de la tarea seleccionada, puedes e
 - **Descripción**: Un breve texto explicativo sobre la tarea, que será visible para el usuario.
 
 :::warning Edición de identificadores
-Al editar un paso, una tarea o un campo ya guardados, el campo **Identificador** aparece bloqueado con un candado. Para modificarlo debes presionar el candado y confirmar la advertencia **Desbloquear campo identificador**: cambiar un identificador rompe las referencias desde sistemas externos o mediante el SDK de Liquid y, en el caso de los campos, las respuestas dejan de poder buscarse por ese campo. El identificador solo se genera automáticamente a partir del nombre durante la creación; al editar, cambiar el nombre ya no lo modifica.
+Al editar un paso, una tarea o un campo ya guardados, el campo **Identificador** aparece bloqueado con un candado. Para modificarlo debes presionar el candado y confirmar la advertencia **Desbloquear campo identificador**: cambiar un identificador rompe las referencias desde sistemas externos o mediante el SDK de Liquid y, en el caso de los campos, las respuestas dejan de poder buscarse por ese campo. El identificador solo se genera automáticamente a partir del nombre durante la creación; al editar, cambiar el nombre no lo modifica.
 :::
 
 ### Input


### PR DESCRIPTION
Documenta el bloqueo de la edición del identificador de campos, tareas y pasos en las originaciones, introducido en modyo/modyo#19978.

## Cambios propuestos

Se actualiza la documentación de Origination (`docs/es/platform/customers/origination.md` y su versión en inglés):

- Nuevo warning **Edición de identificadores** en la sección de propiedades de las tareas: al editar un paso, tarea o campo ya guardados, el campo **Identificador** aparece bloqueado con un candado y requiere confirmar la advertencia **Desbloquear campo identificador**; se documentan los riesgos (referencias desde sistemas externos y SDK de Liquid, y en campos la pérdida de búsqueda de respuestas por ese campo) y que el identificador solo se autogenera desde el nombre durante la creación.

Los textos de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)