### PR TITLE
Corrige la referencia de la API pública de contenido y documenta su modo vista previa

### DIFF
--- a/docs/en/platform/content/public-api-reference.md
+++ b/docs/en/platform/content/public-api-reference.md
@@ -516,23 +516,28 @@ curl -X GET "https://test.modyo.com/api/content/spaces/{my_space}/types/{type}/e
 
 ### Display total number of Entries
 
-To access the total amount of entries returned by a content filter, you can use the liquid `total_entries` filter, for example:
+Every entry listing includes a `meta` object at the root of the response with the total number of entries that match the query, in the `total_entries` field. That total refers to the whole query, not to the page you are viewing.
 
+If you only need the count, request a single-item page with `per_page=1` and read `meta.total_entries`:
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/{my_space}/entries?category_id=25"
+curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?meta.category=news&per_page=1"
 ```
 
-The response contains the `meta` object that includes a field that will help you navigate it. The returned object will look something like this:
+The returned object will look something like this:
 
 ```json
 "meta": {
     "total_entries": 4,
-    "per_page": 10,
+    "per_page": 1,
     "current_page": 1,
-    "total_pages": 1
+    "total_pages": 4
   },
 ```
+
+:::warning Attention
+Entries are always queried under a content type: the only available route is `/spaces/:space_uid/types/:type_uid/entries` and there is no `/spaces/:space_uid/entries`. To filter by category, use `meta.category` with the category's full path, since `category_id` is not a valid parameter and the request responds `400` with <code v-pre>{"error":{"query":{"category_id":["Unknown parameter"]}}}</code>.
+:::
 
 ### Filter
 
@@ -554,16 +559,19 @@ Metadata (e.g., Tags, Category, Dates): SQL searches will be queried by `meta.pa
     - <span v-pre>`.../?fields.{{field_name}}[geohash]=66j`</span>. With the field called `location`, it would be: `.../?fields.location[geohash]=66j`
   - `.../entries?fields.color=black`
 
-###### Language filter
+##### Language filter
 
-Modyo API delivers entries in the Space's default language, unless another language is explicitly requested via the query string locale parameter or the Accept-Language header.
+The content API delivers entries in the Space's default language. To request another language, use the `locale` query string parameter, which is the only way available: the content API does not read the `Accept-Language` header.
 
 For example, to get entries in the Spanish-Chile language (es-cl):
 
-```plain
-Query string: GET .../posts/entries?locale=es-cl
-Header: Set Accept-Language es-cl
+```shell
+curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?locale=es-cl"
 ```
+
+:::warning Attention
+The language you request must be enabled in the Space. If it isn't, the request does not fall back to the default language: it responds `400` with <code v-pre>{"error":"Locale not available for this space"}</code>.
+:::
 
 ##### Operators
 
@@ -604,16 +612,63 @@ Fields that search multiple items (checkboxes, multiple) can use the following s
 
 ### Order
 
-In the same way that you can filter by category `by_category`, tags `by_tags`, and by uuid `by_uuid`, you can create a filter to order the results by meta attributes `name`, `slug`, `created_at`, `updated_at`, and `published_at` of the entries using the filter `sort_by`, in the following way:
+The order of the results is specified with the `sort_by` and `order` parameters:
 
-The order of the results must be specified with the `sort_by` and `order` parameters:
+- `sort_by`: name of the attribute you want to sort by, always with the `meta.` or `fields.` prefix. A name without a prefix, or an attribute that is not sortable, responds `400` with <code v-pre>{"error":{"query":{"sort_by":["Key not sortable"]}}}</code>.
+- `order`: `asc` or `desc`. It is optional and defaults to `asc`. If you send `sort_by` with a different `order`, the request responds `400` with <code v-pre>{"error":{"query":{"order":["Supported values: asc, desc. asc is selected when no order is specified"]}}}</code>.
 
-- `sort_by`: indicating the name of the attribute (e.g., meta.tags, or fields.name)
-- `order`: ['asc','desc'] (optional, asc by default)
+The metadata attributes you can use in `sort_by` are:
+
+- `meta.uuid`
+- `meta.name`
+- `meta.slug`
+- `meta.created_at`
+- `meta.updated_at`
+- `meta.published_at`
+- `meta.unpublished_at`
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/{my_space}/types/{type}/entries?sort_by=id&order=desc"
+curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?sort_by=meta.published_at&order=desc"
 ```
