### PR TITLE
Corrige la referencia Liquid de filtros: retira los filtros inexistentes y arregla los ejemplos que no producen el resultado publicado

### DIFF
--- a/docs/en/platform/channels/liquid-markup/filters.md
+++ b/docs/en/platform/channels/liquid-markup/filters.md
@@ -28,6 +28,16 @@ Hello {{ 'now' | date: "%Y %h" }}
 Adds a string *e.g.*
 <span v-pre>`{{ 'foo' | append:'bar' }} #=> 'foobar'`</span>
 
+### Base64 decode
+
+Decodes a Base64-encoded string *e.g.*
+<span v-pre>`{{ 'SGVsbG8gd29ybGQ=' | base64_decode }} #=> 'Hello world'`</span>
+
+### Base64 encode
+
+Encodes a string to Base64 *e.g.*
+<span v-pre>`{{ 'Hello world' | base64_encode }} #=> 'SGVsbG8gd29ybGQ='`</span>
+
 ### Capitalize
 
 Capitalizes the first letter of each word in the input string.
@@ -198,6 +208,14 @@ If the site doesn't have an associated realm and you don't specify parameters, t
 
 These are the liquid filters that alter values related to the Content module in Modyo Platform.
 
+### Asset lookup by UUID
+
+The `asset_image`, `asset_link`, `asset_url_by_uuid` and `asset_video` filters look the file up by its UUID within the account, not within the site.
+
+:::warning Attention
+If the UUID doesn't match any file in the account, none of the four fails or returns empty: they print the message `Liquid error: Asset with uuid 'the-requested-uuid' does not exist`, which ends up published on the page. Check the UUIDs whenever you move templates or content across accounts.
+:::
+
 ### Asset image
 
 Returns the tags of an image using its uuid from the File Manager. If using Cloudflare for image optimization, you can use these additional parameters: width, height, blur, quality, format and fit. *e.g.*
@@ -205,8 +223,16 @@ Returns the tags of an image using its uuid from the File Manager. If using Clou
 
 ### Asset link
 
