### PR TITLE
Restringir asociación Origination-Page a 1-1 y corregir clonado/sincronización entre stages

### DIFF
--- a/docs/en/platform/channels/sites.md
+++ b/docs/en/platform/channels/sites.md
@@ -219,7 +219,7 @@ Proceed with caution when modifying these options, as they can affect access to 
 :::
 
 - **Change host**: This action modifies the visibility and accessibility of the application. Changing the host can impact the visibility and availability of the web application.
-- **Change realm**: Displays the application's realm. When you change the realm, you lose all privacy settings in your web apps, pages, and navigation.
+- **Change realm**: Displays the application's realm. When you change the realm, you lose all privacy settings in your web apps, pages, and navigation, and the site's origination pages lose the reference to their current origination.
 - **Change status**: Changes the application's status. Options are:
 	* Enabled: Editable and visible to the public. This is the default state of a web app.
 	* Editable: Modifiable but not visible to the public. Requires login to access. Robots.txt, PWAs, and the manifest are disabled in this state.
@@ -464,6 +464,7 @@ The main advantages of having different stages in your web apps are:
 - Custom PWAs and redirections are disabled in stages. They can only be used in the `main` stage.
 - The team members section is separate in each `main` stage. Add members to enable team review.
 - You can have the same members with different roles and permissions for each stage.
+- Origination pages are copied to the new stage without their linked origination. Since each origination allows only one page, to use them in the stage you must link a different origination from the same realm.
 :::
 
 #### Add a New Stage
@@ -501,7 +502,8 @@ To synchronize a stage, follow these steps:
 
 
 :::warning Attention
-Elements of a stage associated with a segment are not synchronized. You must repeat the process manually in the new stage, once the synchronization is complete.
+- Elements of a stage associated with a segment are not synchronized. You must repeat the process manually in the new stage, once the synchronization is complete.
+- The origination linked to an origination page is not synchronized either: each stage keeps its own, and that difference does not appear in the list of elements to synchronize.
 :::
 
 #### Delete a Stage

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -692,4 +692,18 @@ Users will be able to access the origination page to perform the configured flow
 
 Access to this page will be restricted depending on the privacy and segmentation settings established in the origination. This ensures that only authorized segments can interact with the flow, maintaining control and security of the information.
 
