### PR TITLE
Gestión de alternativas en Content::Type

### DIFF
--- a/docs/en/platform/content/types.md
+++ b/docs/en/platform/content/types.md
@@ -101,6 +101,19 @@ This field allows you to add a list from which you can select more than one opti
 
 This field allows you to add a text field in which you can type to select an option; it can be predetermined or proposed.
 
+#### Allowed values
+
+In choice fields (Dropdown, Radio, Checkbox, and Multiple choice), the options are managed in the field's **Allowed values** section: use **Add value** and **Delete value** to manage them, and the selector to mark the **Default value**. Before saving, the interface marks the values as **New** or **Edited** so you can review your changes.
+
+Each value is an individual element of the content type:
+
+- When **renaming a value**, the entries that had it selected keep their selection with the new name, across all their versions.
+- When **deleting a value in use**, it is archived: it is no longer offered for new selections, but the entries that already had it selected continue to display it, with no loss of historical data.
+
+:::tip Tip
+The name of an active value does not allow line breaks or starting with the `*` character.
+:::
+
 ### Boolean
 
 This field allows you to add a question or statement (True or False).

--- a/docs/en/platform/content/types.md
+++ b/docs/en/platform/content/types.md
@@ -101,7 +101,7 @@ This field allows you to add a list from which you can select more than one opti
 
 This field allows you to add a text field in which you can type to select an option; it can be predetermined or proposed.
 
-#### Allowed values
+### Allowed values
 
 In choice fields (Dropdown, Radio, Checkbox, and Multiple choice), the options are managed in the field's **Allowed values** section: use **Add value** and **Delete value** to manage them, and the selector to mark the **Default value**. Before saving, the interface marks the values as **New** or **Edited** so you can review your changes.
 

--- a/docs/es/platform/content/types.md
+++ b/docs/es/platform/content/types.md
@@ -101,9 +101,9 @@ Este campo te permite agregar una lista de la cual puedes seleccionar más de un
 
 Este campo te permite agregar un campo de texto en el cual puedes escribir para seleccionar una opción; puede ser predeterminada o propuesta.
 
-#### Valores permitidos
+### Valores permitidos
 
-En los campos de elección (Dropdown, Radio, Checkbox y Opciones múltiples), las opciones se gestionan en la sección **Valores permitidos** del campo: usa **Agregar valor** y **Eliminar valor** para administrarlas, y el selector para marcar el **Valor predeterminado**. Antes de guardar, la interfaz marca los valores como **Nueva** o **Modificada** para que revises tus cambios.
+En los campos de elección (Dropdown, Radio, Checkbox y Opciones múltiples), las opciones se gestionan en la sección **Valores permitidos** del campo: usa **Agregar valor** y **Eliminar valor** para administrarlas, y el selector para marcar el **Valor predeterminado**. Antes de guardar, la interfaz marca las opciones como **Nueva** o **Modificada** para que revises tus cambios.
 
 Cada valor es un elemento individual del tipo de contenido:
 

--- a/docs/es/platform/content/types.md
+++ b/docs/es/platform/content/types.md
@@ -101,6 +101,19 @@ Este campo te permite agregar una lista de la cual puedes seleccionar más de un
 
 Este campo te permite agregar un campo de texto en el cual puedes escribir para seleccionar una opción; puede ser predeterminada o propuesta.
 
+#### Valores permitidos
+
+En los campos de elección (Dropdown, Radio, Checkbox y Opciones múltiples), las opciones se gestionan en la sección **Valores permitidos** del campo: usa **Agregar valor** y **Eliminar valor** para administrarlas, y el selector para marcar el **Valor predeterminado**. Antes de guardar, la interfaz marca los valores como **Nueva** o **Modificada** para que revises tus cambios.
+
+Cada valor es un elemento individual del tipo de contenido:
+
+- Al **renombrar un valor**, las entradas que lo tenían seleccionado conservan su selección con el nuevo nombre, en todas sus versiones.
+- Al **eliminar un valor en uso**, este se archiva: deja de ofrecerse para nuevas selecciones, pero las entradas que ya lo tenían seleccionado lo siguen mostrando, sin pérdida de datos históricos.
+
+:::tip Tip
+El nombre de un valor activo no admite saltos de línea ni comenzar con el carácter `*`.
+:::
+
 ### Booleano
 
 Este campo te permite agregar una pregunta o afirmación (Verdadero/True o Falso/False).


### PR DESCRIPTION
Documenta la gestión de alternativas en los campos de elección de los tipos de contenido, introducida en modyo/modyo#19821.

## Cambios propuestos

Se agrega la subsección **Valores permitidos** en la documentación de Tipos de contenido (`docs/es/platform/content/types.md` y su versión en inglés), cubriendo los campos Dropdown, Radio, Checkbox y Opciones múltiples:

- La gestión de opciones en la sección **Valores permitidos** del campo: **Agregar valor**, **Eliminar valor**, selector de **Valor predeterminado** y los indicadores **Nueva**/**Modificada** antes de guardar.
- El nuevo comportamiento de identidad estable: al renombrar un valor, las entradas que lo tenían seleccionado conservan su selección con el nuevo nombre en todas sus versiones.
- El borrado seguro: eliminar un valor en uso lo archiva (deja de ofrecerse para nuevas selecciones, pero las entradas existentes lo siguen mostrando, sin pérdida de datos históricos).
- Tip con la restricción de nombres de valores activos (sin saltos de línea ni `*` inicial).

Los nombres de la interfaz fueron validados contra los locales de la rama master de modyo/modyo. Sin detalles internos (migración/backfill/reindexación quedan fuera por ser de operaciones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)