### PR TITLE
Asignación de tareas a Agentes

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -453,6 +453,31 @@ The user sees each selected task with its answers and an **Edit** link that take
 
 In the details of a submission, completed confirmation tasks show the list of **Confirmed Tasks**.
 
+### Tasks answered by agents
+
+Each task in the flow has the **Assigned to** option, which defines who answers it:
+
+- **User**: The task is answered by the end user on the origination page.
+- **Agent**: The task is answered by an administrator from the admin. **Validation** and **Pending review** tasks are always agent tasks; **Input** and **Code snippet** tasks can be configured in either mode.
+
+When the flow reaches an agent task, the assigned administrators receive an email with a direct link to the task and also see it in the **My tasks** view. The effective assignee is resolved in this order: the assignee of the task response, the assignee configured on the task and, failing that, the assignee of the submission; you can reassign a specific task from the submission view, which notifies the new assignee.
+
+From the submission view, the agent opens the task and answers the form with the same experience as the site: live conditional logic, file uploads, repeatable groups, and code snippets. While the task awaits the agent's action, the user sees on the origination page the text configured in **Waiting message shown to the user**.
+
+Additional options depending on the task type:
+
+- **Disable manual completion** (Pending review): Hides the Complete button so the task cannot be completed manually from the admin. Administrators with the **Change Status of Task Response** permission can still complete it.
+- **Allow same-origin** (Code snippet): Grants the task iframe access to the admin origin (session and cookies), disabling the sandbox isolation. Enable it only for trusted snippets.
+
+#### Agent verification for external services
+
+When an agent answers a Code snippet task, your code can obtain a short-lived credential (5 minutes) so an external service can verify that the caller is an agent authorized for that task and submission:
+
+1. From the task iframe, request the credential at `GET .../agent_task_forms/{step_task_id}/assertion` (accepts the optional `audience` parameter with the target service identifier) and send it to the external service.
+2. The external service validates it at `POST /api/admin/customers/{realm_uid}/originations/agent_assertions/introspect` (requires API Access with the view submissions permission). The response indicates `active: true` with the identifiers of the agent, submission, task, and acted user, or `active: false` if the credential expired or the authorization was revoked — validation always checks the current state, not just the signature.
+
+You can find the endpoint details in the [API](/en/platform/core/api.html) Swagger documentation.
+
 ### Conditional Logic
 
 Conditional logic allows you to create more dynamic and intelligent workflows. With this functionality, you can define rules for showing or hiding **Steps**, **Tasks**, and **Input task fields** based on answers provided by users or on existing data within the submission. This allows you to personalize the user experience, presenting only relevant information at each stage of the process and simplifying or bifurcating the interaction. Conditional logic gives you the flexibility to:

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -466,15 +466,15 @@ From the submission view, the agent opens the task and answers the form with the
 
 Additional options depending on the task type:
 
-- **Disable manual completion** (Pending review): Hides the Complete button so the task cannot be completed manually from the admin. Administrators with the **Change Status of Task Response** permission can still complete it.
+- **Disable manual completion** (Pending review): Hides the **Complete** button so the task cannot be completed manually from the admin. Administrators with the **Change Status of Task Response** permission can still complete it.
 - **Allow same-origin** (Code snippet): Grants the task iframe access to the admin origin (session and cookies), disabling the sandbox isolation. Enable it only for trusted snippets.
 
 #### Agent verification for external services
 
 When an agent answers a Code snippet task, your code can obtain a short-lived credential (5 minutes) so an external service can verify that the caller is an agent authorized for that task and submission:
 
-1. From the task iframe, request the credential at `GET .../agent_task_forms/{step_task_id}/assertion` (accepts the optional `audience` parameter with the target service identifier) and send it to the external service.
-2. The external service validates it at `POST /api/admin/customers/{realm_uid}/originations/agent_assertions/introspect` (requires API Access with the view submissions permission). The response indicates `active: true` with the identifiers of the agent, submission, task, and acted user, or `active: false` if the credential expired or the authorization was revoked — validation always checks the current state, not just the signature.
+1. From the task iframe, request the credential at `GET /admin/customers/{realm_uid}/originations/{origination_id}/submissions/{submission_id}/agent_task_forms/{step_task_id}/assertion` (same admin base where the iframe runs; accepts the optional `audience` parameter with the target service identifier) and send it to the external service.
+2. The external service validates it at `POST /api/admin/customers/{realm_uid}/originations/agent_assertions/introspect` (requires API Access with a permission that includes viewing submissions: **View All Submissions** or **View Assigned Submissions**). The response indicates `active: true` with the identifiers of the agent, submission, task, and acted user, or `active: false` if the credential expired or the authorization was revoked — validation always checks the current state, not just the signature.
 
 You can find the endpoint details in the [API](/en/platform/core/api.html) Swagger documentation.
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -454,6 +454,31 @@ El usuario ve cada tarea seleccionada con sus respuestas y un enlace **Editar** 
 
 En los detalles de una respuesta, las tareas de confirmación completadas muestran el listado de **Tareas confirmadas**.
 
