### PR TITLE
Actualización de la sección SEO: sitemap.xml y robots.txt por sitio

### DIFF
--- a/docs/en/platform/channels/sites.md
+++ b/docs/en/platform/channels/sites.md
@@ -239,14 +239,13 @@ SEO (Search Engine Optimization) is fundamental for search engine positioning. U
 You can configure:
 
 - **Tagline**: Description in search engines, below the web application name.
-- **Automatically update the sitemap.xml file for me**: Allows Modyo to automatically create and maintain the sitemap.xml. Disable this option to use a custom sitemap.
-- **Sitemap**: This XML file allows search engines to index the site's content.
-- **Custom sitemap.xml file**: File that allows search engines to index the web app's content.
-- **Automatically update the robots.txt file for me**: Allows Modyo to automatically create and maintain robots.txt. Disable this option to provide custom instructions to web app crawlers.
-- **Custom robots.txt file**: File that tells web crawlers which parts of the application they may or may not index.
+- **Enable sitemap.xml from this site**: Publishes the web application's `sitemap.xml` file, available for all sites. If you disable it, the file URL responds with a 404 error.
+- **Automatically update the sitemap.xml file for me**: Allows Modyo to automatically create and maintain the sitemap.xml. Disable this option to edit the custom file.
+- **Custom sitemap.xml file**: Sitemap content that allows search engines to index the web app's content. Editable when the automatic update is disabled.
+- **Enable robots.txt from this site**: Publishes the site's `robots.txt` file and enables its editing. This option is only available for sites with a custom domain enabled; if it is disabled, the file URL responds with a 404 error.
+- **Custom robots.txt file**: Content of the robots.txt, which tells web crawlers which parts of the application they may or may not index.
 
 :::tip Tip
-Manual updates to the robots.txt file can only be enabled for custom domains. 
 There are also sitemap.xml and robots.txt file configurations at the account level.
 :::
 

--- a/docs/en/platform/channels/sites.md
+++ b/docs/en/platform/channels/sites.md
@@ -239,8 +239,8 @@ SEO (Search Engine Optimization) is fundamental for search engine positioning. U
 You can configure:
 
 - **Tagline**: Description in search engines, below the web application name.
-- **Enable sitemap.xml from this site**: Publishes the web application's `sitemap.xml` file, available for all sites. If you disable it, the file URL responds with a 404 error.
-- **Automatically update the sitemap.xml file for me**: Allows Modyo to automatically create and maintain the sitemap.xml. Disable this option to edit the custom file.
+- **Enable sitemap.xml from this site**: Publishes the web application's `sitemap.xml` file, available for all public sites. If you disable it, or if the site is not public, the file URL responds with a 404 error.
+- **Automatically update the sitemap.xml file for me**: Allows Modyo to automatically create and maintain the sitemap.xml; the generated file does not include private pages. Disable this option to edit the custom file.
 - **Custom sitemap.xml file**: Sitemap content that allows search engines to index the web app's content. Editable when the automatic update is disabled.
 - **Enable robots.txt from this site**: Publishes the site's `robots.txt` file and enables its editing. This option is only available for sites with a custom domain enabled; if it is disabled, the file URL responds with a 404 error.
 - **Custom robots.txt file**: Content of the robots.txt, which tells web crawlers which parts of the application they may or may not index.

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -239,14 +239,13 @@ El SEO (Search Engine Optimization) es fundamental para el posicionamiento en mo
 Puedes configurar:
 
 - **Tagline**: Descripción en los motores de búsqueda, debajo del nombre de la aplicación web.
-- **Actualizar automáticamente el archivo sitemap.xml para mí**: Permite a Modyo crear y mantener el sitemap.xml automáticamente. Desactiva esta opción para usar un mapa de sitio personalizado.
-- **Sitemap**: Este archivo XML permite a los motores de búsqueda indexar el contenido del sitio.
-- **Archivo sitemap.xml personalizado**: Archivo que permite a los motores de búsqueda indexar el contenido de la web app.
-- **Actualizar automáticamente el archivo robots.xml para mí**: Permite a Modyo crear y mantener robots.txt automáticamente. Desactiva esta opción para proporcionar instrucciones personalizadas a los rastreadores de web apps.
-- **Archivo robots.txt personalizado**: Archivo que indica a los robots rastreadores las partes de la aplicación pueden o no indexar.
+- **Habilitar sitemap.xml de este sitio**: Publica el archivo `sitemap.xml` de la aplicación web, disponible para todos los sitios. Si lo deshabilitas, la URL del archivo responde con un error 404.
+- **Actualizar automáticamente el archivo sitemap.xml para mí**: Permite a Modyo crear y mantener el sitemap.xml automáticamente. Desactiva esta opción para editar el archivo personalizado.
+- **Archivo sitemap.xml personalizado**: Contenido del sitemap que permite a los motores de búsqueda indexar el contenido de la web app. Editable cuando la actualización automática está desactivada.
+- **Habilitar robots.txt de este sitio**: Publica el archivo `robots.txt` del sitio y habilita su edición. Esta opción solo está disponible para sitios con dominio personalizado habilitado; si está deshabilitada, la URL del archivo responde con un error 404.
+- **Archivo robots.txt personalizado**: Contenido del robots.txt, que indica a los robots rastreadores qué partes de la aplicación pueden o no indexar.
 
 :::tip Tip
