### PR TITLE
Validación de caracteres del nombre de usuario

### DIFF
--- a/docs/en/platform/core/roles.md
+++ b/docs/en/platform/core/roles.md
@@ -20,7 +20,7 @@ To create an internal user, follow these steps:
 1. Fill in the first name, last name, username, email, and password fields.
 1. Click **Save**.
 
-The username can only contain letters (a to z), numbers, and the symbols `| # @ % . _ - ' + /`. Spaces and other characters are not allowed.
+The username can only contain letters A to Z (uppercase or lowercase), numbers, and the symbols `| # @ % . _ - ' + /`. Spaces and other characters are not allowed.
 
 :::tip Tip
 If you want the new member to receive an email with their account details on the platform, check the box “Send password to the user's email”.

--- a/docs/en/platform/core/roles.md
+++ b/docs/en/platform/core/roles.md
@@ -20,6 +20,8 @@ To create an internal user, follow these steps:
 1. Fill in the first name, last name, username, email, and password fields.
 1. Click **Save**.
 
+The username can only contain letters (a to z), numbers, and the symbols `| # @ % . _ - ' + /`. Spaces and other characters are not allowed.
+
 :::tip Tip
 If you want the new member to receive an email with their account details on the platform, check the box “Send password to the user's email”.
 :::
@@ -34,6 +36,10 @@ Within the user edit screen, platform administrators have access to the followin
 - Edit: Modify user data such as name, email, and password.
 - Groups: Shows a list of all the groups to which the user belongs.
 - Devices: Shows a list of all devices where the user has an active session. It displays data such as browser, operating system, last login, and IP address. Here, in addition, you can remotely log out for each device.
+
+:::warning Usernames created in earlier versions
+Users created before the character validation existed may have usernames that are no longer allowed (for example, containing spaces). While the username does not meet the validation, any update to that user will fail — including administrative actions such as removing their authenticator (2FA), which may show a success message without actually taking effect. Before performing actions on one of these users, correct their username first.
+:::
 
 ## Groups
 

--- a/docs/en/platform/customers/users.md
+++ b/docs/en/platform/customers/users.md
@@ -38,7 +38,7 @@ To add a new user, click the **New User** button and complete the following fiel
 - **First Name**: **[Required]**. The user's legal first name.
 - **Surname**
 - **Maternal surname**
-- **Username**: **[Required]**. Unique identifier on the platform. It can only contain letters (a to z), numbers, and the symbols `| # @ % . _ - ' + /`; spaces are not allowed.
+- **Username**: **[Required]**. Unique identifier on the platform. It can only contain letters A to Z (uppercase or lowercase), numbers, and the symbols `| # @ % . _ - ' + /`; spaces are not allowed.
 - **Email**: **[Required]**
 - **Password**: **[Required]**. Must be at least 8 characters long.
 - **Password Confirmation**: **[Required]**

--- a/docs/en/platform/customers/users.md
+++ b/docs/en/platform/customers/users.md
@@ -38,7 +38,7 @@ To add a new user, click the **New User** button and complete the following fiel
 - **First Name**: **[Required]**. The user's legal first name.
 - **Surname**
 - **Maternal surname**
-- **Username**: **[Required]**. Unique identifier on the platform.
+- **Username**: **[Required]**. Unique identifier on the platform. It can only contain letters (a to z), numbers, and the symbols `| # @ % . _ - ' + /`; spaces are not allowed.
 - **Email**: **[Required]**
 - **Password**: **[Required]**. Must be at least 8 characters long.
 - **Password Confirmation**: **[Required]**

--- a/docs/es/platform/core/roles.md
+++ b/docs/es/platform/core/roles.md
@@ -20,6 +20,8 @@ Para crear un usuario interno, sigue estos pasos:
 1. Completa los campos de nombre, apellido, nombre de usuario, correo electrónico y contraseña.
 1. Haz click en **Guardar**.
 
+El nombre de usuario solo puede contener letras (de la a a la z), números y los símbolos `| # @ % . _ - ' + /`. No se permiten espacios ni otros caracteres.
+
 :::tip Tip
 Si deseas que el nuevo miembro reciba un correo electrónico con los datos de su cuenta en la plataforma, marca la casilla "Enviar contraseña al correo electrónico del usuario".
 :::
@@ -34,6 +36,10 @@ Dentro de la pantalla de edición de usuario, los administradores de la platafor
 - Editar: Modifica los datos del usuario como nombre, correo electrónico y contraseña.
 - Grupos: Muestra una lista de todos los grupos a los que pertenece el usuario.
 - Dispositivos: Muestra un listado de todos los dispositivos en los que el usuario tiene una sesión activa.  Despliega datos como navegador, sistema operativo, último inicio de sesión y dirección IP. Aquí, además, puedes cerrar la sesión de forma remota para cada dispositivo.
