### PR TITLE
Permisos granulares para submissions: desacoplar creación/asignación, listado y detalle

### DIFF
--- a/docs/en/platform/core/roles.md
+++ b/docs/en/platform/core/roles.md
@@ -123,6 +123,8 @@ To create a custom role, select the **New Role** button and define its **scope**
 
 When you create a new role or select an existing one, you will be able to view and modify all its associated permissions and accesses. If you select the **All** option, you will automatically assign all permissions to the role.
 
+Some permissions include others: when you check one, the platform also checks the ones that permission needs to work. The most granular case is origination submissions, with three tiers of detail visibility; review [submission visibility permissions](/en/platform/customers/origination.html#submission-visibility-permissions).
+
 To keep the changes, press the **Save** button.
 
 ### Access to applications

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -571,6 +571,7 @@ In the details view, you will find the following main sections:
 - **Fields**: Fields configured in the flow to collect user information.
 - **Documents**: Files uploaded by users or required for the origination process.
 - **Signatures**: Tracking of the digital signatures collected during the flow.
+- **Identity Verification**: Result of the user's identity verification when the flow includes it.
 - **Validations**: Validations carried out by administrators to authorize progress.
 - **Activity**: Record of activities and changes made to the submission, useful for monitoring and auditing.
 
@@ -584,6 +585,27 @@ From the submission view in the actions menu (identified with ...), you can [imp
 
 :::tip Segment scope
 If your access to the realm is [restricted by segments](/en/platform/customers/settings.html#restrict-scope-with-segments), you will only see the submissions of the users within your scope. Submissions assigned to you remain visible and operable even if the user belongs to segments outside your scope.
+:::
+
+#### Submission visibility permissions
+
+The role's permissions decide which submissions a team member sees and how much of each one. In the role's Customers permissions there are four that work in tiers:
+
+- **List Assigned Submissions**: in the list they only see the submissions assigned to them and, when opening one, only the **Details** section.
+- **List All Submissions**: they see every submission, not only the ones assigned to them. It includes **List Assigned Submissions**.
+- **View Submission Tasks**: adds the **Tasks** section, with the ability to assign and complete tasks and to approve or reject validations. It includes **List Assigned Submissions**.
+- **View Full Submission**: adds the remaining sections, **Fields**, **Documents**, **Signatures**, **Identity Verification**, **Validations** and **Activity**. It includes **View Submission Tasks**.
+
+When you check a permission, the platform also checks the ones that permission includes. The sections a role cannot see do not appear in the submission menu.
+
+The action permissions build on those tiers: **Edit Submissions** requires **View Full Submission**; **Assign Submissions** requires **List All Submissions**; **Delete Submissions** and **Complete Submissions** require **List Assigned Submissions**.
+
+:::tip Tip
+**Start Submissions** is independent from the visibility permissions: a role can create submissions on behalf of a user without seeing the full list or the detail.
+:::
+
+:::warning Attention
+The roles you already had keep the access they had: those that saw the full detail keep **View Full Submission**, and those that had **Start Submissions** also keep **Assign Submissions** and **List All Submissions**. The separate tiers apply when you edit the role.
 :::
 
 #### Search submissions

--- a/docs/es/platform/core/roles.md
+++ b/docs/es/platform/core/roles.md
@@ -123,6 +123,8 @@ Para crear un rol a medida, selecciona el botón **Nuevo Rol** y define su **sco
 
 Al crear un nuevo rol o seleccionar uno existente, podrás ver y modificar todos sus permisos y accesos asociados. Si seleccionas la opción **Todos**, asignarás automáticamente todos los permisos al rol.
 
+Algunos permisos incluyen a otros: al marcar uno, la plataforma marca también los que ese permiso necesita para funcionar. El caso más granular son las respuestas de originación, con tres niveles de visibilidad del detalle; revisa [permisos de visibilidad de las respuestas](/es/platform/customers/origination.html#permisos-de-visibilidad-de-las-respuestas).
+
 Para conservar los cambios, presiona el botón **Guardar**.
 
 ### Acceso a las aplicaciones

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -572,6 +572,7 @@ En la vista de detalles, encontrarás las siguientes secciones principales:
 - **Campos**: Campos configurados en el flujo para recopilar información del usuario.
 - **Documentos**: Archivos subidos por los usuarios o necesarios para el proceso de originación.
 - **Firmas**: Seguimiento de las firmas digitales recolectadas durante el flujo.
+- **Verificación de Identidad**: Resultado de la verificación de identidad del usuario cuando el flujo la incluye.
 - **Validaciones**: Validaciones realizadas por los administradores para autorizar el progreso.
 - **Actividad**: Registro de actividades y cambios realizados en la respuesta, útil para seguimiento y auditoría.
 
@@ -585,6 +586,27 @@ Desde la vista de una respuesta en el menú de acciones (identificado con …) s
 
 :::tip Alcance por segmentos
 Si tu acceso al reino está [restringido por segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos), solo verás las respuestas de los usuarios de tu alcance. Las respuestas que tengas asignadas siguen visibles y operables aunque el usuario pertenezca a segmentos fuera de tu alcance.
+:::
+
+#### Permisos de visibilidad de las respuestas
+
+Los permisos del rol deciden qué respuestas ve un miembro del equipo y cuánto ve de cada una. En los permisos de Customers del rol hay cuatro que funcionan por niveles:
+
+- **Listar Respuestas Asignadas**: en el listado ve solo las respuestas que tiene asignadas y, al abrir una, solo la sección **Detalles**.
+- **Listar Todas las Respuestas**: ve todas las respuestas, no solo las que tiene asignadas. Incluye **Listar Respuestas Asignadas**.
+- **Ver Tareas de la Respuesta**: agrega la sección **Tareas**, con la posibilidad de asignar y completar tareas y de aprobar o rechazar validaciones. Incluye **Listar Respuestas Asignadas**.
+- **Ver Respuesta Completa**: agrega las secciones restantes, **Campos**, **Documentos**, **Firmas**, **Verificación de Identidad**, **Validaciones** y **Actividad**. Incluye **Ver Tareas de la Respuesta**.
+
+Al marcar un permiso, la plataforma marca también los que ese permiso incluye. Las secciones que el rol no puede ver no aparecen en el menú de la respuesta.
+
+Los permisos de acción se apoyan en esos niveles: **Editar Respuestas** requiere **Ver Respuesta Completa**; **Asignar Respuestas** requiere **Listar Todas las Respuestas**; **Eliminar Respuestas** y **Completar Respuestas** requieren **Listar Respuestas Asignadas**.
+
+:::tip Tip
+**Iniciar Respuestas** es independiente de los permisos de visibilidad: un rol puede crear respuestas en nombre de un usuario sin ver el listado completo ni el detalle.
+:::
+
+:::warning Atención
+Los roles que ya tenías conservan el acceso que tenían: los que veían el detalle completo mantienen **Ver Respuesta Completa**, y los que tenían **Iniciar Respuestas** mantienen además **Asignar Respuestas** y **Listar Todas las Respuestas**. Los niveles separados aplican cuando edites el rol.
 :::
 
 #### Buscar respuestas


### PR DESCRIPTION
## Cambios propuestos

Documenta los permisos granulares de visibilidad de las respuestas de originación, con los labels exactos de la UI en cada idioma.

**`platform/customers/origination.md`** — nueva subsección *Permisos de visibilidad de las respuestas* dentro de *Gestión de Respuestas*:
- Los cuatro permisos por niveles: **Listar Respuestas Asignadas**, **Listar Todas las Respuestas**, **Ver Tareas de la Respuesta** y **Ver Respuesta Completa**, con las secciones del detalle que habilita cada uno.
- Que al marcar un permiso la plataforma marca también los que ese permiso incluye, y que las secciones sin permiso no aparecen en el menú de la respuesta.
- Cómo se apoyan los permisos de acción en esos niveles: editar requiere ver la respuesta completa, asignar requiere el listado completo, y eliminar y completar requieren el listado de asignadas.
- Tip: **Iniciar Respuestas** quedó independiente de la visibilidad (antes arrastraba el listado completo).
- Atención: los roles existentes conservan el acceso que tenían; la separación aplica al editar el rol.
- Además se agrega **Verificación de Identidad** a la lista de secciones del detalle, que faltaba.

**`platform/core/roles.md`** — nota breve en *Crear roles a medida* sobre los permisos que incluyen a otros, con enlace a la subsección nueva.

Espejo en inglés incluido en las dos páginas.

Referencia: modyo/modyo#20173

Build local de VuePress verificado (`success`), con los anclajes de los links nuevos comprobados en `docs/.vuepress/dist` para `es` y `en`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