-La actualización manual del archivo robots.txt solo se puede habilitar para dominios personalizados.
 También existen configuraciones de archivos sitemap.xml y robots.txt a nivel de la cuenta.
 :::
 

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -239,8 +239,8 @@ El SEO (Search Engine Optimization) es fundamental para el posicionamiento en mo
 Puedes configurar:
 
 - **Tagline**: Descripción en los motores de búsqueda, debajo del nombre de la aplicación web.
-- **Habilitar sitemap.xml de este sitio**: Publica el archivo `sitemap.xml` de la aplicación web, disponible para todos los sitios. Si lo deshabilitas, la URL del archivo responde con un error 404.
-- **Actualizar automáticamente el archivo sitemap.xml para mí**: Permite a Modyo crear y mantener el sitemap.xml automáticamente. Desactiva esta opción para editar el archivo personalizado.
+- **Habilitar sitemap.xml de este sitio**: Publica el archivo `sitemap.xml` de la aplicación web, disponible para todos los sitios públicos. Si lo deshabilitas, o si el sitio no es público, la URL del archivo responde con un error 404.
+- **Actualizar automáticamente el archivo sitemap.xml para mí**: Permite a Modyo crear y mantener el sitemap.xml automáticamente; el archivo generado no incluye páginas privadas. Desactiva esta opción para editar el archivo personalizado.
 - **Archivo sitemap.xml personalizado**: Contenido del sitemap que permite a los motores de búsqueda indexar el contenido de la web app. Editable cuando la actualización automática está desactivada.
 - **Habilitar robots.txt de este sitio**: Publica el archivo `robots.txt` del sitio y habilita su edición. Esta opción solo está disponible para sitios con dominio personalizado habilitado; si está deshabilitada, la URL del archivo responde con un error 404.
 - **Archivo robots.txt personalizado**: Contenido del robots.txt, que indica a los robots rastreadores qué partes de la aplicación pueden o no indexar.


### PR DESCRIPTION
Corrige la sección **SEO** de Aplicaciones Web, que describía un modelo desactualizado de robots.txt/sitemap.xml (modificado en modyo/modyo#16320).

## Cambios propuestos

Se reescribe el listado de opciones de SEO (`docs/es/platform/channels/sites.md` y espejo EN) al estado actual:

- Se documentan los checkboxes **Habilitar sitemap.xml de este sitio** y **Habilitar robots.txt de este sitio**, con su efecto al deshabilitarlos (la URL del archivo responde 404).
- **sitemap.xml**: disponible y personalizable para todos los sitios (automático o personalizado), sin requerir dominio personalizado.
- **robots.txt**: personalizable, pero la opción solo está disponible para sitios con dominio personalizado habilitado.
- Se elimina el bullet inexistente "Actualizar automáticamente el archivo robots.xml para mí" (robots no tiene modo automático: solo habilitar + editor del archivo personalizado) y un bullet duplicado de Sitemap.
- El tip conserva la referencia a las configuraciones equivalentes a nivel de cuenta.

## Verificación contra el código

- `Site::BaseController#verify_site_map_access`: 404 si `enable_sitemap` está deshabilitado; `render_sitemap` sirve `custom_sitemap` salvo que `use_auto_sitemap` esté activo (sin condición de dominio).
- `Site::BaseController#verify_robots_access`: 404 salvo `enable_robots` Y dominio personalizado habilitado con host presente; sirve `custom_robots` (editable, con default `User-agent: * / Allow: /`).
- UI `GeneralSeoSettingsSection.js` y labels en `config/locales/admin/{es,en}.yml` (enable_robots deshabilitado sin dominio personalizado, con el hint correspondiente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)