+
+You can also sort by a field of the content type using the `fields.` prefix, as long as the field is of type Boolean, Checkbox, Date, Decimal, Dropdown, Integer, Radio, or Single-line text. The remaining [field types](/en/platform/content/types.html), such as Rich text, Multiple choice, Location, File, or Group, are not sortable.
+
+For example, to sort by a field called `priority` of type Integer:
+
+```shell
+curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?sort_by=fields.priority&order=asc"
+```
+
+:::warning Attention
+`meta.tags` is not sortable, it only works as a filter. Don't use `meta.category`, `meta.category_slug`, or `meta.category_name` as sorting criteria either: the API accepts them as a parameter, but it cannot resolve the order and the request fails.
+:::
+
+### Preview
+
+By default, the content API delivers only the published versions of entries. If the browser making the request has an administrator session with [preview mode](/en/platform/core/#preview-modes) open, and the **Content SDK** selector in the preview bar is set to **Draft**, the API delivers the draft versions of the entries instead of the published ones. In those responses, `meta.version_type` comes back with the value `editable`.
+
+This applies both to the entry listing and to a single entry:
+
+```bash
+https://www.example.com/api/content/spaces/:space_uid/types/:type_uid/entries
+
+https://www.example.com/api/content/spaces/:space_uid/types/:type_uid/entries/:entry_uuid
+```
+
+Only the entry endpoints switch versions. The content type schema, the categories, and the locations are not affected by the selector.
+
+While the preview session is open, the response is no longer cacheable: the `cache-control` header goes from `public, no-cache` to `no-store, must-revalidate, private, max-age=0`, so that neither the browser nor the CDN stores a draft version. This happens even when the selector is set to **Published**.
+
+The API goes back to delivering published content when any of these conditions is met:
+
+- The request doesn't carry the admin panel session cookie, or there is no preview session open.
+- The administrator session is impersonating a user.
+- The session lost its authorization, for example because it was logged out or an administrator revoked the access.
+- The account validates the browser fingerprint and the request doesn't match the browser that opened the session.
+
+:::warning Attention
+API preview depends on the session of the browser making the request, so it never exposes draft versions to an anonymous end user or to a server-side consumer. The risk is the opposite one: if you develop your consumer layer in the same browser where you have preview mode open, you will see draft versions where your production application will see published content. Check your responses in a window without the administrator session before taking them as final.
+:::
 
 ### Private content
 

--- a/docs/en/platform/content/public-api-reference.md
+++ b/docs/en/platform/content/public-api-reference.md
@@ -521,7 +521,7 @@ Every entry listing includes a `meta` object at the root of the response with th
 If you only need the count, request a single-item page with `per_page=1` and read `meta.total_entries`:
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?meta.category=news&per_page=1"
+curl -X GET "https://my_account.modyo.com/api/content/spaces/my_space/types/my_type/entries?meta.category=my_category&per_page=1"
 ```
 
 The returned object will look something like this:
@@ -563,10 +563,10 @@ Metadata (e.g., Tags, Category, Dates): SQL searches will be queried by `meta.pa
 
 The content API delivers entries in the Space's default language. To request another language, use the `locale` query string parameter, which is the only way available: the content API does not read the `Accept-Language` header.
 
-For example, to get entries in the Spanish-Chile language (es-cl):
+For example, to get entries in the Spanish language (es):
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?locale=es-cl"
+curl -X GET "https://my_account.modyo.com/api/content/spaces/my_space/types/my_type/entries?locale=es"
 ```
 
 :::warning Attention
@@ -628,7 +628,7 @@ The metadata attributes you can use in `sort_by` are:
 - `meta.unpublished_at`
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?sort_by=meta.published_at&order=desc"
+curl -X GET "https://my_account.modyo.com/api/content/spaces/my_space/types/my_type/entries?sort_by=meta.published_at&order=desc"
 ```
 
 You can also sort by a field of the content type using the `fields.` prefix, as long as the field is of type Boolean, Checkbox, Date, Decimal, Dropdown, Integer, Radio, or Single-line text. The remaining [field types](/en/platform/content/types.html), such as Rich text, Multiple choice, Location, File, or Group, are not sortable.
@@ -636,7 +636,7 @@ You can also sort by a field of the content type using the `fields.` prefix, as 
 For example, to sort by a field called `priority` of type Integer:
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?sort_by=fields.priority&order=asc"
+curl -X GET "https://my_account.modyo.com/api/content/spaces/my_space/types/my_type/entries?sort_by=fields.priority&order=asc"
 ```
 
 :::warning Attention

--- a/docs/en/platform/core/README.md
+++ b/docs/en/platform/core/README.md
@@ -158,8 +158,10 @@ The preview bar contains the following interactive elements:
 - **Share link**: Allows you to copy a link that can be shared with other users. Opening the link provides direct access to preview mode with the configuration that was in place when the link was copied. To access preview mode, you must have an active session in the administrator account.
 - **Exit preview mode**: Closes preview mode, removing the bar and keeping the tab at the site's current URL.
 
-:::warning JavaScript SDK
-Changing the content selector in the preview bar will not affect content you are using through the JavaScript SDK or the content API. It will only affect content used through the Liquid SDK.
+:::warning Content SDK
+The **Content SDK** selector affects content used through the Liquid SDK and also the public content API: if the browser making the request has preview mode open and the selector set to **Draft**, the content API responds with the draft versions of the entries.
+
+This only happens when the request travels with the administrator session of that browser. An anonymous end user, or any server-side consumer, always receives published content. See [Preview](/en/platform/content/public-api-reference.html#preview) for the details.
 :::
 ## Team Review
 

--- a/docs/es/platform/content/public-api-reference.md
+++ b/docs/es/platform/content/public-api-reference.md
@@ -519,7 +519,7 @@ Todo listado de entradas incluye en la raíz de la respuesta un objeto `meta` co
 Si sólo necesitas el conteo, pide una página de un elemento con `per_page=1` y lee `meta.total_entries`:
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?meta.category=noticias&per_page=1"
+curl -X GET "https://my_account.modyo.com/api/content/spaces/my_space/types/my_type/entries?meta.category=my_category&per_page=1"
 ```
 
 La forma del objeto retornado será algo como esto:
@@ -561,10 +561,10 @@ Metadata (ej: Tags, Category, Fechas): Búsquedas por SQL, serán consultables m
 
 La API de contenido entrega las entradas en el idioma por defecto del Espacio. Para pedir otro idioma usa el parámetro de query string `locale`, que es la única vía disponible: la API de contenido no lee la cabecera `Accept-Language`.
 
-Por ejemplo, para obtener entradas en el idioma Español-Chile (es-cl):
+Por ejemplo, para obtener entradas en el idioma Español (es):
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?locale=es-cl"
+curl -X GET "https://my_account.modyo.com/api/content/spaces/my_space/types/my_type/entries?locale=es"
 ```
 
 :::warning Atención
@@ -626,7 +626,7 @@ Los atributos de metadata que puedes usar en `sort_by` son:
 - `meta.unpublished_at`
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?sort_by=meta.published_at&order=desc"
+curl -X GET "https://my_account.modyo.com/api/content/spaces/my_space/types/my_type/entries?sort_by=meta.published_at&order=desc"
 ```
 
 También puedes ordenar por un campo propio del tipo de contenido usando el prefijo `fields.`, siempre que el campo sea de tipo Booleano, Checkbox, Decimal, Dropdown, Entero, Fecha, Radio o Texto de una línea. El resto de los [tipos de campo](/es/platform/content/types.html), como Texto enriquecido, Opciones múltiples, Ubicación, Archivo o Grupo, no son ordenables.
@@ -634,7 +634,7 @@ También puedes ordenar por un campo propio del tipo de contenido usando el pref
 Por ejemplo, para ordenar por un campo llamado `priority` de tipo Entero:
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?sort_by=fields.priority&order=asc"
+curl -X GET "https://my_account.modyo.com/api/content/spaces/my_space/types/my_type/entries?sort_by=fields.priority&order=asc"
 ```
 
 :::warning Atención

--- a/docs/es/platform/content/public-api-reference.md
+++ b/docs/es/platform/content/public-api-reference.md
@@ -514,23 +514,28 @@ curl -X GET "https://test.modyo.com/api/content/spaces/{my_space}/types/{type}/e
 
 ### Desplegar cantidad total de Entradas
 
-Para acceder a la cantidad total de entradas que retorna un filtro de contenido, puedes usar el filtro de liquid `total_entries`, por ejemplo:
+Todo listado de entradas incluye en la raíz de la respuesta un objeto `meta` con el total de entradas que coinciden con la consulta, en el campo `total_entries`. Ese total corresponde a la consulta completa, no a la página que estás viendo.
 
+Si sólo necesitas el conteo, pide una página de un elemento con `per_page=1` y lee `meta.total_entries`:
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/{my_space}/entries?category_id=25"
+curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?meta.category=noticias&per_page=1"
 ```
 
-La respuesta contiene el objeto `meta` que incluye un campo que te ayudará a navegarlo. La forma del objeto retornado será algo como esto:
+La forma del objeto retornado será algo como esto:
 
 ```json
 "meta": {
     "total_entries": 4,
-    "per_page": 10,
+    "per_page": 1,
     "current_page": 1,
-    "total_pages": 1
+    "total_pages": 4
   },
 ```
+
+:::warning Atención
+Las entradas siempre se consultan bajo un tipo de contenido: la única ruta disponible es `/spaces/:space_uid/types/:type_uid/entries` y no existe `/spaces/:space_uid/entries`. Para filtrar por categoría usa `meta.category` con la ruta completa de la categoría, ya que `category_id` no es un parámetro válido y la petición responde `400` con <code v-pre>{"error":{"query":{"category_id":["Unknown parameter"]}}}</code>.
+:::
 
 ### Filtrar
 
@@ -552,16 +557,19 @@ Metadata (ej: Tags, Category, Fechas): Búsquedas por SQL, serán consultables m
     - <span v-pre>`.../?fields.{{field_name}}[geohash]=66j`</span>. Con el campo llamado `location` quedaría: `.../?fields.location[geohash]=66j`
   - `.../entries?fields.color=black`
 
-###### Filtro de idiomas
+##### Filtro de idiomas
 
-La API de Modyo entrega entries en el idioma por defecto del Espacio, a menos que se pida explícitamente otro idioma a través del parámetro de query string locale o el Accept-Language header.
+La API de contenido entrega las entradas en el idioma por defecto del Espacio. Para pedir otro idioma usa el parámetro de query string `locale`, que es la única vía disponible: la API de contenido no lee la cabecera `Accept-Language`.
 
-Por ejemplo, para obtener entries en el idioma Español-Chile (es-cl):
+Por ejemplo, para obtener entradas en el idioma Español-Chile (es-cl):
 
-```plain
-Query string: GET .../posts/entries?locale=es-cl
-Header: Setear Accept-Language es-cl
+```shell
+curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?locale=es-cl"
 ```
+
+:::warning Atención
+El idioma que pidas tiene que estar habilitado en el Espacio. Si no lo está, la petición no cae al idioma por defecto: responde `400` con <code v-pre>{"error":"Locale not available for this space"}</code>.
+:::
 
 ##### Operadores
 
@@ -602,16 +610,63 @@ Los campos que buscan en elementos múltiples (checkboxes, multiple) pueden usar
 
 ### Ordenar
 
-De la misma forma en que se puede filtrar por categoría `by_category`, tags `by_tags` y por uuid `by_uuid`, se puede crear un filtro para ordenar los resultados por los atributos "meta" `name`, `slug`, `created_at`, `updated_at`, `published_at` de las entradas usando los filtros `sort_by`, de la siguiente forma:
+El orden de los resultados se especifica con los parámetros `sort_by` y `order`:
 
-El orden de los resultados se debe especificar con los parámetros `sort_by` y `order`:
+- `sort_by`: nombre del atributo por el que quieres ordenar, siempre con el prefijo `meta.` o `fields.`. Un nombre sin prefijo, o un atributo que no sea ordenable, responde `400` con <code v-pre>{"error":{"query":{"sort_by":["Key not sortable"]}}}</code>.
+- `order`: `asc` o `desc`. Es opcional y su valor por defecto es `asc`. Si envías `sort_by` con un `order` distinto, la petición responde `400` con <code v-pre>{"error":{"query":{"order":["Supported values: asc, desc. asc is selected when no order is specified"]}}}</code>.
 
-- `sort_by`: indicando el nombre del atributo (ej: meta.tags, o fields.name)
-- `order`: ['asc','desc'] (opcional, asc por default)
+Los atributos de metadata que puedes usar en `sort_by` son:
+
+- `meta.uuid`
+- `meta.name`
+- `meta.slug`
+- `meta.created_at`
+- `meta.updated_at`
+- `meta.published_at`
+- `meta.unpublished_at`
 
 ```shell
-curl -X GET "https://test.modyo.com/api/content/spaces/{my_space}/types/{type}/entries?sort_by=id&order=desc"
+curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?sort_by=meta.published_at&order=desc"
 ```
+
+También puedes ordenar por un campo propio del tipo de contenido usando el prefijo `fields.`, siempre que el campo sea de tipo Booleano, Checkbox, Decimal, Dropdown, Entero, Fecha, Radio o Texto de una línea. El resto de los [tipos de campo](/es/platform/content/types.html), como Texto enriquecido, Opciones múltiples, Ubicación, Archivo o Grupo, no son ordenables.
+
+Por ejemplo, para ordenar por un campo llamado `priority` de tipo Entero:
+
+```shell
+curl -X GET "https://test.modyo.com/api/content/spaces/blog/types/post/entries?sort_by=fields.priority&order=asc"
+```
+
+:::warning Atención
+`meta.tags` no es ordenable, sólo sirve como filtro. Tampoco uses `meta.category`, `meta.category_slug` ni `meta.category_name` como criterio de orden: la API los acepta como parámetro, pero no puede resolver el orden y la petición falla.
+:::
+
+### Vista previa
+
+Por defecto, la API de contenido entrega sólo las versiones publicadas de las entradas. Si el navegador que hace la petición tiene una sesión de administrador con el [modo vista previa](/es/platform/core/#modos-de-vista-previa) abierto, y el selector **SDK de contenido** de la barra de vista previa está en **Editable**, la API entrega las versiones editables de las entradas en lugar de las publicadas. En esas respuestas, `meta.version_type` llega con el valor `editable`.
+
+Esto aplica tanto al listado de entradas como a una entrada puntual:
+
+```bash
+https://www.example.com/api/content/spaces/:space_uid/types/:type_uid/entries
+
+https://www.example.com/api/content/spaces/:space_uid/types/:type_uid/entries/:entry_uuid
+```
+
+Sólo los endpoints de entradas cambian de versión. El esquema del tipo de contenido, las categorías y las ubicaciones no se ven afectados por el selector.
+
+Mientras la sesión de vista previa está abierta, la respuesta deja de ser cacheable: la cabecera `cache-control` pasa de `public, no-cache` a `no-store, must-revalidate, private, max-age=0`, para que ni el navegador ni la CDN guarden una versión editable. Esto ocurre incluso cuando el selector está en **Publicada**.
+
+La API vuelve a entregar contenido publicado cuando se cumple cualquiera de estas condiciones:
+
+- La petición no viaja con la cookie de sesión del panel de administración, o no hay una sesión de vista previa abierta.
+- La sesión de administrador está impersonando a un usuario.
+- La sesión perdió su autorización, por ejemplo porque se cerró sesión o un administrador revocó el acceso.
+- La cuenta valida la huella del navegador y la petición no coincide con el navegador que abrió la sesión.
+
+:::warning Atención
+La vista previa de la API depende de la sesión del navegador que hace la petición, así que nunca expone versiones editables a un usuario final anónimo ni a un consumo desde servidor. El riesgo es el opuesto: si desarrollas tu capa de consumo en el mismo navegador donde tienes el modo vista previa abierto, vas a ver versiones editables donde tu aplicación en producción verá contenido publicado. Verifica las respuestas en una ventana sin la sesión de administrador antes de darlas por buenas.
+:::
 
 ### Contenido privado
 

--- a/docs/es/platform/core/README.md
+++ b/docs/es/platform/core/README.md
@@ -157,8 +157,10 @@ La barra de vista previa contiene los siguientes elementos interactivos:
 - **Compartir link**: Permite copiar un enlace que se puede compartir con otros usuarios. Al abrir el enlace, se accede directamente al modo vista previa con la configuración que se tenía al momento de copiar el enlace. Para acceder al modo vista previa, es necesario tener una sesión iniciada en la cuenta de administradora.
 - **Salir del modo vista previa**: Cierra el modo vista previa, eliminando la barra y manteniendo la pestaña en la URL actual del sitio.
 
-:::warning SDK de Javascript
-Cambiar el selector de contenido de la barra de previsualización no tendrá efecto sobre el contenido que estés usando a través del SDK de JavaScript o la API de contenido. Solo tendrá efecto en el contenido que se usa a través del SDK de Liquid.
+:::warning SDK de contenido
+El selector **SDK de contenido** afecta al contenido que se usa a través del SDK de Liquid y también a la API pública de contenido: si el navegador que hace la petición tiene el modo vista previa abierto y el selector en **Editable**, la API de contenido responde con las versiones editables de las entradas.
+
+Esto sólo ocurre cuando la petición viaja con la sesión de administrador de ese navegador. Un usuario final anónimo, o cualquier consumo desde un servidor, siempre recibe contenido publicado. Revisa [Vista previa](/es/platform/content/public-api-reference.html#vista-previa) para el detalle.
 :::
 
 


### PR DESCRIPTION
## Cambios propuestos

Esta tanda corrige cuatro afirmaciones de la referencia de la API pública de Content que no coinciden con el comportamiento de la plataforma, y documenta por primera vez el efecto del modo vista previa sobre esa API. Cierra los gaps API-PUBLICA-11, API-PUBLICA-23, API-PUBLICA-24 y API-PUBLICA-04.

### `docs/es/platform/content/public-api-reference.md` y su espejo en `docs/en`

**Filtro de idiomas** (API-PUBLICA-23). La página publicaba la cabecera `Accept-Language` como forma de pedir el idioma. La API de contenido no la lee: el único camino es el parámetro de query string `locale`. Se reemplaza el bloque, se cambia el ejemplo por un `curl` completo y se agrega un aviso de que un idioma que el Espacio no tenga habilitado no cae al idioma por defecto, sino que responde `400` con `Locale not available for this space`. De paso el encabezado pasa de H6 a H5 para quedar al mismo nivel que Operadores, Campos retornados e Igualdades/Desigualdades en arrays.

**Desplegar cantidad total de Entradas** (API-PUBLICA-24). El ejemplo apuntaba a `/spaces/{my_space}/entries?category_id=25`: esa ruta no existe en el namespace de contenido y `category_id` no es un parámetro permitido, así que el request nunca podía devolver el JSON que la propia sección mostraba. Además la sección mezclaba el filtro de Liquid `total_entries` con la API REST. Ahora se explica que `meta.total_entries` viene en el envelope de cualquier listado, se muestra cómo pedir sólo el conteo con `per_page=1`, y un callout deja claro que las entradas siempre se consultan bajo un tipo de contenido y que el filtro de categoría es `meta.category` con la ruta completa.

**Ordenar** (API-PUBLICA-04). Los dos ejemplos eran inválidos: `sort_by=id` y la mención a `meta.tags` responden `400` con `Key not sortable`. Se documenta que `sort_by` exige prefijo `meta.` o `fields.`, se listan los atributos de metadata que sí ordenan, se explica que también se puede ordenar por un campo del tipo de contenido cuando es de tipo Booleano, Checkbox, Decimal, Dropdown, Entero, Fecha, Radio o Texto de una línea, y que `order` sólo acepta `asc` o `desc` con `asc` por defecto. Se agregan dos ejemplos que sí funcionan y un aviso sobre los atributos que no sirven como criterio de orden.

**Vista previa**, sección nueva (API-PUBLICA-11). Desde 10.2 la API pública de contenido respeta el modo vista previa. Se documenta que cuando el navegador que hace la petición tiene una sesión de administrador con vista previa abierta y el selector **SDK de contenido** en **Editable**, los endpoints de entradas devuelven las versiones editables y `meta.version_type` llega como `editable`; que mientras la sesión está abierta la respuesta deja de ser cacheable (`cache-control` pasa a `no-store, must-revalidate, private, max-age=0`); qué condiciones devuelven la API a contenido publicado (sin cookie de sesión, sesión impersonando a un usuario, sesión sin autorización, huella de navegador que no coincide); y que el efecto es por navegador, nunca para usuarios finales anónimos ni para consumos desde servidor.

### `docs/es/platform/core/README.md` y su espejo en `docs/en`

Se reescribe el callout de la barra de vista previa (API-PUBLICA-11), que afirmaba que cambiar el selector de contenido "no tendrá efecto sobre el contenido que estés usando a través del SDK de JavaScript o la API de contenido". Eso es falso para la API de contenido en 10.2. El callout nuevo explica el alcance real y enlaza a la sección Vista previa de la referencia de la API.

### Notas para el revisor

- La sección Ordenar lista 7 atributos de metadata, no los 10 que acepta el validador de parámetros. `meta.category`, `meta.category_slug` y `meta.category_name` pasan la validación pero no se pueden resolver como orden y la petición falla, así que quedan documentados como algo que no hay que usar en lugar de como atributos ordenables.
- El callout de `core/README.md` y la sección Vista previa no afirman nada sobre el SDK de JavaScript: enuncian la condición real, que la petición viaje con la sesión de administrador del navegador.
- Los cuerpos de error JSON inline van dentro de `<code v-pre>` para no arriesgar el build de VuePress.

## Para el revisor

1. Me desvié de la ficha en API-PUBLICA-04. La ficha pedía enumerar los 10 atributos meta de META_TERMS como ordenables, pero sólo 7 producen un orden real. entries_query.rb:278 resuelve el orden meta con `query.order(field_name => order)`, es decir contra una columna de content_entries, y db/schema.rb:484-503 no tiene columnas category, category_slug ni category_name (sólo category_id). Esos tres pasan la validación del parser y después la consulta falla. Documenté los 7 que funcionan (uuid, name, slug, created_at, updated_at, published_at, unpublished_at) y agregué un callout que dice explícitamente que no se usen los tres de categoría. No pude ejecutar la app para capturar el código HTTP exacto de esa falla, así que el texto dice "la petición falla" sin prometer un status. Si prefieren no exponer ese comportamiento, se puede recortar la segunda frase del callout de Ordenar sin tocar el resto.

2. El SDK de JavaScript no vive en el repo modyo, así que no pude verificar si sus peticiones viajan con la cookie de sesión. Por eso ni el callout de core/README.md ni la sección Vista previa afirman nada sobre el SDK de JavaScript: enuncian la condición real ("cuando la petición viaja con la sesión de administrador de ese navegador"). Nota para quien revise: content_controller.rb responde con access-control-allow-credentials true (cors_resolver.rb), así que un front end que envíe credenciales desde un origen permitido sí arrastra la sesión.

3. No nombré la variable de entorno de validación de fingerprint (preview_support.rb:67) por la regla de no publicar internos de operaciones; el bullet describe el efecto observable. Lo mismo con surrogate-control: sólo documenté cache-control y hablé de "la CDN".

4. Fuera del alcance de esta tanda, detectado al verificar, para una tanda futura: (a) docs/es|en/platform/core/README.md línea 139/141 sigue diciendo que el selector de contenido sólo aplica a elementos usados "mediante el SDK de Liquid de contenido"; el callout que reescribo queda justo debajo y lo corrige, pero la línea de la lista quedó sin tocar a propósito. (b) Los ejemplos JSON y el JSON Schema de public-api-reference.md muestran `unpublished_at`, mientras entry.rb:154 emite `unpublish_at`, y los ejemplos omiten `segments`, `author` y `excerpt`. (c) docs/es/platform/tools/sdk.md:53 repite el mismo ejemplo inválido con `category_id` que corrijo acá.

5. Las 10 ediciones fueron validadas con conteo de ocurrencias sobre los archivos actuales: cada old_string aparece exactamente una vez. También revisé que ninguna línea nueva fuera de bloques cercados contenga {{ }} ni {% %}; los cuerpos de error JSON inline van en <code v-pre>, patrón que ya existe en docs/es/dynamic/development/api-integration.md:236. No pude correr yarn docs:build porque node no está disponible en este entorno.

Closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)