+### Tareas respondidas por agentes
+
+Cada tarea del flujo tiene la opción **Asignado a**, que define quién la responde:
+
+- **Usuario**: La tarea la responde el usuario final en la página de originación.
+- **Agente**: La tarea la responde un administrador desde el admin. Las tareas de **Validación** y **Revisión pendiente** son siempre de agente; las tareas **Input** y **Snippet de código** pueden configurarse en cualquiera de los dos modos.
+
+Cuando el flujo llega a una tarea de agente, los administradores asignados reciben un correo con el enlace directo a la tarea y también la ven en la vista **Mis tareas**. El asignado efectivo se resuelve en este orden: el asignado de la respuesta a la tarea, el asignado configurado en la tarea y, en su defecto, el asignado de la respuesta; puedes reasignar una tarea específica desde la vista de la respuesta, lo que notifica al nuevo asignado.
+
+Desde la vista de la respuesta, el agente abre la tarea y responde el formulario con la misma experiencia del sitio: lógica condicional en vivo, carga de archivos, grupos repetibles y snippets de código. Mientras la tarea espera la acción del agente, el usuario ve en la página de originación el texto configurado en **Mensaje de espera que ve el usuario**.
+
+Opciones adicionales según el tipo de tarea:
+
+- **Desactivar el completado manual** (Revisión pendiente): Oculta el botón Completar para que la tarea no pueda completarse manualmente desde el admin. Los administradores con el permiso **Cambiar estado de la Respuesta de una Tarea** pueden completarla de todas formas.
+- **Permitir same-origin** (Snippet de código): Otorga al iframe de la tarea acceso al origen del admin (sesión y cookies), desactivando el aislamiento del sandbox. Actívalo solo para snippets de confianza.
+
+#### Verificación de agentes para servicios externos
+
+Cuando un agente responde una tarea de Snippet de código, tu código puede obtener una credencial de corta vida (5 minutos) para que un servicio externo verifique que quien lo invoca es un agente autorizado sobre esa tarea y respuesta:
+
+1. Desde el iframe de la tarea, solicita la credencial en `GET .../agent_task_forms/{step_task_id}/assertion` (acepta el parámetro opcional `audience` con el identificador del servicio destino) y envíala al servicio externo.
+2. El servicio externo la valida en `POST /api/admin/customers/{realm_uid}/originations/agent_assertions/introspect` (requiere API Access con permiso de ver respuestas). La respuesta indica `active: true` con los identificadores del agente, la respuesta, la tarea y el usuario actuado, o `active: false` si la credencial expiró o la autorización fue revocada — la validación siempre revisa el estado vigente, no solo la firma.
+
+Puedes conocer el detalle de los endpoints en la documentación Swagger de la [API](/es/platform/core/api.html).
+
 ### Lógica Condicional
 
 La lógica condicional te permite crear flujos de trabajo más dinámicos e inteligentes. Con esta funcionalidad, puedes definir reglas para mostrar u ocultar **Pasos**, **Tareas** y **campos de tareas Input** basándote en las respuestas proporcionadas por los usuarios o en datos existentes dentro de la respuesta. Esto te permite personalizar la experiencia del usuario, presentando solo la información relevante en cada etapa del proceso y simplificando o bifurcando la interacción. La lógica condicional te ofrece la flexibilidad de:

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -461,21 +461,21 @@ Cada tarea del flujo tiene la opción **Asignado a**, que define quién la respo
 - **Usuario**: La tarea la responde el usuario final en la página de originación.
 - **Agente**: La tarea la responde un administrador desde el admin. Las tareas de **Validación** y **Revisión pendiente** son siempre de agente; las tareas **Input** y **Snippet de código** pueden configurarse en cualquiera de los dos modos.
 
