### PR TITLE
Integracion SMS custom en base a endpoint genérico

### DIFF
--- a/docs/en/platform/customers/settings.md
+++ b/docs/en/platform/customers/settings.md
@@ -281,6 +281,23 @@ Use an authentication client to send your integration access tokens to your reso
 - Confidential: There are two types of OAuth clients, confidential or public. Select the confidential option if your application can securely authenticate with the authentication server. Public clients are usually applications that run on mobile devices or browsers.
 - Scopes: If your OAuth2 authentication service uses multiple spaces or environments to separate users, and you want to use a specific one in this integration, define it in this field.
 
+### Custom SMS
+
+The Custom SMS integration, of the messaging category, allows sending the soft login OTP code via SMS through your own service, using a generic HTTP endpoint.
+
+To enable it, the realm's registration form must have the phone field **enabled and required**. While a phone OTP integration is enabled, those registration form options remain locked.
+
+In the **Credentials** section, complete:
+
+- **Endpoint URL**: The OTP code is sent as a POST request to this URL, with a JSON body containing `phone` and `code`.
+- **Auth Token**: Sent in the `Authorization` header as a Bearer token.
+
+Once the integration is enabled, select **Phone** in the **OTP delivery channel** of the General settings. Custom SMS can coexist with other phone OTP integrations, such as Auronix: both send the code on each login independently, and the failure of one does not interrupt the other.
+
+:::warning Attention
+You cannot disable or remove the last enabled phone OTP integration while the realm's OTP delivery channel is set to Phone.
+:::
+
 ### Webhooks
 
 The platform allows the creation of Webhooks for specific events related to realm users.

--- a/docs/en/platform/customers/settings.md
+++ b/docs/en/platform/customers/settings.md
@@ -287,7 +287,7 @@ The Custom SMS integration, of the messaging category, allows sending the soft l
 
 To enable it, the realm's registration form must have the phone field **enabled and required**. While a phone OTP integration is enabled, those registration form options remain locked.
 
-In the **Credentials** section, complete:
+In the **Credentials** section, fill in the following fields:
 
 - **Endpoint URL**: The OTP code is sent as a POST request to this URL, with a JSON body containing `phone` and `code`.
 - **Auth Token**: Sent in the `Authorization` header as a Bearer token.

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -295,7 +295,7 @@ En la sección **Credenciales** completa:
 Una vez habilitada la integración, selecciona **Phone** en el **Canal de envío del OTP** de la configuración General. Custom SMS puede convivir con otras integraciones de OTP por teléfono, como Auronix: ambas envían el código en cada inicio de sesión de forma independiente, y el fallo de una no interrumpe a la otra.
 
 :::warning Atención
-No puedes deshabilitar ni eliminar la última integración de OTP por teléfono habilitada mientras el canal de envío OTP del reino esté configurado como Phone.
+No puedes deshabilitar ni eliminar la última integración de OTP por teléfono habilitada mientras el canal de envío del OTP del reino esté configurado como Phone.
 :::
 
 ### Webhooks

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -281,6 +281,23 @@ Utiliza un cliente de autenticación para enviar los tokens de acceso de tu inte
 - Confidencial: Existen dos tipos de clientes OAuth, confidencial o públicos. Selecciona la opción confidencial si tu aplicación puede autenticarse de manera segura con el servidor de autenticación. Los clientes públicos suelen ser aplicaciones que se ejecutan en dispositivos móviles o navegadores.
 - Scopes: Si tu servicio de autenticación OAuth2 usa múltiples espacios o ambientes para separar a los usuarios y quieres usar uno en específico en esta integración, defínelo en este campo.
 
+### Custom SMS
+
+La integración de Custom SMS, de la categoría de mensajería, permite enviar el código OTP del soft login por SMS mediante tu propio servicio, a través de un endpoint HTTP genérico.
+
+Para habilitarla, el formulario de registro del reino debe tener el campo de teléfono **habilitado y requerido**. Mientras exista una integración de OTP por teléfono activa, esas opciones del formulario de registro quedan bloqueadas.
+
+En la sección **Credenciales** completa:
+
+- **URL del endpoint**: El código OTP se envía como una petición POST a esta URL, con un cuerpo JSON que contiene `phone` y `code`.
+- **Token de autenticación**: Se envía en el header `Authorization` como Bearer token.
+
+Una vez habilitada la integración, selecciona **Phone** en el **Canal de envío del OTP** de la configuración General. Custom SMS puede convivir con otras integraciones de OTP por teléfono, como Auronix: ambas envían el código en cada inicio de sesión de forma independiente, y el fallo de una no interrumpe a la otra.
+
+:::warning Atención
+No puedes deshabilitar ni eliminar la última integración de OTP por teléfono habilitada mientras el canal de envío OTP del reino esté configurado como Phone.
+:::
+
 ### Webhooks
 
 La plataforma permite la creación de Webhooks para ciertos eventos específicos de los usuarios del reino.


### PR DESCRIPTION
Documenta la integración Custom SMS para el envío del OTP del soft login por SMS, introducida en modyo/modyo#19979.

## Cambios propuestos

Se agrega la sección **Custom SMS** en Integraciones de la configuración de reino (`docs/es/platform/customers/settings.md` y su versión en inglés):

- Qué hace: envío del código OTP del soft login por SMS mediante un servicio propio, vía endpoint HTTP genérico (POST con cuerpo JSON `phone`/`code` y Bearer token).
- Campos de **Credenciales**: **URL del endpoint** y **Token de autenticación**, con sus comportamientos exactos.
- Prerequisito del campo de teléfono habilitado y requerido en el formulario de registro, y su bloqueo mientras haya una integración de OTP por teléfono activa.
- Convivencia con otras integraciones de OTP por teléfono (como Auronix): ambas envían el código de forma independiente y el fallo de una no interrumpe a la otra.
- Warning sobre la restricción de no poder deshabilitar/eliminar la última integración que sostiene el canal Phone.

Nota: complementa modyo/modyo-docs#962 (Auronix), que agrega la sección hermana y el bullet **Canal de envío del OTP** en General; ambas secciones se insertan en el mismo punto, por lo que al mergear el segundo habrá un conflicto trivial que se resuelve conservando ambas (Auronix primero, Custom SMS después).

Los textos de la interfaz fueron validados contra los locales de la rama master de modyo/modyo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)