+
+:::warning Nombres de usuario creados en versiones anteriores
+Los usuarios creados antes de que existiera la validación de caracteres pueden tener nombres de usuario hoy no permitidos (por ejemplo, con espacios). Mientras el nombre de usuario no cumpla la validación, cualquier actualización de ese usuario fallará — incluidas acciones administrativas como eliminar su autenticador (2FA), que puede mostrar un mensaje de éxito sin aplicarse realmente. Antes de realizar acciones sobre uno de estos usuarios, corrige primero su nombre de usuario.
+:::
 
 ## Grupos
 

--- a/docs/es/platform/core/roles.md
+++ b/docs/es/platform/core/roles.md
@@ -20,7 +20,7 @@ Para crear un usuario interno, sigue estos pasos:
 1. Completa los campos de nombre, apellido, nombre de usuario, correo electrónico y contraseña.
 1. Haz click en **Guardar**.
 
-El nombre de usuario solo puede contener letras (de la a a la z), números y los símbolos `| # @ % . _ - ' + /`. No se permiten espacios ni otros caracteres.
+El nombre de usuario solo puede contener letras de la A a la Z (mayúsculas o minúsculas), números y los símbolos `| # @ % . _ - ' + /`. No se permiten espacios ni otros caracteres.
 
 :::tip Tip
 Si deseas que el nuevo miembro reciba un correo electrónico con los datos de su cuenta en la plataforma, marca la casilla "Enviar contraseña al correo electrónico del usuario".

--- a/docs/es/platform/customers/users.md
+++ b/docs/es/platform/customers/users.md
@@ -38,7 +38,7 @@ Para agregar un nuevo usuario, haz clic en el botón **Nuevo Usuario** y complet
 - **Nombre**: **[Requerido]**. Nombre legal del usuario.
 - **Apellido**
 - **Apellido materno**
-- **Nombre de usuario**: **[Requerido]**. Identificador único en la plataforma. Solo puede contener letras (de la a a la z), números y los símbolos `| # @ % . _ - ' + /`; no se permiten espacios.
+- **Nombre de usuario**: **[Requerido]**. Identificador único en la plataforma. Solo puede contener letras de la A a la Z (mayúsculas o minúsculas), números y los símbolos `| # @ % . _ - ' + /`; no se permiten espacios.
 - **Email**: **[Requerido]**
 - **Contraseña**: **[Requerido]**. Debe contener al menos 8 caracteres.
 - **Confirmación de contraseña**: **[Requerido]**

--- a/docs/es/platform/customers/users.md
+++ b/docs/es/platform/customers/users.md
@@ -38,7 +38,7 @@ Para agregar un nuevo usuario, haz clic en el botón **Nuevo Usuario** y complet
 - **Nombre**: **[Requerido]**. Nombre legal del usuario.
 - **Apellido**
 - **Apellido materno**
-- **Nombre de usuario**: **[Requerido]**. Identificador único en la plataforma.
+- **Nombre de usuario**: **[Requerido]**. Identificador único en la plataforma. Solo puede contener letras (de la a a la z), números y los símbolos `| # @ % . _ - ' + /`; no se permiten espacios.
 - **Email**: **[Requerido]**
 - **Contraseña**: **[Requerido]**. Debe contener al menos 8 caracteres.
 - **Confirmación de contraseña**: **[Requerido]**


### PR DESCRIPTION
Documenta el estado actual de la validación de caracteres del nombre de usuario, incorporada en Modyo 10, y su impacto en usuarios creados en versiones anteriores.

## Cambios propuestos

- **Equipos y Grupos** (`docs/es/platform/core/roles.md` y espejo EN):
  - En **Crear usuario**: la regla de caracteres del nombre de usuario — solo letras (a-z), números y los símbolos `| # @ % . _ - ' + /`; sin espacios ni otros caracteres.
  - En **Editar usuario**: warning sobre los nombres de usuario creados antes de la validación (por ejemplo, con espacios): mientras no cumplan la validación, cualquier actualización de ese usuario falla — incluidas acciones administrativas como eliminar su autenticador (2FA), que puede mostrar un mensaje de éxito sin aplicarse. La recomendación es corregir primero el nombre de usuario.
- **Usuarios** (`docs/es/platform/customers/users.md` y espejo EN): la misma regla de caracteres en el campo **Nombre de usuario** de la creación de usuarios de reino (la validación aplica a ambos modelos).

## Verificación contra el código

- Validador `app/validators/username_validator.rb`: `\A[a-zA-Z0-9|#@%._-'+/]+\z` (símbolos por defecto), aplicado a `AdminUser#username` y `User#username`; mensaje de error "solo puede contener letras (de la a a la z), números y algunos símbolos".
- Flujo verificado del 2FA: `Admin::AdminUsersController#remove_otp` ejecuta `update(otp_secret: nil)` sin verificar el resultado y muestra el flash de éxito incondicionalmente; con un username legacy inválido la validación hace fallar el update y el autenticador no se elimina.

🤖 Generated with [Claude Code](https://claude.com/claude-code)