### PR TITLE
Code splitting de widgets

### DIFF
--- a/docs/en/platform/channels/widgets.md
+++ b/docs/en/platform/channels/widgets.md
@@ -158,6 +158,28 @@ ES Module loading is especially useful for widgets built with modern frameworks 
 ES Modules have strict CORS requirements and are always loaded in strict mode. Ensure your widget code is compatible with ES module semantics before enabling this option.
 :::
 
+## Code splitting
+
+Widgets deployed through the [Modyo CLI](/en/platform/tools/cli.html) can be split into multiple files (*chunks*) in addition to their entry files. The platform stores and serves each chunk individually, and the widget loads them dynamically only when needed, making the initial load of large widgets lighter.
+
+To deploy a widget with code splitting, enable ZIP deployment in the CLI with the `MODYO_ZIP`, `MODYO_ZIP_ENTRY_JS`, and `MODYO_ZIP_ENTRY_CSS` variables. The build files other than the entry points (`js`, `css`, `map`, `wasm`) are uploaded as widget chunks.
+
+### Template requirement on existing sites
+
+The dynamic loading of chunks uses a global variable defined by each site's custom widget template. Sites created since this functionality exists already include it; sites created earlier keep their original template and require adding it manually.
+
+To enable it on an existing site, go to **Channels**, select your site, and click on **Templates**; in the views section, under the widgets category, edit the **custom_widget** template by adding this block at the beginning, and then publish the template:
+
+```liquid
+<script nonce="{{csp_nonce}}">
+  window['resourceBasePath-{{widget.wid}}'] = "{{site.url}}/widget_manager/{{widget.wid}}/{{widget.version}}/";
+</script>
+```
+
+:::warning Attention
+Without this block, widgets deployed with code splitting cannot resolve the URL of their chunks on that site and their dynamic loading fails.
+:::
+
 ## Use Internationalization (i18n)
 
 With i18n, you can configure and add new languages to your widgets.

--- a/docs/en/platform/tools/cli.md
+++ b/docs/en/platform/tools/cli.md
@@ -108,7 +108,7 @@ MODYO_ZIP_ENTRY_CSS=main.css
 - `MODYO_ZIP_ENTRY_CSS` Specifies the main CSS entry file when using ZIP deployment (default: `main.css`).
 
 :::warning Code splitting on existing sites
-The dynamic loading of chunks requires the site's custom widget template to include the `resourceBasePath` variable. Sites created before this functionality must update their template; see [Code splitting](/en/platform/channels/widgets.html#code-splitting).
+The dynamic loading of chunks requires the site's custom widget template to define the `resourceBasePath-<widget id>` global variable (one per widget). Sites created before this functionality must update their template; see [Code splitting](/en/platform/channels/widgets.html#code-splitting).
 :::
 
 ## Initializing a New Project

--- a/docs/en/platform/tools/cli.md
+++ b/docs/en/platform/tools/cli.md
@@ -107,6 +107,10 @@ MODYO_ZIP_ENTRY_CSS=main.css
 - `MODYO_ZIP_ENTRY_JS` Specifies the main JavaScript entry file when using ZIP deployment (default: `main.js`).
 - `MODYO_ZIP_ENTRY_CSS` Specifies the main CSS entry file when using ZIP deployment (default: `main.css`).
 
+:::warning Code splitting on existing sites
+The dynamic loading of chunks requires the site's custom widget template to include the `resourceBasePath` variable. Sites created before this functionality must update their template; see [Code splitting](/en/platform/channels/widgets.html#code-splitting).
+:::
+
 ## Initializing a New Project
 
 The quickest and easiest way to create your first widget is by using our framework's React base template through the `get` command.

--- a/docs/es/platform/channels/widgets.md
+++ b/docs/es/platform/channels/widgets.md
@@ -158,6 +158,28 @@ La carga como ES Module es especialmente útil para widgets construidos con fram
 Los ES Modules tienen requisitos estrictos de CORS y siempre se cargan en modo estricto. Asegúrate de que el código de tu widget sea compatible con la semántica de ES modules antes de habilitar esta opción.
 :::
 
+## Code splitting
+
+Los widgets que despliegas mediante el [CLI de Modyo](/es/platform/tools/cli.html) pueden dividirse en múltiples archivos (*chunks*) además de sus archivos de entrada. La plataforma almacena y sirve cada chunk individualmente, y el widget los carga de forma dinámica solo cuando los necesita, con lo que la carga inicial de widgets grandes es más liviana.
+
+Para desplegar un widget con code splitting, habilita el despliegue ZIP en el CLI con las variables `MODYO_ZIP`, `MODYO_ZIP_ENTRY_JS` y `MODYO_ZIP_ENTRY_CSS`. Los archivos del build adicionales a los de entrada (`js`, `css`, `map`, `wasm`) se suben como chunks del widget.
+
+### Requisito de la plantilla en sitios existentes
+
+La carga dinámica de los chunks utiliza una variable global que define la plantilla del custom widget de cada sitio. Los sitios creados desde que existe esta funcionalidad ya la incluyen; los sitios creados antes conservan su plantilla original y requieren agregarla manualmente.
+
+Para habilitarla en un sitio existente, ve a **Channels**, selecciona tu sitio y haz click en **Plantillas**; en la sección de vistas, bajo la categoría widgets, edita la plantilla **custom_widget** agregando al inicio este bloque, y luego publica la plantilla:
+
+```liquid
+<script nonce="{{csp_nonce}}">
+  window['resourceBasePath-{{widget.wid}}'] = "{{site.url}}/widget_manager/{{widget.wid}}/{{widget.version}}/";
+</script>
+```
+
+:::warning Atención
+Sin este bloque, los widgets desplegados con code splitting no pueden resolver la URL de sus chunks en ese sitio y su carga dinámica falla.
+:::
+
 ## Usar Internacionalización (i18n)
 
 Con i18n puedes configurar y agregar nuevos idiomas a tus widgets.