-Returns the URL of an image using its uuid from the File Manager. *e.g.*
-<span v-pre>`{{ uuid | asset_link: 'This is a link for the asset' }}`</span>
+Emits an HTML anchor tag pointing to the File Manager file identified by its UUID. The argument is the visible link text and, if you omit it, the asset's file name is used instead. *e.g.*
+<span v-pre>`{{ uuid | asset_link: 'Download the guide' }}`</span> => `<a href='https://mydomain.com/uploads/guide.pdf'>Download the guide</a>`
+
+**Parameters**:
+- uuid (String) — asset uuid
+- label (String) (default: the asset's file name) — visible link text
+
+:::tip Tip
+If all you need is the file's address, to build your own markup, use `asset_url_by_uuid`.
+:::
 
 ### Asset URL by UUID
 
@@ -234,12 +260,20 @@ Returns a list of Entries that belong to the selected Category. *e.g.*
 
 ### By lang
 
-Returns a list of Entries that belong to a selected language. *e.g.*
-<span v-pre>`{% assign entries = widget.entries | locale: 'es,en,pt' %} => entries`</span>
+Returns a list of Entries in the given language. The filter is called `by_lang`: `locale` is the name of the parameter, not the name of the filter. *e.g.*
+<span v-pre>`{% assign entries = widget.entries | by_lang: 'es' %} => entries`</span>
 
 **Parameters**:
 - entries (ArrayEntry) — array with entries
-- locale (String) (default: '') — String with comma-separated languages.
+- locale (String) (default: '') — a single locale code
+
+`by_lang` replaces any language condition the collection already had, it doesn't add to it: the last `by_lang` in the chain wins.
+
+:::warning Attention
+It doesn't take a comma-separated list. A value such as `'es,en,pt'` is compared as-is against each entry's language, so the result is an empty collection instead of the union of the three languages. If you need several languages, resolve one collection per language and iterate them separately.
+
+Applied to anything that isn't a collection of entries, the filter aborts and the published HTML keeps the comment `<!-- Liquid Error -->` in place of the block.
+:::
 
 ### By slug
 
@@ -288,7 +322,7 @@ Applies multiple entry filters in one call. Supported option keys (all optional)
 - tags: comma-separated tags (applies `by_tag`)
 - slugs: comma-separated entry slugs (applies `by_slug`)
 - uuids: comma-separated UUIDs (applies `by_uuid`)
-- locale: locale code (applies `by_lang`)
+- locale: a single locale code (applies `by_lang`; a comma-separated list is not supported)
 - from_published_date: date string (>= `published_at`)
 - to_published_date: date string (<= `published_at`)
 - sort_by: field name (`name`, `slug`, `created_at`, `updated_at`, `published_at`, or a field path)
@@ -301,31 +335,53 @@ Applies multiple entry filters in one call. Supported option keys (all optional)
 ### Filter By
 
 Returns a list of Entries that match a filter. *e.g.*
-<span v-pre>`{% assign entries = widget.entries | filter_by: field: 'name', eq: 'entry3Cat3' %}`</span>
+<span v-pre>`{% assign entries = widget.entries | filter_by: field: 'meta.name', eq: 'entry3Cat3' %}`</span>
 
 **Parameters**:
 - entries (ArrayEntry) — array with entries
 - opts (Hash) (default: {}) — hash with field and operator/value pairs
 
+The value of `field` is always written with its prefix:
+
+- `fields.<name>` for the content type's fields.
+- `meta.<attribute>` for metadata, with these attributes available: `meta.uuid`, `meta.name`, `meta.slug`, `meta.category`, `meta.category_slug`, `meta.category_name`, `meta.created_at`, `meta.updated_at`, `meta.published_at` and `meta.unpublished_at`. To filter by tags use `by_tag`.
+
+:::warning Attention
+A field name without a prefix is silently discarded: the filter raises no error and returns the whole collection, unfiltered. If a listing shows you every entry, check first that the value of `field` starts with `fields.` or with `meta.`.
+:::
+
 **Supported Operators** (use as keys in `opts`):
 - `eq` — equals (implicit when only `field` and value provided)
+- `not` — not equal to. With `nil` as the value it returns the entries that do have a value in the field
 - `gt`, `lt` — greater than / less than
 - `in` — field value must be one of the comma-separated values
 - `nin` — field value must NOT be one of the comma-separated values
 - `has` — array-type field must contain all of the comma-separated values
+- `search` — searches the text in the attributes of the entry's locations; requires a location field
+- `geohash` — searches by proximity with a base 32 geohash; requires a location field
 
-All multi-value operators take a comma-separated string.
+Only `in`, `nin` and `has` take a comma-separated string; the rest take a single value. `search` and `geohash` behave just like in the [Content public API](/en/platform/content/public-api-reference.html#operators). The `all` operator, which appears in the Filter By Query String list, is not available in `filter_by`.
 
 **Examples**:
 
 Filter entries where the `status` field is either 'published' or 'featured':
-<span v-pre>`{% assign entries = entries | filter_by: field: 'status', in: 'published,featured' %}`</span>
+<span v-pre>`{% assign entries = entries | filter_by: field: 'fields.status', in: 'published,featured' %}`</span>
 
 Filter entries where the `author_id` is not 1 or 5:
-<span v-pre>`{% assign entries = entries | filter_by: field: 'author_id', nin: '1,5' %}`</span>
+<span v-pre>`{% assign entries = entries | filter_by: field: 'fields.author_id', nin: '1,5' %}`</span>
 
 Filter entries that have both 'tech' and 'news' in their `categories` array field:
-<span v-pre>`{% assign entries = entries | filter_by: field: 'categories', has: 'tech,news' %}`</span>
+<span v-pre>`{% assign entries = entries | filter_by: field: 'fields.categories', has: 'tech,news' %}`</span>
+
+Filter entries whose `subtitle` field has any value:
+<span v-pre>`{% assign entries = entries | filter_by: field: 'fields.subtitle', not: nil %}`</span>
+
+Filter entries published after a date:
+<span v-pre>`{% assign entries = entries | filter_by: field: 'meta.published_at', gt: '2026-01-01' %}`</span>
+
+:::warning Attention
+There are two cases where `filter_by` aborts and the published HTML keeps the comment `<!-- Liquid Error -->` in place of the block: when you call it without `field`, and when you apply it to a collection whose content type can't be resolved, such as <span v-pre>`spaces['blog'].entries`</span>. Always start from a collection scoped to a single type, such as <span v-pre>`spaces['blog'].types['post'].entries`</span> or <span v-pre>`widget.entries`</span>.
+:::
 
 ### Filter By Query String
 
@@ -403,34 +459,25 @@ Returns a list of Entries that have a publication date older than the limit. *e.
 
 These Liquid filters alter values related to Cryptography.
 
-### Base64 Decode
-
-Returns the Base64-decoded value of a string (e.g. <span v-pre> `{% 'Hello world' | base64_encode %} # => 'SGVsbG8gd29ybGQ='`</span>).
-
-### Base64 Encode
-
-Returns the Base64-encoded value of a string (e.g. <span v-pre>`{% 'SGVsbG8gd29ybGQ=' | base64_decode %} # => 'Hello world'`</span>).
-
-### HMAC SHA1
-
-Returns the SHA-1 hash using a message authentication code (HMAC) of a string (e.g. <span v-pre>`{% 'Hello world' | hmac_sha1: 'key' %} # => '2a73959742baf046e6e2e27e5ee94bcff0af31b1'`</span>).
+:::warning Attention
+The only hash filters in Modyo Platform are `hmac_sha256` and `sha256`. `md5`, `sha1` and `hmac_sha1` do not exist and, because an unknown filter doesn't interrupt rendering, Liquid returns the input value untransformed: the page publishes the data in the clear where you expected a hash. Review your templates before signing an integration with them.
+:::
 
 ### HMAC SHA256
-Returns the SHA-256 hash using a message authentication code (HMAC) of a string (e.g. <span v-pre>`{% 'Hello world' | hmac_sha256: 'key' %} # => 'a82b2e160edaf92a6589dc11160d2a10c04449840a58717db308c1ee3512b039'`</span>).
 
-### MD5
-
-Returns the MD5 hash of a string (e.g. <span v-pre>`{% 'Hello world' | md5 %} # => '3e25960a79dbc69b674cd4ec67a72c62'`</span>).
-
-### SHA1
-Returns the SHA-1 hash of a string (e.g. <span v-pre>`{% 'Hello world' | sha1 %} # => '7b502c3a1f48c8609ae212cdfb639dee39673f5e'`</span>).
+Returns the SHA-256 hash of a string using a message authentication code (HMAC), with the key as the argument (e.g. <span v-pre>`{{ 'Hello world' | hmac_sha256: 'key' }} #=> 'a82b2e160edaf92a6589dc11160d2a10c04449840a58717db308c1ee3512b039'`</span>).
 
 ### SHA 256
-Returns the SHA-256 hash of a string (e.g. <span v-pre>`{% 'Hello world' | sha256 %} # => '64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c'`</span>).
+
+Returns the SHA-256 hash of a string (e.g. <span v-pre>`{{ 'Hello world' | sha256 }} #=> '64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c'`</span>).
 
 ## CSS
 
 These Liquid filters alter CSS-related values in Modyo Platform.
+
+:::warning Attention
+Every color filter aborts if the input value isn't a valid color, for example a variable that doesn't exist in the context. When that happens, the published HTML keeps the comment `<!-- Liquid Error -->` in place of the color and the CSS rule that used it is lost.
+:::
 
 ### Brighten
 
@@ -446,7 +493,15 @@ Desaturates a color (e.g. <span v-pre>`{{ '#00ff00' | desaturate: 15 }} #=> '#13
 
 ### Grayscale
 
-Converts a color to grayscale (e.g. <span v-pre>`{{ '#00ff00' | grayscale }} #=> '#808080'`</span>). Alias: `greyscale` (same output).
+Converts a color to grayscale (e.g. <span v-pre>`{{ '#00ff00' | grayscale }} #=> '#808080'`</span>). It accepts a second argument, but that argument doesn't change the result because the grayscale conversion never uses it.
+
+### Greyscale
+
+Converts a color to grayscale, with the same output as `grayscale`, but it only takes the color (e.g. <span v-pre>`{{ '#00ff00' | greyscale }} #=> '#808080'`</span>).
+
+:::warning Attention
+`greyscale` and `grayscale` are not interchangeable: `greyscale` doesn't accept a second argument. A template that passes an amount, such as <span v-pre>`{{ color | greyscale: 15 }}`</span>, aborts because of the number of arguments and the published HTML keeps the comment `<!-- Liquid Error -->`. The same template with `grayscale` works.
+:::
 
 ### Lighten
 
@@ -535,38 +590,41 @@ Returns the Origination with the selected UID. *e.g.*
 
 These Liquid filters alter values related to Sites in Modyo Platform.
 
+### Removed filters
+
+As of version 10.2 the `video_player`, `audio_player`, `embedded_video` and `asset_thumbnail_link_tag` filters no longer exist. The `bar_code` and `qr_code` filters never existed in Modyo Platform.
+
+:::warning Attention
+An unknown filter doesn't interrupt rendering: Liquid returns the input value untransformed. A template that still invokes these filters on an asset no longer shows the player or the link, and publishes the internal name of the object it received instead, for example `Liquid::Drops::Assets::VideoAssetDrop`. There is no error message or visible hint of the cause on the page, so review your templates before upgrading.
+:::
+
+To replace `video_player` and `audio_player`, build the markup with the file's address, available in `url`:
+
+```liquid
+{% assign video = assets['video-uuid'] %}
+<video src="{{ video.url }}" width="320" height="320" controls="controls"></video>
+
+{% assign audio = assets['audio-uuid'] %}
+<audio src="{{ audio.url }}" controls="controls"></audio>
+```
+
+To replace `asset_thumbnail_link_tag`, wrap the thumbnail, available in `thumbnail_url`, in a link to the file:
+
+```liquid
+{% assign image = assets['image-uuid'] %}
+<a href="{{ image.url }}" class="thumbnail"><img src="{{ image.thumbnail_url }}" alt="{{ image.alt_text }}"></a>
+```
+
+`embedded_video`, `bar_code` and `qr_code` have no replacement: the platform doesn't currently offer an equivalent filter.
+
 ### Asset image Tag
 
 Generates the HTML tag of an image (e.g. <span v-pre>`{{ asset | asset_image_tag: 'original' }}`</span>).
-
-### Asset Thumbnail Link Tag
-
-Generates the HTML thumbnail tag of an image (e.g. <span v-pre>`{{ asset | asset_thumbnail_link_tag: 'class', 'target' }}`</span>).
-
-**Parameters**
-
-- `asset` (Asset) — Asset-type object.
-- `classes` (String) (default: '') — Additional HTML classes (optional).
-- `target` (String) (default: '') — Additional HTML targets (optional).
 
 ### Asset URL
 
 Generates the URL of an Asset object or a template asset path. For Asset objects using Cloudflare for image optimization, you can use the following additional parameters: width, height, blur, quality, format and fit. (e.g. <span v-pre>`{{ assets['asset_uuid'] | asset_url: blur: 40, format: 'auto', fit: 'cover'  }}`</span>).
 For template asset paths from the template builder, specify the asset type as the second argument (e.g. <span v-pre>`{{ 'base' | asset_url: 'js'  }}`</span>). You can also use the script_tag or stylesheet_tag filters to automatically generate the complete HTML <script> or <link> tag (e.g. <span v-pre>`{{ 'base' | asset_url: 'css' | stylesheet_tag: media: 'screen' }}`</span>).
-
-### Audio Player
-
-Generates the URL of an Audio-type object (e.g. <span v-pre>`{{ audio1 | audio_player }}`</span>).
-
-### Bar Code
-
-Generates the URL of a barcode (e.g. <span v-pre>`{{ value | bar_code: 320, 320 }}`</span>).
-
-**Parameters**
-
-- `value` (String) — Barcode value.
-- `width` (Integer) (default: 100) — Width.
-- `height` (Integer) (default: 100) — Height.
 
 ### Button To
 
@@ -575,10 +633,6 @@ Generates a button (e.g. <span v-pre>`{{ 'Hello World' | button_to: 'http://www.
 ### Cookie Value
 
 Returns the value of a cookie (e.g. <span v-pre>`{{ 32 | cookie_value }}`</span>).
-
-### Embedded Video
-
-Returns the URL of an embedded video (e.g. <span v-pre>`{{ movie2 | embedded_video }}`</span>).
 
 ### Escape JS
 
@@ -639,17 +693,6 @@ Generates a primary type button (e.g. <span v-pre>`{{ 'Hello World' | primary_bu
 - `link` (String) (default: '/') — Link URL.
 - `size` (String) (default: 'large') — Size for the link.
 
-### QR Code
-
-Generates a QR code (e.g. <span v-pre>`{{ value | qr_code: 4, 320, 320 }}`</span>).
-
-**Parameters**
-
-- `value` (String) (default: '') — QR value.
-- `qr_size` (Integer) (default: 4) — QR size.
-- `width` (Integer) (default: 100) — QR width.
-- `height` (Integer) (default: 100) — QR height.
-
 ### Sanitize HTML
 
 Sanitizes HTML tags from a String (e.g. <span v-pre>`{{ '<script>Hello World</script>' | sanitize }} #=> 'Hello World'`</span>).
@@ -692,16 +735,6 @@ Resolves the translation text for Site keys. Custom values will be returned if t
 ### Truncate HTML
 
 Returns a String after truncating it (e.g. <span v-pre>`{{ html | truncate_html: 10 }}`</span>).
-
-### Video Player
-
-Adds a video player in HTML code using a File Manager asset (e.g. <span v-pre>`{{ movie1 | video_player: 320, 320 }}`</span>).
-
-**Parameters**
-
-- `video` (Asset) — Video-type object from the File Manager.
-- `width` (Integer) — Video width.
-- `height` (Integer) — Video height.
 
 ## Step
 
@@ -789,24 +822,34 @@ The filters `completed`, `url`, and `resume_link` (documented under Submission) 
 
 These Liquid filters alter values related to Users.
 
+### Avatar For
+
+Shows the HTML code for a user's image. If the user has no avatar of their own, it returns the default avatar (e.g. <span v-pre>`{{ user | avatar_for: 'C50x50', true }}`</span>).
+
+**Parameters**
+
+- `user` (User) — User object.
+- `size` (String) (default: 'C50x50') — Image size.
+- `link` (Boolean) (default: true) — `true` adds a link to the user's profile.
+
 ### Default Avatar Image
 
-Shows the default avatar image (e.g. <span v-pre>`{{ user | avatar_for: 'C50x50' }}`</span>).
+Shows the HTML code of the default avatar. The signature is the reverse of what the name suggests: the value before the pipe is the **size**, and the user is the first, optional argument (e.g. <span v-pre>`{{ 'C50x50' | default_avatar_image: user }}`</span>).
 
 **Parameters**
 
-- `user` (User) — User object.
-- `size` (Integer) (default: 'C50x50') — Image size.
+- `size` (String) — Image size, using the avatar version format: `C25x25`, `C50x50`, `C75x75`, `C100x100`, `C125x125`, `C160x160`, `C200x200` or `C250x250`.
+- `user` (User) (default: nil) — User object from the Liquid context. It has to be the object, not an id or an email.
 
-### Image For
+It returns one of three images, depending on what it receives:
 
-Shows the HTML code for a user's image (e.g. <span v-pre>`{{ user | avatar_for: 'C50x50', true }}`</span>).
+- With a user whose realm has a **Default avatar image** configured in [Realm Settings](/en/platform/customers/settings.html#general), the realm's image in the requested size.
+- With a user whose realm doesn't have it configured, the placeholder image in the requested size.
+- With no user, the placeholder image in the requested size.
 
-**Parameters**
-
-- `user` (User) — User object.
-- `size` (Integer) (default: 'C50x50') — Image size.
-- `link` (Boolean) (default: true) — `true` adds a link to the user's profile.
+:::tip Tip
+For the usual case you don't need to call it: `avatar_for` already falls back to `default_avatar_image` when the user has no avatar of their own. Call it directly only when you want the default avatar without looking at the user's own.
+:::
 
 ### By Form Slug
 

--- a/docs/es/platform/channels/liquid-markup/filters.md
+++ b/docs/es/platform/channels/liquid-markup/filters.md
@@ -226,7 +226,7 @@ Retorna los tags de una imagen usando su uuid del Gestor de Archivos. Al usar Cl
 Emite una etiqueta de enlace HTML que apunta al archivo del Gestor de Archivos identificado por su UUID. El argumento es el texto visible del enlace y, si lo omites, se usa el nombre de archivo del asset. *e.g.*
 <span v-pre>`{{ uuid | asset_link: 'Descarga el instructivo' }}`</span> => `<a href='https://midominio.com/uploads/instructivo.pdf'>Descarga el instructivo</a>`
 
-**Parametros**:
+**Parámetros**:
 - uuid (String) — asset uuid
 - label (String) (default: nombre de archivo del asset) — texto visible del enlace
 

--- a/docs/es/platform/channels/liquid-markup/filters.md
+++ b/docs/es/platform/channels/liquid-markup/filters.md
@@ -28,6 +28,16 @@ Hello {{ 'now' | date: "%Y %h" }}
 Añade un string *e.g.*
 <span v-pre>`{{ 'foo' | append:'bar' }} #=> 'foobar'`</span>
 
+### Base64 decode
+
+Decodifica un string codificado en Base64 *e.g.*
+<span v-pre>`{{ 'SGVsbG8gd29ybGQ=' | base64_decode }} #=> 'Hello world'`</span>
+
+### Base64 encode
+
+Codifica un string en Base64 *e.g.*
+<span v-pre>`{{ 'Hello world' | base64_encode }} #=> 'SGVsbG8gd29ybGQ='`</span>
+
 ### Capitalize
 
 Poner palabra en mayúscula en la frase de entrada.
@@ -198,6 +208,14 @@ En caso de que el sitio no tenga un reino asociado y no especifiques parámetros
 
 Estos son los filtros liquid que alteran valores relacionados al módulo de Content en Modyo Platform.
 
+### Búsqueda de assets por UUID
+
+Los filtros `asset_image`, `asset_link`, `asset_url_by_uuid` y `asset_video` buscan el archivo por su UUID en el ámbito de la cuenta, no del sitio.
+
+:::warning Atención
+Si el UUID no corresponde a ningún archivo de la cuenta, ninguno de los cuatro falla ni devuelve vacío: imprimen el mensaje `Error de liquid: No existe el archivo con UUID 'el-uuid-pedido'`, que queda publicado en la página. Revisa los UUID cuando muevas plantillas o contenido entre cuentas.
+:::
+
 ### Asset image
 
 Retorna los tags de una imagen usando su uuid del Gestor de Archivos. Al usar Cloudflare para la optimización de imágenes, puedes usar estos parámetros adicionales: width, height, blur, quality, format y fit *e.g.*
@@ -205,8 +223,16 @@ Retorna los tags de una imagen usando su uuid del Gestor de Archivos. Al usar Cl
 
 ### Asset link
 
-Retorna el URL de una imagen usando su uuid del Gestor de Archivos. *e.g.*
-<span v-pre>`{{ uuid | asset_link: 'Este es una liga para el asset' }}`</span>
+Emite una etiqueta de enlace HTML que apunta al archivo del Gestor de Archivos identificado por su UUID. El argumento es el texto visible del enlace y, si lo omites, se usa el nombre de archivo del asset. *e.g.*
+<span v-pre>`{{ uuid | asset_link: 'Descarga el instructivo' }}`</span> => `<a href='https://midominio.com/uploads/instructivo.pdf'>Descarga el instructivo</a>`
+
+**Parametros**:
+- uuid (String) — asset uuid
+- label (String) (default: nombre de archivo del asset) — texto visible del enlace
+
+:::tip Tip
+Si lo que necesitas es solo la dirección del archivo, para armar tu propio markup, usa `asset_url_by_uuid`.
+:::
 
 ### Asset URL by UUID
 
@@ -234,12 +260,20 @@ Retorna una lista de Entradas que pertenecen a la Categoría seleccionada. *e.g.
 
 ### By lang
 
-Retorna una lista de Entradas que pertenecen a un lenguaje seleccionado. *e.g.*
-<span v-pre>`{% assign entries = widget.entries | locale: 'es,en,pt' %} => entries`</span>
+Retorna una lista de Entradas en el idioma indicado. El filtro se llama `by_lang`: `locale` es el nombre del parámetro, no el del filtro. *e.g.*
+<span v-pre>`{% assign entries = widget.entries | by_lang: 'es' %} => entries`</span>
 
 **Parametros**:
 - entries (ArrayEntry) — array con entradas
-- locale (String) (default: '') — String con lenguajes separadas por coma.
+- locale (String) (default: '') — un único código de idioma
+
+`by_lang` reemplaza la condición de idioma que la colección ya tuviera, no la acumula: el último `by_lang` de la cadena es el que manda.
+
+:::warning Atención
+No acepta una lista separada por comas. Un valor como `'es,en,pt'` se compara tal cual contra el idioma de cada entrada, así que el resultado es una colección vacía en lugar de la unión de los tres idiomas. Si necesitas varios idiomas, resuelve una colección por idioma y recórrelas por separado.
+
+Aplicado sobre algo que no sea una colección de entradas, el filtro aborta y en el HTML publicado queda el comentario `<!-- Liquid Error -->` en lugar del bloque.
+:::
 
 ### By slug
 
@@ -288,7 +322,7 @@ Aplica múltiples filtros de entradas en una sola llamada. Claves soportadas (to
 - tags: tags separados por comas (aplica `by_tag`)
 - slugs: slugs de entradas separados por comas (aplica `by_slug`)
 - uuids: UUIDs separados por comas (aplica `by_uuid`)
-- locale: código de idioma (aplica `by_lang`)
+- locale: un único código de idioma (aplica `by_lang`; no acepta lista separada por comas)
 - from_published_date: fecha límite inicial (>= `published_at`)
 - to_published_date: fecha límite final (<= `published_at`)
 - sort_by: nombre de campo (`name`, `slug`, `created_at`, `updated_at`, `published_at` u otro path de campo)
@@ -306,25 +340,47 @@ Retorna una lista de Entradas que cumplen con un filtro.
 - entries (ArrayEntry) — array con entradas
 - opts (Hash) (default: {}) — hash con campo y pares operador/valor
 
+El valor de `field` se escribe siempre con su prefijo:
+
+- `fields.<nombre>` para los campos del tipo de contenido.
+- `meta.<atributo>` para los metadatos, con estos atributos disponibles: `meta.uuid`, `meta.name`, `meta.slug`, `meta.category`, `meta.category_slug`, `meta.category_name`, `meta.created_at`, `meta.updated_at`, `meta.published_at` y `meta.unpublished_at`. Para filtrar por tags usa `by_tag`.
+
+:::warning Atención
+Un nombre de campo sin prefijo se descarta en silencio: el filtro no lanza error y devuelve la colección completa, sin filtrar. Si un listado te muestra todas las entradas, revisa primero que el valor de `field` empiece por `fields.` o por `meta.`.
+:::
+
 **Operadores soportados** (usar como llaves dentro de `opts`):
 - `eq` — igual a (implícito cuando solo se provee `field` y valor)
+- `not` — distinto de. Con `nil` como valor devuelve las entradas que tienen algún valor en el campo
 - `gt`, `lt` — mayor que / menor que
 - `in` — el valor del campo debe estar dentro de los valores separados por comas
 - `nin` — el valor del campo NO debe estar dentro de los valores separados por comas
 - `has` — el campo (tipo array) debe contener todos los valores separados por comas
+- `search` — busca el texto en los atributos de las ubicaciones de la entrada; necesita un campo de tipo ubicación
+- `geohash` — busca por proximidad con un geohash en base 32; necesita un campo de tipo ubicación
 
-Todos los operadores multi-valor aceptan un string separado por comas.
+Solo `in`, `nin` y `has` aceptan un string separado por comas; el resto toma un valor único. `search` y `geohash` se comportan igual que en la [API pública de Content](/es/platform/content/public-api-reference.html#operadores). El operador `all`, que aparece en la lista de Filter By Query String, no está disponible en `filter_by`.
 
 **Ejemplos**:
 
 Filtrar entradas donde el campo `status` sea 'published' o 'featured':
-<span v-pre>`{% assign entries = entries | filter_by: field: 'status', in: 'published,featured' %}`</span>
+<span v-pre>`{% assign entries = entries | filter_by: field: 'fields.status', in: 'published,featured' %}`</span>
 
 Filtrar entradas donde `author_id` no sea 1 ni 5:
-<span v-pre>`{% assign entries = entries | filter_by: field: 'author_id', nin: '1,5' %}`</span>
+<span v-pre>`{% assign entries = entries | filter_by: field: 'fields.author_id', nin: '1,5' %}`</span>
 
 Filtrar entradas que tengan ambos 'tech' y 'news' en su campo array `categories`:
-<span v-pre>`{% assign entries = entries | filter_by: field: 'categories', has: 'tech,news' %}`</span>
+<span v-pre>`{% assign entries = entries | filter_by: field: 'fields.categories', has: 'tech,news' %}`</span>
+
+Filtrar entradas cuyo campo `subtitle` tenga algún valor:
+<span v-pre>`{% assign entries = entries | filter_by: field: 'fields.subtitle', not: nil %}`</span>
+
+Filtrar entradas publicadas después de una fecha:
+<span v-pre>`{% assign entries = entries | filter_by: field: 'meta.published_at', gt: '2026-01-01' %}`</span>
+
+:::warning Atención
+En dos casos `filter_by` aborta y en el HTML publicado queda el comentario `<!-- Liquid Error -->` en lugar del bloque: cuando lo llamas sin `field` y cuando lo aplicas sobre una colección de la que no se puede resolver el tipo de contenido, como <span v-pre>`spaces['blog'].entries`</span>. Parte siempre de una colección acotada a un tipo, como <span v-pre>`spaces['blog'].types['post'].entries`</span> o <span v-pre>`widget.entries`</span>.
+:::
 
 ### Filter By Query String
 
@@ -406,34 +462,25 @@ Retorna una lista de Entradas que tengan una fecha de publicación más vieja qu
 
 Estos filtros Liquid alteran valores relacionados con la Criptografía.
 
-### Base64 Decode
-
-Devuelve el valor Base64-decoded de un string (ej. <span v-pre> `{% 'Hello world' | base64_encode %} # => 'SGVsbG8gd29ybGQ='`</span>).
-
-### Base64 Encode
-
-Devuelve el valor Base64-encoded de un string (ej. <span v-pre>`{% 'SGVsbG8gd29ybGQ=' | base64_decode %} # => 'Hello world'`</span>).
-
-### HMAC SHA1
-
-Devuelve el hash SHA-1 usando un código de autenticación de mensajes (HMAC) de un string (ej. <span v-pre>`{% 'Hello world' | hmac_sha1: 'key' %} # => '2a73959742baf046e6e2e27e5ee94bcff0af31b1'`</span>).
+:::warning Atención
+Los únicos filtros de hash de Modyo Platform son `hmac_sha256` y `sha256`. `md5`, `sha1` y `hmac_sha1` no existen y, como un filtro desconocido no interrumpe el renderizado, Liquid devuelve el valor de entrada sin transformar: la página publica el dato en claro donde esperabas un hash. Revisa tus plantillas antes de firmar una integración con ellos.
+:::
 
 ### HMAC SHA256
-Devuelve el hash SHA-256 usando un código de autenticación de mensajes (HMAC) de un string (ej. <span v-pre>`{% 'Hello world' | hmac_sha256: 'key' %} # => 'a82b2e160edaf92a6589dc11160d2a10c04449840a58717db308c1ee3512b039'`</span>).
 
-### MD5
-
-Devuelve el hash MD5 de un string (ej. <span v-pre>`{% 'Hello world' | md5 %} # => '3e25960a79dbc69b674cd4ec67a72c62'`</span>).
-
-### SHA1
-Devuelve el hash SHA-1 de un string (ej. <span v-pre>`{% 'Hello world' | sha1 %} # => '7b502c3a1f48c8609ae212cdfb639dee39673f5e'`</span>).
+Devuelve el hash SHA-256 de un string usando un código de autenticación de mensajes (HMAC), con la clave como argumento (ej. <span v-pre>`{{ 'Hello world' | hmac_sha256: 'key' }} #=> 'a82b2e160edaf92a6589dc11160d2a10c04449840a58717db308c1ee3512b039'`</span>).
 
 ### SHA 256
-Devuelve el hash SHA-256 de un string (ej. <span v-pre>`{% 'Hello world' | sha256 %} # => '64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c'`</span>).
+
+Devuelve el hash SHA-256 de un string (ej. <span v-pre>`{{ 'Hello world' | sha256 }} #=> '64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c'`</span>).
 
 ## CSS
 
 Estos filtros Liquid alteran valores relacionados con CSS en Modyo Platform.
+
+:::warning Atención
+Todos los filtros de color abortan si el valor de entrada no es un color válido, por ejemplo una variable que no existe en el contexto. Cuando eso pasa, en el HTML publicado queda el comentario `<!-- Liquid Error -->` en lugar del color y la regla CSS que lo usaba se pierde.
+:::
 
 ### Brighten
 
@@ -449,7 +496,15 @@ Desatura un color (ej. <span v-pre>`{{ '#00ff00' | desaturate: 15 }} #=> '#13ec1
 
 ### Grayscale
 
-Convierte un color a escala de grises (ej. <span v-pre>`{{ '#00ff00' | grayscale }} #=> '#808080'`</span>). Alias: `greyscale` (mismo resultado).
+Convierte un color a escala de grises (ej. <span v-pre>`{{ '#00ff00' | grayscale }} #=> '#808080'`</span>). Acepta un segundo argumento, pero no altera el resultado porque la conversión a escala de grises no lo usa.
+
+### Greyscale
+
+Convierte un color a escala de grises, con el mismo resultado que `grayscale`, pero recibe solo el color (ej. <span v-pre>`{{ '#00ff00' | greyscale }} #=> '#808080'`</span>).
+
+:::warning Atención
+`greyscale` y `grayscale` no son intercambiables: `greyscale` no admite un segundo argumento. Una plantilla que pase intensidad, como <span v-pre>`{{ color | greyscale: 15 }}`</span>, aborta por el número de argumentos y en el HTML publicado queda el comentario `<!-- Liquid Error -->`. La misma plantilla con `grayscale` funciona.
+:::
 
 ### Lighten
 
@@ -538,38 +593,41 @@ Devuelve el Origination con el UID seleccionado. *ej.*
 
 Estos filtros Liquid alteran valores relacionados con los Sitios en Modyo Platform.
 
+### Filtros retirados
+
+Desde la versión 10.2 los filtros `video_player`, `audio_player`, `embedded_video` y `asset_thumbnail_link_tag` ya no existen. Los filtros `bar_code` y `qr_code` nunca existieron en Modyo Platform.
+
+:::warning Atención
+Un filtro desconocido no interrumpe el renderizado: Liquid devuelve el valor de entrada sin transformar. Una plantilla que todavía invoque estos filtros sobre un asset ya no muestra el reproductor ni el enlace y publica en su lugar el nombre interno del objeto que recibió, por ejemplo `Liquid::Drops::Assets::VideoAssetDrop`. No hay mensaje de error ni pista visible de la causa en la página, así que revisa tus plantillas antes de actualizar.
+:::
+
+Para reemplazar `video_player` y `audio_player`, arma el markup con la dirección del archivo, disponible en `url`:
+
+```liquid
+{% assign video = assets['uuid-del-video'] %}
+<video src="{{ video.url }}" width="320" height="320" controls="controls"></video>
+
+{% assign audio = assets['uuid-del-audio'] %}
+<audio src="{{ audio.url }}" controls="controls"></audio>
+```
+
+Para reemplazar `asset_thumbnail_link_tag`, envuelve la miniatura, disponible en `thumbnail_url`, en un enlace al archivo:
+
+```liquid
+{% assign image = assets['uuid-de-la-imagen'] %}
+<a href="{{ image.url }}" class="thumbnail"><img src="{{ image.thumbnail_url }}" alt="{{ image.alt_text }}"></a>
+```
+
+`embedded_video`, `bar_code` y `qr_code` no tienen reemplazo: la plataforma no ofrece hoy un filtro equivalente.
+
 ### Asset image Tag
 
 Genera la etiqueta HTML de una imagen (ej. <span v-pre>`{{ asset | asset_image_tag: 'original' }}`</span>).
-
-### Asset Thumbnail Link Tag
-
-Genera la etiqueta HTML del thumbnail de una imagen (ej. <span v-pre>`{{ asset | asset_thumbnail_link_tag: 'class', 'target' }}`</span>).
-
-**Parametros**
-
-- `asset` (Asset) — Objeto de tipo Asset.
-- `classes` (String) (default: '') — Clases HTML adicionales (opcional).
-- `target` (String) (default: '') — Targets HTML adicionales (opcional).
 
 ### Asset URL
 
 Genera la URL de un objeto **Asset** o una ruta de activo de plantilla. Para los objetos Asset que utilizan Cloudflare para la optimización de imágenes, puedes usar los siguientes parámetros adicionales: width, height, blur, quality, format y fit. (ej. <span v-pre>{{ assets['asset_uuid'] | asset_url: blur: 40, format: 'auto', fit: 'cover' }}</span>).
 Para las rutas de assets de plantilla (template asset paths) desde el template builder, especifica el tipo de asset como el segundo argumento (ej. <span v-pre>{{ 'base' | asset_url: 'js' }}</span>). También puedes usar los filtros `script_tag` o `stylesheet_tag` para generar automáticamente la etiqueta HTML `<script>` o `<link>` completa (ej. <span v-pre>{{ 'base' | asset_url: 'css' | stylesheet_tag: media: 'screen' }}</span>).
-
-### Audio Player
-
-Genera la URL de un objeto tipo Audio (ej. <span v-pre>`{{ audio1 | audio_player }}`</span>).
-
-### Bar Code
-
-Genera la URL de un código de barras (ej. <span v-pre>`{{ value | bar_code: 320, 320 }}`</span>).
-
-**Parametros**
-
-- `value` (String) — Valor del código de barras.
-- `width` (Integer) (default: 100) — Ancho.
-- `height` (Integer) (default: 100) — Alto.
 
 ### Button To
 
@@ -578,10 +636,6 @@ Genera un botón (ej. <span v-pre>`{{ 'Hello World' | button_to: 'http://www.goo
 ### Cookie Value
 
 Devuelve el valor de una cookie (ej. <span v-pre>`{{ 32 | cookie_value }}`</span>).
-
-### Embedded Video
-
-Devuelve la URL de un video integrado (ej. <span v-pre>`{{ movie2 | embedded_video }}`</span>).
 
 ### Escape JS
 
@@ -642,17 +696,6 @@ Genera un botón de tipo primario (ej. <span v-pre>`{{ 'Hello World' | primary_b
 - `link` (String) (default: '/') — URL para el enlace.
 - `size` (String) (default: 'large') — Tamaño para el enlace.
 
-### QR Code
-
-Genera un código QR (ej. <span v-pre>`{{ value | qr_code: 4, 320, 320 }}`</span>).
-
-**Parametros**
-
-- `value` (String) (default: '') — Valor para el QR.
-- `qr_size` (Integer) (default: 4) — Tamaño del QR.
-- `width` (Integer) (default: 100) — Ancho del QR.
-- `height` (Integer) (default: 100) — Alto del QR.
-
 ### Sanitize HTML
 
 Sanitiza las etiquetas HTML de un String (ej. <span v-pre>`{{ '<script>Hello World</script>' | sanitize }} #=> 'Hello World'`</span>).
@@ -695,16 +738,6 @@ Resuelve el texto de traducción para claves de Sitios. Se devolverán valores p
 ### Truncate HTML
 
 Devuelve un String después de truncarlo (ej. <span v-pre>`{{ html | truncate_html: 10 }}`</span>).
-
-### Video Player
-
-Agrega un reproductor de video en código HTML usando un asset del Gestor de Archivos (ej. <span v-pre>`{{ movie1 | video_player: 320, 320 }}`</span>).
-
-**Parámetros**
-
-- `video` (Asset) — Objeto de tipo Video del Gestor de Archivos.
-- `width` (Integer) — Ancho para el video.
-- `height` (Integer) — Alto para el video.
 
 ## Step
 
@@ -788,24 +821,34 @@ Devuelve el Task con el UID seleccionado. *ej.*
 
 Estos filtros Liquid alteran valores relacionados con los Usuarios.
 
+### Avatar For
+
+Muestra el código HTML de la imagen de un usuario. Si el usuario no tiene avatar propio, entrega el avatar por defecto (ej. <span v-pre>`{{ user | avatar_for: 'C50x50', true }}`</span>).
+
+**Parámetros**
+
+- `user` (User) — Objeto User.
+- `size` (String) (default: 'C50x50') — Tamaño para la imagen.
+- `link` (Boolean) (default: true) — `true` agrega un enlace hacia el perfil del usuario.
+
 ### Default Avatar Image
 
-Muestra la imagen por defecto del avatar (ej. <span v-pre>`{{ user | avatar_for: 'C50x50' }}`</span>).
+Muestra el código HTML del avatar por defecto. La firma es al revés de lo que sugiere el nombre: el valor que va antes de la barra es el **tamaño**, y el usuario es el primer argumento, opcional (ej. <span v-pre>`{{ 'C50x50' | default_avatar_image: user }}`</span>).
 
 **Parámetros**
 
-- `user` (User) — Objeto User.
-- `size` (Integer) (default: 'C50x50') — Tamaño para la imagen.
+- `size` (String) — Tamaño para la imagen, con el formato de las versiones de avatar: `C25x25`, `C50x50`, `C75x75`, `C100x100`, `C125x125`, `C160x160`, `C200x200` o `C250x250`.
+- `user` (User) (default: nulo) — Objeto User del contexto Liquid. Tiene que ser el objeto, no un id ni un correo.
 
-### Image For
+Devuelve una de tres imágenes, según lo que reciba:
 
-Muestra el código HTML para la imagen de un usuario (ej. <span v-pre>`{{ user | avatar_for: 'C50x50', true }}`</span>).
+- Con un usuario cuyo reino tiene configurada la **Imagen de avatar por defecto** en [Configuración de reino](/es/platform/customers/settings.html#general), la imagen del reino en el tamaño pedido.
+- Con un usuario cuyo reino no la tiene configurada, la imagen de marcador de posición en el tamaño pedido.
+- Sin usuario, la imagen de marcador de posición en el tamaño pedido.
 
-**Parámetros**
-
-- `user` (User) — Objeto User.
-- `size` (Integer) (default: 'C50x50') — Tamaño para la imagen.
-- `link` (Boolean) (default: true) — `true` agrega un enlace hacia el perfil del usuario.
+:::tip Tip
+Para el caso habitual no necesitas llamarlo: `avatar_for` ya recurre a `default_avatar_image` cuando el usuario no tiene avatar propio. Llámalo directo solo cuando quieras el avatar por defecto sin consultar el del usuario.
+:::
 
 ### By Form Slug
 


### PR DESCRIPTION
## Cambios propuestos

La referencia Liquid de filtros publica hoy fichas de filtros que no existen y ejemplos que no producen el resultado documentado. Este PR hace un pase de limpieza y corrección sobre `docs/es/platform/channels/liquid-markup/filters.md` y su espejo `docs/en/platform/channels/liquid-markup/filters.md`.

Cierra LIQUID-FILTROS-01, LIQUID-FILTROS-06, LIQUID-FILTROS-07, LIQUID-FILTROS-10, LIQUID-FILTROS-11, LIQUID-FILTROS-12, LIQUID-FILTROS-14 y LIQUID-FILTROS-16.

### Básicos

- Agrega `base64_decode` y `base64_encode`, que estaban en Crypto con las descripciones cruzadas y con `{% %}` donde corresponde `{{ }}`. Son filtros estándar del motor Liquid, no filtros de criptografía de Modyo.

### Content

- Nueva sección **Búsqueda de assets por UUID**: los cuatro filtros de asset por uuid (`asset_image`, `asset_link`, `asset_url_by_uuid`, `asset_video`) buscan el archivo en el ámbito de la cuenta y, si el UUID no existe, no fallan ni devuelven vacío: publican el mensaje de error de asset no encontrado en la página.
- **Asset link**: la ficha decía "Retorna el URL de una imagen", igual que Asset URL by UUID. El filtro devuelve una etiqueta de enlace completa; se documenta el ancla que emite, que el argumento es el texto del enlace y que si se omite se usa el nombre de archivo del asset.
- **By lang**: el ejemplo invocaba `| locale: 'es,en,pt'`, que no es el nombre del filtro y no filtra nada. Se corrige a `by_lang`, se aclara que recibe un único código de idioma (una lista separada por comas devuelve cero resultados), que reemplaza la condición de idioma previa en lugar de acumularla, y que sobre algo que no sea una colección de entradas aborta con error de Liquid visible como comentario en la salida. La clave `locale` del filtro compuesto `by` queda igual de explícita.
- **Filter By**: los tres ejemplos publicados usaban el nombre del campo sin prefijo, que la capa de consulta descarta en silencio, de modo que devolvían la colección completa sin filtrar. Se reescriben con `fields.`, se documenta qué prefijos y qué atributos meta admite el parámetro `field`, se agregan los tres operadores que faltaban (`not`, `search`, `geohash`), se aclara que solo `in`, `nin` y `has` aceptan lista separada por comas, se advierte que `all` no está disponible en este filtro y se documentan los dos casos en que aborta: sin `field` y sobre una colección de la que no se puede resolver el tipo de contenido.

### Crypto

- Se retiran las fichas de `md5`, `sha1` y `hmac_sha1`, que no existen en la plataforma. Como un filtro desconocido no interrumpe el renderizado, la plantilla publica el valor de entrada sin transformar, es decir el dato en claro donde se esperaba un hash: queda advertido en la sección.
- `hmac_sha256` y `sha256`, los dos que sí existen, quedan con la sintaxis correcta (`{{ }}` en lugar de `{% %}`).

### CSS

- Se advierte, a nivel de sección, que todos los filtros de color abortan si el valor de entrada no es un color válido y que en el HTML publicado queda un comentario de error en lugar del color.
- **Grayscale** ya no se presenta como intercambiable con `greyscale`: se aclara que su segundo argumento se acepta pero no altera el resultado, y `greyscale` pasa a tener ficha propia con su firma de un solo parámetro más la advertencia de que pasarle intensidad aborta la plantilla.

### Site

- Nueva sección **Filtros retirados**: `video_player`, `audio_player`, `embedded_video` y `asset_thumbnail_link_tag` ya no existen desde 10.2, y `bar_code` y `qr_code` nunca existieron. Se documenta el síntoma real (la plantilla publica el nombre interno del objeto que recibió, sin mensaje de error) y el reemplazo, armando el markup a mano con `url` y `thumbnail_url` del asset.
- Se retiran las seis fichas correspondientes.

### User

- **Image For** pasa a llamarse **Avatar For**, que es el nombre real del filtro; antes el único filtro de avatar no tenía entrada ni ancla bajo su nombre.
- **Default Avatar Image**: la ficha documentaba el usuario como objeto de entrada y el tamaño como argumento, cuando es al revés, y su ejemplo invocaba otro filtro. Se corrige la firma y el ejemplo, se aclara que el argumento `user` tiene que ser el objeto del contexto Liquid, se documentan los tres resultados posibles y su relación con `avatar_for`.

## Para el revisor

1. La ficha de LIQUID-FILTROS-01 proponía documentar el reemplazo con `url`, `thumbnail_url` y `embedded_code` del asset drop. `embedded_code` no existe: no está en `app/lib/liquid/drops/assets/asset_drop.rb` ni en `video_asset_drop.rb`, y `AssetDrop#liquid_method_missing` lo interpretaría como un uuid, así que devuelve vacío. Documenté solo `url` y `thumbnail_url`, y dejé dicho que `embedded_video` no tiene reemplazo. Además `Assets::Video` no define `thumb` (`app/models/assets/asset.rb:98` lo deja vacío y `app/models/assets/video.rb` no lo sobrescribe), por eso el ejemplo de video no usa `poster`.

2. `base64_encode` y `base64_decode` no están definidos en ningún filtro de Modyo; los documento en Básicos como filtros estándar del motor Liquid (gema liquid 5.13.0, `Gemfile.lock:279`). No hay spec en el repo que los ejercite, así que conviene probarlos una vez en un sitio real antes de mergear. Los cuatro digests y los dos valores Base64 del PR los recalculé y coinciden con los publicados.

3. En 10.2/master `Liquid::Filters::SiteFilter#image_tag` (`lib/liquid/filters/site_filter.rb:192`) ignora las opciones que recibe, así que `default_avatar_image` no emite `class`, `title` ni `name` aunque el código se los pase (lo confirma `spec/lib/liquid/liquid_filters_spec.rb:585-614`, que espera `<img src="...">` a secas). Por eso la ficha describe qué imagen devuelve en cada caso y no promete esos atributos, a diferencia de lo que sugería la ficha del gap.

4. Mismo defecto, fuera del alcance de esta tanda: `docs/es/platform/channels/liquid-markup/examples.md:84` y `:93` usan `filter_by: field: 'field_name'` sin prefijo, con lo que esos dos ejemplos tampoco filtran; y la ficha Filter By Query String lista el operador `all`, que tampoco llega a la consulta porque `Content::EntryParamsParser` lo descarta antes (`entries_query.rb:163` lo resuelve un nivel más arriba, solo alcanzable desde la API pública). Vale una tanda aparte.

5. Renombres de encabezados: Image For a Avatar For, los dos Base64 pasan de Crypto a Básicos, se agrega Greyscale y se retiran seis fichas. Cambian anclas, pero no hay ningún enlace interno a anclas de `filters.md` en docs (`grep -rn "filters.html#" docs/es docs/en --include="*.md"` no devuelve nada) y `sidebarDepth` es 1, así que la barra lateral solo lista los H2, que no se tocan.

6. Los dos enlaces nuevos apuntan a `/es/platform/content/public-api-reference.html#operadores` y `/en/.../public-api-reference.html#operators` (encabezados `##### Operadores` / `##### Operators`, únicos en cada archivo) y a `/es/platform/customers/settings.html#general` y `/en/platform/customers/settings.html#general` (`## General`, único en cada archivo). Vale confirmarlos en el build.

## Fuera de alcance de este PR

- `LIQUID-FILTROS-01 · nota de migración en release-notes.md`: docs/es/platform/release-notes.md todavía no tiene sección 10.2 (la primera es '## 10.1' en la línea 7) y cada release lleva su fecha en un callout; crearla implicaría inventar número y fecha de release, que además es decisión de operaciones. La tanda declara filters.md como única página, así que la advertencia de migración quedó en la propia página de filtros, en la nueva sección 'Filtros retirados' del bloque Site. Queda pendiente sumar la línea a release-notes cuando exista la sección 10.2.

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