-Cuando el flujo llega a una tarea de agente, los administradores asignados reciben un correo con el enlace directo a la tarea y también la ven en la vista **Mis tareas**. El asignado efectivo se resuelve en este orden: el asignado de la respuesta a la tarea, el asignado configurado en la tarea y, en su defecto, el asignado de la respuesta; puedes reasignar una tarea específica desde la vista de la respuesta, lo que notifica al nuevo asignado.
+Cuando el flujo llega a una tarea de agente, los administradores asignados reciben un correo con el enlace directo a la tarea y también la ven en la vista **Mis tareas**. El asignado efectivo se resuelve en este orden: el asignado de la respuesta a la tarea, el asignado configurado en la tarea y, en su defecto, el asignado general de la respuesta; puedes reasignar una tarea específica desde la vista de la respuesta, lo que notifica al nuevo asignado.
 
 Desde la vista de la respuesta, el agente abre la tarea y responde el formulario con la misma experiencia del sitio: lógica condicional en vivo, carga de archivos, grupos repetibles y snippets de código. Mientras la tarea espera la acción del agente, el usuario ve en la página de originación el texto configurado en **Mensaje de espera que ve el usuario**.
 
 Opciones adicionales según el tipo de tarea:
 
-- **Desactivar el completado manual** (Revisión pendiente): Oculta el botón Completar para que la tarea no pueda completarse manualmente desde el admin. Los administradores con el permiso **Cambiar estado de la Respuesta de una Tarea** pueden completarla de todas formas.
+- **Desactivar el completado manual** (Revisión pendiente): Oculta el botón **Completar** para que la tarea no pueda completarse manualmente desde el admin. Los administradores con el permiso **Cambiar estado de la Respuesta de una Tarea** pueden completarla de todas formas.
 - **Permitir same-origin** (Snippet de código): Otorga al iframe de la tarea acceso al origen del admin (sesión y cookies), desactivando el aislamiento del sandbox. Actívalo solo para snippets de confianza.
 
 #### Verificación de agentes para servicios externos
 
 Cuando un agente responde una tarea de Snippet de código, tu código puede obtener una credencial de corta vida (5 minutos) para que un servicio externo verifique que quien lo invoca es un agente autorizado sobre esa tarea y respuesta:
 
-1. Desde el iframe de la tarea, solicita la credencial en `GET .../agent_task_forms/{step_task_id}/assertion` (acepta el parámetro opcional `audience` con el identificador del servicio destino) y envíala al servicio externo.
-2. El servicio externo la valida en `POST /api/admin/customers/{realm_uid}/originations/agent_assertions/introspect` (requiere API Access con permiso de ver respuestas). La respuesta indica `active: true` con los identificadores del agente, la respuesta, la tarea y el usuario actuado, o `active: false` si la credencial expiró o la autorización fue revocada — la validación siempre revisa el estado vigente, no solo la firma.
+1. Desde el iframe de la tarea, solicita la credencial en `GET /admin/customers/{realm_uid}/originations/{origination_id}/submissions/{submission_id}/agent_task_forms/{step_task_id}/assertion` (misma base del admin en la que corre el iframe; acepta el parámetro opcional `audience` con el identificador del servicio destino) y envíala al servicio externo.
+2. El servicio externo la valida en `POST /api/admin/customers/{realm_uid}/originations/agent_assertions/introspect` (requiere API Access con un permiso que incluya ver respuestas: **Ver Todas las Respuestas** o **Ver Respuestas Asignadas**). La respuesta indica `active: true` con los identificadores del agente, la respuesta, la tarea y el usuario actuado, o `active: false` si la credencial expiró o la autorización fue revocada — la validación siempre revisa el estado vigente, no solo la firma.
 
 Puedes conocer el detalle de los endpoints en la documentación Swagger de la [API](/es/platform/core/api.html).
 


### PR DESCRIPTION
Documenta la asignación y respuesta de tareas por agentes, introducida en modyo/modyo#20008.

## Cambios propuestos

Se agrega la sección **Tareas respondidas por agentes** en la documentación de Origination (`docs/es/platform/customers/origination.md` y su versión en inglés):

- La opción **Asignado a** de cada tarea con sus modos **Usuario**/**Agente** y las reglas por tipo (Validación y Revisión pendiente siempre de agente; Input y Snippet de código en ambos modos).
- La resolución del asignado efectivo (respuesta a la tarea → configuración de la tarea → asignado de la respuesta), la reasignación con notificación, los correos de asignación y la vista **Mis tareas**.
- La experiencia de respuesta del agente desde la vista de la respuesta (fidelidad con el sitio: lógica condicional en vivo, archivos, grupos repetibles, snippets) y el **Mensaje de espera que ve el usuario**.
- Las opciones **Desactivar el completado manual** (Revisión pendiente, con el bypass del permiso Cambiar estado de la Respuesta de una Tarea) y **Permitir same-origin** (Snippet de código, con su advertencia de seguridad).
- Subsección **Verificación de agentes para servicios externos**: flujo de credencial de corta vida (assertion de 5 minutos con `audience` opcional) e introspección que revalida la autorización vigente, con referencia al Swagger para el detalle.

Los textos de la interfaz fueron validados contra los locales de la rama master de modyo/modyo. Build de VuePress validado localmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)