--- a/docs/es/platform/tools/cli.md
+++ b/docs/es/platform/tools/cli.md
@@ -107,6 +107,10 @@ MODYO_ZIP_ENTRY_CSS=main.css
 - `MODYO_ZIP_ENTRY_JS` Especifica el archivo JavaScript de entrada principal al usar despliegue ZIP (por defecto: `main.js`).
 - `MODYO_ZIP_ENTRY_CSS` Especifica el archivo CSS de entrada principal al usar despliegue ZIP (por defecto: `main.css`).
 
+:::warning Code splitting en sitios existentes
+La carga dinámica de los chunks requiere que la plantilla del custom widget del sitio incluya la variable `resourceBasePath`. Los sitios creados antes de esta funcionalidad deben actualizar su plantilla; consulta [Code splitting](/es/platform/channels/widgets.html#code-splitting).
+:::
+
 ## Inicialización de un Nuevo Proyecto
 
 La forma más rápida y fácil de crear tu primer widget es utilizando la plantilla base en React de nuestro framework mediante el comando `get`.

--- a/docs/es/platform/tools/cli.md
+++ b/docs/es/platform/tools/cli.md
@@ -108,7 +108,7 @@ MODYO_ZIP_ENTRY_CSS=main.css
 - `MODYO_ZIP_ENTRY_CSS` Especifica el archivo CSS de entrada principal al usar despliegue ZIP (por defecto: `main.css`).
 
 :::warning Code splitting en sitios existentes
-La carga dinámica de los chunks requiere que la plantilla del custom widget del sitio incluya la variable `resourceBasePath`. Los sitios creados antes de esta funcionalidad deben actualizar su plantilla; consulta [Code splitting](/es/platform/channels/widgets.html#code-splitting).
+La carga dinámica de los chunks requiere que la plantilla del custom widget del sitio defina la variable global `resourceBasePath-<id del widget>` (una por widget). Los sitios creados antes de esta funcionalidad deben actualizar su plantilla; consulta [Code splitting](/es/platform/channels/widgets.html#code-splitting).
 :::
 
 ## Inicialización de un Nuevo Proyecto


### PR DESCRIPTION
Documenta el estado actual del code splitting de widgets desplegados por el CLI y el requisito de plantilla en sitios creados antes de la funcionalidad.

## Cambios propuestos

- **Widgets** (`docs/es/platform/channels/widgets.md` y espejo EN): nueva sección **Code splitting** —
  - Qué hace: los widgets desplegados por el CLI pueden dividirse en chunks (además de los archivos de entrada) que la plataforma almacena y sirve individualmente con carga dinámica bajo demanda, aliviando la carga inicial de widgets grandes.
  - Cómo se habilita en el despliegue: variables `MODYO_ZIP`, `MODYO_ZIP_ENTRY_JS` y `MODYO_ZIP_ENTRY_CSS` del CLI (los archivos js/css/map/wasm adicionales se suben como chunks).
  - **Requisito de la plantilla en sitios existentes**: la carga dinámica usa una variable global definida en la plantilla del custom widget de cada sitio; los sitios creados antes de la funcionalidad conservan su plantilla original y deben agregar el bloque `resourceBasePath` (incluido en la doc con el código exacto) y publicar la plantilla. Warning con el síntoma si falta.
- **CLI** (`docs/es/platform/tools/cli.md` y espejo EN): warning junto a las variables `MODYO_ZIP*` enlazando al requisito de plantilla.

## Verificación contra el código

- Chunks almacenados como templates `widgets/chunk/<uuid>/...` y servidos por `GET /widget_manager/:uuid/:version/(*chunk)` (`config/routes.rb`, `Dispatch::SearchWidget`); extensiones aceptadas `css,js,html,map,wasm` (`Api::Admin::WidgetDefinitionsController`).
- El soporte se agregó en modyo#14246 junto con la migración `RestoreDefaultTheme`: el bloque `resourceBasePath` quedó en la plantilla `_custom_widget.html.liquid` del tema por defecto (sitios nuevos); cada sitio renderiza su propia copia (`Templates::SiteTemplate` por `site_id`), por lo que los sitios anteriores no lo tienen hasta editar su plantilla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)