### PR TITLE
Agregar soporte para llms.txt

### DIFF
--- a/docs/en/platform/channels/sites.md
+++ b/docs/en/platform/channels/sites.md
@@ -244,10 +244,13 @@ You can configure:
 - **Custom sitemap.xml file**: File that allows search engines to index the web app's content.
 - **Automatically update the robots.txt file for me**: Allows Modyo to automatically create and maintain robots.txt. Disable this option to provide custom instructions to web app crawlers.
 - **Custom robots.txt file**: File that tells web crawlers which parts of the application they may or may not index.
+- **Enable llms.txt from this site**: Publishes the web application's `llms.txt` file at the `/llms.txt` path. It is a Markdown file that helps large language models (LLMs) understand the site's content, and it is available for all public sites. This option is disabled by default; if it is disabled, or if the site is not public, the file URL responds with a 404 error.
+- **Automatically update the llms.txt file for me**: Allows Modyo to automatically create and maintain the llms.txt with the web application's name, tagline, and description, plus links to its pages grouped into the **Pages** and **Content** sections. Private pages are never included. Disable this option to edit the custom file.
+- **Custom llms.txt file**: Content of the llms.txt when automatic updates are disabled.
 
 :::tip Tip
 Manual updates to the robots.txt file can only be enabled for custom domains. 
-There are also sitemap.xml and robots.txt file configurations at the account level.
+There are also sitemap.xml, robots.txt, and llms.txt file configurations at the account level. The account's llms.txt is enabled by default, is generated from the public production sites without a custom domain that you add to its list, and also supports a custom file.
 :::
 
 - **Custom meta tags**: Allows you to configure meta tags for all pages and their default values. Click **+ new meta tag** to create a new one.

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -244,10 +244,13 @@ Puedes configurar:
 - **Archivo sitemap.xml personalizado**: Archivo que permite a los motores de búsqueda indexar el contenido de la web app.
 - **Actualizar automáticamente el archivo robots.xml para mí**: Permite a Modyo crear y mantener robots.txt automáticamente. Desactiva esta opción para proporcionar instrucciones personalizadas a los rastreadores de web apps.
 - **Archivo robots.txt personalizado**: Archivo que indica a los robots rastreadores las partes de la aplicación pueden o no indexar.
+- **Habilitar llms.txt de este sitio**: Publica el archivo `llms.txt` de la aplicación web en la ruta `/llms.txt`. Es un archivo en formato Markdown que ayuda a los modelos de lenguaje (LLMs) a entender el contenido del sitio, y está disponible para todos los sitios públicos. Esta opción viene deshabilitada por defecto; si está deshabilitada, o si el sitio no es público, la URL del archivo responde con un error 404.
+- **Actualizar automáticamente el archivo llms.txt para mí**: Permite a Modyo crear y mantener el llms.txt automáticamente con el nombre, el tagline y la descripción de la aplicación web, más los enlaces a sus páginas agrupados en las secciones **Pages** y **Content**. Las páginas privadas nunca se incluyen. Desactiva esta opción para editar el archivo personalizado.
+- **Archivo llms.txt personalizado**: Contenido del llms.txt cuando la actualización automática está desactivada.
 
 :::tip Tip
 La actualización manual del archivo robots.txt solo se puede habilitar para dominios personalizados.
-También existen configuraciones de archivos sitemap.xml y robots.txt a nivel de la cuenta.
+También existen configuraciones de archivos sitemap.xml, robots.txt y llms.txt a nivel de la cuenta. El llms.txt de la cuenta está habilitado por defecto, se genera con los sitios públicos en producción y sin dominio personalizado que agregues a su lista, y también admite un archivo personalizado.
 :::
 
 - **Meta tags personalizados**: Te permite configurar meta tags para todas las páginas y sus valores por defecto. Da click en **nuevo meta tag** para crear uno nuevo.


### PR DESCRIPTION
## Cambios propuestos

Documenta el soporte de `llms.txt` introducido en modyo/modyo#19769 (issue modyo/modyo#18995):

- Nuevos ajustes por sitio en la sección **SEO** de la configuración: **Habilitar llms.txt de este sitio**, **Actualizar automáticamente el archivo llms.txt para mí** y **Archivo llms.txt personalizado**, con su comportamiento verificado: deshabilitado por defecto, la URL `/llms.txt` responde 404 si la opción está deshabilitada o el sitio no es público, y la generación automática incluye nombre, tagline y descripción del sitio más enlaces agrupados en las secciones **Pages** y **Content**, excluyendo siempre las páginas privadas.
- Actualiza el tip de nivel de cuenta: el llms.txt de la cuenta está habilitado por defecto, se genera con los sitios públicos en producción sin dominio personalizado agregados a su lista, y admite archivo personalizado.
- Espejo en inglés en el mismo PR.

Convive con #975, que reescribe bullets de la misma sección SEO: el conflicto al mergear en secuencia es trivial (conservar los bullets de ambos PRs).

Verificación técnica: rutas `/llms.txt` de sitio y cuenta (`config/routes.rb`), guardas `verify_llms_access` (`site/base_controller.rb`, `admin/base_controller.rb`), generación automática (`Site#default_llms`, `Account#default_llms`, `Account#llms_site_section`), labels exactos en `config/locales/admin/{es,en}.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)