-It is important to note that each origination can only be linked to one page. If you need to create a new origination page, you will first need to unlink or delete the existing page to avoid conflicts and ensure proper configuration.
+It is important to note that each origination can only be linked to one page across your entire organization. This includes pages on other sites and pages on the stages of the same site: if the origination is already linked to another page, the platform does not let you save the new one. If you need to create a new origination page, you will first need to unlink or delete the existing page to avoid conflicts and ensure proper configuration.
+
+The origination you link must belong to the same realm as the site where you create the page. If the site is connected to a different realm, the platform rejects the link and indicates that the origination must belong to the site's realm.
+
+### Pages without a linked origination
+
+An origination page can be left without a linked origination. While it is in that state, the page responds to end users with a 404 error, so you must link an origination to deploy the flow again.
+
+This happens in three situations:
+
+- **You delete the origination**: the page remains on the site, but without a linked origination.
+- **You change the site's realm**: all origination pages on that site lose the reference, because each origination belongs to a realm. The application settings form warns you about this before you confirm the change.
+- **You create a stage**: origination pages are copied to the stage without their linked origination. Since each origination allows only one page, in the stage you must link a different origination from the same realm.
+
+For more details on how stages behave, review the [stages](/en/platform/channels/sites.html#stages) section of web applications.

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -219,7 +219,7 @@ Procede con cautela al modificar estas opciones, ya que pueden afectar el acceso
 :::
 
 - **Cambiar host**: Esta acción modifica la visibilidad y accesibilidad de la aplicación. Realizar un cambio de host puede impactar la visibilidad y disponibilidad de la aplicación web.
-- **Cambiar reino**: Despliega el reino de la aplicación. Al cambiar de reino pierdes toda la configuración de privacidad en tus web apps, páginas y navegación.
+- **Cambiar reino**: Despliega el reino de la aplicación. Al cambiar de reino pierdes toda la configuración de privacidad en tus web apps, páginas y navegación, y las páginas de originación del sitio pierden la referencia a su originación actual.
 - **Cambiar estado**: Cambia el estado de la aplicación, las opciones son:
 	* Habilitado: Editable y visible al público. Este es el estado por defecto de una web app.
 	* Editable: Modificable pero no visible al público. Requiere inicio de sesión para acceder. Robots.txt, PWAs y el manifiesto están deshabilitados en este estado.
@@ -464,6 +464,7 @@ Las principales ventajas de tener distintas etapas en tus web apps son:
 - Las PWAs y redirecciones personalizadas se deshabilitan en los stages. Solo se pueden usar en el stage `main`.
 - La sección de miembros del equipos es independiente en cada stage `main`. Agrega miembros para habilitar la revisión de equipo.
 - Puedes tener los mismos miembros con diferentes roles y permisos para cada stage.
+- Las páginas de originación se copian al nuevo stage sin la originación vinculada. Como cada originación admite una sola página, para usarlas en el stage debes vincular una originación distinta del mismo reino.
 :::
 
 #### Agregar un nuevo stage
@@ -501,7 +502,8 @@ Para sincronizar un stage sigue estos pasos:
 
 
 :::warning Atención
-Los elementos de un stage asociados a un segmento no se sincronizan. Deberás repetir el proceso manualmente en el nuevo stage, una vez concluida la sincronización.
+- Los elementos de un stage asociados a un segmento no se sincronizan. Deberás repetir el proceso manualmente en el nuevo stage, una vez concluida la sincronización.
+- La originación vinculada a una página de originación tampoco se sincroniza: cada stage conserva la suya y esa diferencia no aparece en el listado de elementos por sincronizar.
 :::
 
 #### Eliminar un stage

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -693,4 +693,18 @@ Los usuarios podrán acceder a la página de originación para realizar el flujo
 
 El acceso a esta página estará restringido según las configuraciones de privacidad y segmentación establecidas en la originación. Esto asegura que solo los segmentos autorizados puedan interactuar con el flujo, manteniendo el control y la seguridad de la información.
 
-Es importante tener en cuenta que cada originación puede estar vinculada únicamente a una página. Si necesitas crear una nueva página de originación, primero será necesario desvincular o eliminar la página existente para evitar conflictos y asegurar una configuración adecuada.
+Es importante tener en cuenta que cada originación puede estar vinculada únicamente a una página en toda tu organización. Esto incluye las páginas de otros sitios y las de los stages de un mismo sitio: si la originación ya está vinculada a otra página, la plataforma no te permite guardar la nueva. Si necesitas crear una nueva página de originación, primero será necesario desvincular o eliminar la página existente para evitar conflictos y asegurar una configuración adecuada.
+
+La originación que vincules debe pertenecer al mismo reino que el sitio donde creas la página. Si el sitio está conectado a otro reino, la plataforma rechaza el vínculo e indica que la originación debe pertenecer al reino del sitio.
+
+### Páginas sin originación vinculada
+
+Una página de originación puede quedar sin originación vinculada. Mientras esté en ese estado, la página responde a los usuarios finales con un error 404, por lo que debes vincularle una originación para volver a desplegar el flujo.
+
+Esto ocurre en tres situaciones:
+
+- **Eliminas la originación**: la página se mantiene en el sitio, pero sin originación vinculada.
+- **Cambias el reino del sitio**: todas las páginas de originación de ese sitio pierden la referencia, porque cada originación pertenece a un reino. El formulario de configuración de la aplicación te advierte de esto antes de que confirmes el cambio.
+- **Creas un stage**: las páginas de originación se copian al stage sin la originación vinculada. Como cada originación admite una sola página, en el stage debes vincular una originación distinta del mismo reino.
+
+Para más detalles sobre el comportamiento de los stages, revisa la sección [stages](/es/platform/channels/sites.html#stages) de las aplicaciones web.


### PR DESCRIPTION
## Cambios propuestos

Documenta las reglas del vínculo entre una originación y su página de originación, y qué pasa cuando ese vínculo se pierde.

**`platform/customers/origination.md`** — sección *Crear una Página de Originación*:
- Precisa que el vínculo uno a uno aplica a toda la organización, incluidas las páginas de otros sitios y las de los stages de un mismo sitio.
- Agrega la regla de reino: la originación vinculada debe pertenecer al mismo reino que el sitio de la página.
- Nueva subsección *Páginas sin originación vinculada*: una página en ese estado responde 404 a los usuarios finales, y se explican las tres situaciones que lo provocan (eliminar la originación, cambiar el reino del sitio, crear un stage), con enlace a la sección de stages.

**`platform/channels/sites.md`**:
- *Zona peligrosa* → **Cambiar reino**: agrega que las páginas de originación del sitio pierden la referencia a su originación actual, alineado con la advertencia que ahora muestra el formulario.
- *Stages*: agrega que las páginas de originación se copian al nuevo stage sin la originación vinculada y que, por la regla de una sola página por originación, en el stage hay que vincular una originación distinta del mismo reino.
- *Sincronizar un stage*: agrega que la originación vinculada no se sincroniza entre stages y que esa diferencia no aparece en el listado de elementos por sincronizar.

Espejo en inglés incluido en ambas páginas.

Referencia: modyo/modyo#20133

Build local de VuePress verificado (`success`), con los anclajes de los links nuevos comprobados en `docs/.vuepress/dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
