### PR TITLE
Corregir los parámetros y el alcance de GET /api/admin/logs y documentar el recurso /api/admin/profile

### DIFF
--- a/docs/en/platform/core/api.md
+++ b/docs/en/platform/core/api.md
@@ -538,13 +538,15 @@ Finally, the API will always return the first page (`current_page: 1`) of resour
 
 ## Logs
 
-With the Logs API you can get all the records that happen within Modyo Platform, you can choose between User or Administrator logs. If you want to query User logs, use:
+With the Logs API you get the activity records that happen within Modyo Platform. Each record stores the type of action (`type`), the administrator who performed it (`user`, empty when the action is automated), the affected object (`loggeable_type` and `loggeable_id`), and the context where it happened (`site_id`, `space_id`). End user activity arrives with its own record types, such as `user_login_log` or `form_response_created_log`.
+
+To get the list, call the resource without parameters:
 
 ```shell script
-curl -X GET https://test.modyo.com/api/admin/logs?user_type=User"   -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+curl -X GET https://test.modyo.com/api/admin/logs -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
 ```
 
-This query obtained all the records and displays them in a JSON:
+The query returns the records you are allowed to see, from the most recent to the oldest, and displays them in a JSON:
 
 ```json
 {
@@ -604,6 +606,143 @@ This query obtained all the records and displays them in a JSON:
 }
 ```
 
-If you want to know the administrator logs, change the user type to: `user_type=AdminUser`
+### What logs you see
+
+The scope of the response depends on the user who owns the token:
+
+- If the token belongs to the account owner, to a user with the **Full admin** role at the account level, or to a user in a group with that role, the response includes every record in the account.
+- Any other administrator gets only their own records when the query is not narrowed down, with `HTTP 200 OK` and without any warning in the response.
+- To see the activity of a whole context, add `realm_id`, `site_id`, or `space_id` with the identifier of a context where the user has a role assigned, or where the user has full scope through the **Manage Customers**, **Manage Channels**, or **Manage Content** grouped permissions. If you send more than one, the scope validation runs on the first one present in this order: `realm_id`, `site_id`, and `space_id`.
+- If you narrow the query down to a context where the user has no role, you get only their own records for that context, which is usually an empty list.
+
+:::warning Attention
+Up to 10.1, users with the **Default admin** role at the account level also got every record. As of 10.2, only the account owner and the **Full admin** role keep that scope. If your integration queries `/api/admin/logs` with a token that does not hold that role, add `realm_id`, `site_id`, or `space_id` to the call: otherwise the records you used to get stop showing up, with no error to warn you.
+:::
+
+### Query filters
+
+`GET /api/admin/logs` accepts these parameters:
+
+- `type`: one record type, for example `entry_published_log`.
+- `types`: several types in a single value, separated by comma and space, with the space encoded as `%20`. If you send `type` and `types` in the same call, `types` wins.
+- `not_in_type`: excludes record types, with the same format as `types`.
+- `from_date` and `to_date`: creation range in ISO 8601 format, for example `2026-07-01T00:00:00-03:00`. If you omit them, the query covers the whole history up to the end of the current day. A date that cannot be parsed returns `HTTP 409 Conflict`.
+- `date_range`: a shortcut for the range above. It takes two dates as an array (`date_range[]=2026-07-01&date_range[]=2026-07-15`) and expands them to the beginning of the first day and the end of the second one. It takes precedence over `from_date` and `to_date`, and if either date cannot be parsed the platform silently drops the whole range and responds with the history unfiltered by date.
+- `realm_id`, `site_id`, and `space_id`: narrow the records down to the given realm, site, or space, and define the scope of the query.
+- `user_uuid`: records of one specific administrator, by their `uuid`. With the literal value `system` you get only the automated records, that is, the ones without an administrator behind them.
+- `loggeable_type` and `loggeable_id`: the object affected by the action, for example `loggeable_type=Content::Entry`.
+- `application`: with the value `core` it narrows the results down to the platform core objects, such as sites, spaces, entries, roles, forms, and webhooks.
+- `query`: free text. It searches by prefix in the record title and in the name and email of its author.
+- `admin_actions`: with `true` it leaves end user activity out.
+- `sort_by` and `order`: sorting of the list.
+- `page` and `per_page`: pagination, as described in [Pagination](/en/platform/core/api.html#pagination).
+
+:::warning Attention
+`user_type` and `user_id` do not filter anything. They still show up among the parameters of the resource in `/api/admin/docs`, but the list ignores them: a call with `user_type=User` or with `user_type=AdminUser` returns the same result as the call without parameters. If you use them to separate administrator activity from end user activity, you are actually getting the complete list.
+:::
+
+### Isolating administration activity
+
+`admin_actions=true` is the filter that does tell both activities apart: it excludes the records of type `email_delivered_log`, `email_opened_log`, `email_spam_report_log`, `form_response_created_log`, `notification_opened_log`, and `user_login_log`.
+
+```shell script
+curl -X GET "https://test.modyo.com/api/admin/logs?admin_actions=true" -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+If the user who owns the token is not the account owner and has no role at the account level, `admin_actions=true` also limits the response to the sites where they have a role assigned, and ignores the `site_id` you sent.
+
+There is no inverse filter. To keep only end user activity, list the types you care about in `types`:
+
+```shell script
+curl -X GET "https://test.modyo.com/api/admin/logs?types=user_login_log,%20form_response_created_log" -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+### Sorting the results
+
+`sort_by` accepts `created_at`, `type`, and `loggeable_type`, and `order` accepts `asc` and `desc`. By default the list arrives sorted by `created_at` in `desc`, from the newest record to the oldest one.
+
+:::tip Tip
+The Swagger catalog publishes `sort_by` with the example value `COMPLETAR`, which is not a valid value. Use `created_at`, `type`, or `loggeable_type`.
+:::
+
+### Log detail and log types
+
+- `GET /api/admin/logs/{id}` returns one specific record.
+- `GET /api/admin/logs/types` returns the record types that exist in the account and how many records there are of each one. This is how you find out the valid values for `type`, `types`, and `not_in_type`.
+
+Both calls are governed by the **View Activity Logs** grouped permission. The `GET /api/admin/logs` list does not require a specific permission: what changes from one user to another is the scope of the response.
+
+## Authenticated user profile
+
+The `/api/admin/profile` resource always works on the user who owns the token, without taking identifiers, and it requires no permissions: being authenticated is enough. It is the resource that replaces `GET /api/admin/admin_users/me`, which no longer exists.
+
+The Swagger catalog in `/api/admin/docs` does not list this resource yet, so these are its calls:
+
+```http request
+GET    /api/admin/profile                              Authenticated user profile
+PUT    /api/admin/profile                              Updates first name, last name, language, and avatar
+PUT    /api/admin/profile/update_protected_attributes  Updates username and email
+DELETE /api/admin/profile/remove_otp                   Removes two-factor authentication
+GET    /api/admin/profile/sessions                     Lists active sessions
+DELETE /api/admin/profile/revoke_session               Revokes active sessions
+```
+
+### Reading and updating the profile
+
+`GET /api/admin/profile` returns the data of the token user: `id`, `uuid`, `name`, `first_name`, `last_name`, `email`, `username`, `avatar`, `lang`, `time_zone`, `active`, `created_at`, `updated_at`, `last_login_at`, `last_login_ip`, the assigned roles (`roles`), and the applications the user has access to (`application_access`).
+
+```shell script
+curl -X GET https://test.modyo.com/api/admin/profile -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+`PUT /api/admin/profile` updates only `first_name`, `last_name`, `lang`, and `avatar_id`. `lang` accepts `en`, `es`, and `pt`, and `avatar_id` is the identifier of an avatar created with `/api/admin/profile_avatar`.
+
+```shell script
+curl -X PUT https://test.modyo.com/api/admin/profile -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56' -H 'Content-Type: application/json' -d '{"first_name":"Sam","last_name":"Johnson","lang":"es"}'
+```
+
+:::tip Tip
+If you include `username` or `email` in this call, the platform discards them and responds `HTTP 200 OK` with those fields unchanged. To modify them, use the protected attributes call.
+:::
+
+### Changing the username or the email
+
+`username` and `email` are protected attributes: they are updated only with `PUT /api/admin/profile/update_protected_attributes`, and the call must include `current_password` with the current password of the user.
+
+```shell script
+curl -X PUT https://test.modyo.com/api/admin/profile/update_protected_attributes -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56' -H 'Content-Type: application/json' -d '{"email":"sam.johnson@modyo.com","current_password":"your-current-password"}'
+```
+
+Keep in mind that:
+
+- The `username` change applies immediately and responds `HTTP 200 OK`.
+- The `email` change does not apply immediately: the platform sends a confirmation email to the new address and keeps it pending until the user confirms it.
+- If `current_password` is wrong or empty, the response is `HTTP 422 Unprocessable Entity` and nothing is updated.
+
+:::danger Danger
+Failed attempts with a wrong password add up. When the limit configured for your account is reached, the platform revokes every active session of the user, so anyone working in the administration panel is logged out. Handle the `HTTP 422` in your integration and do not retry in a loop.
+:::
+
+### Two-factor authentication
+
+`DELETE /api/admin/profile/remove_otp` removes the two-factor authentication settings of the authenticated user and responds `HTTP 200 OK`, even if the user had no two-factor authentication configured.
+
+:::warning Attention
+This call does not ask for the current password, so any valid token of the user is enough to disable their two-factor authentication. Treat administration API tokens with the same care as a password.
+:::
+
+### Active sessions
+
+`GET /api/admin/profile/sessions` lists the current sessions of the user, from the most recent to the oldest. Each session comes with its `uuid`, the date it was opened (`created_at`), the IP it was opened from (`request_ip`), the browser (`device_name`), the operating system (`device_os`), the device type (`device_type`, with value `Desktop` or `Mobile`), and, where applicable, the name of the administrator who opened it through impersonation (`impersonator`).
+
+`DELETE /api/admin/profile/revoke_session` revokes sessions: with `grant_uuid` you revoke one specific session and with `all=true` you revoke every active session. The response is `HTTP 204 No Content`, and `HTTP 404 Not Found` if the session was already revoked.
+
+```shell script
+curl -X DELETE "https://test.modyo.com/api/admin/profile/revoke_session?all=true" -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+:::tip Tip
+The session tied to the call is left out of the revocation, even if you send its own `grant_uuid`: the response is `HTTP 204 No Content` and the session stays active.
+:::
 
 To learn more about how to query Content information via API, see our guide and examples in [API](/en/platform/content/public-api-reference.html).

--- a/docs/es/platform/core/api.md
+++ b/docs/es/platform/core/api.md
@@ -534,13 +534,15 @@ Finalmente, la API siempre retornará la primera página (`current_page: 1`) de 
 
 ## Registros (Logs)
 
-Con la API de Logs puedes obtener todos los registros que suceden dentro de Modyo Platform, puedes elegir entre logs de Usuarios o Administradores. Si quieres consultar los logs de Usuarios, usa:  
+Con la API de Logs obtienes los registros de actividad que suceden dentro de Modyo Platform. Cada registro guarda el tipo de acción (`type`), el administrador que la ejecutó (`user`, vacío cuando la acción es automática), el objeto afectado (`loggeable_type` y `loggeable_id`) y el contexto donde ocurrió (`site_id`, `space_id`). La actividad de los usuarios finales llega con tipos de registro propios, como `user_login_log` o `form_response_created_log`.
+
+Para obtener el listado, llama al recurso sin parámetros:  
 
 ```shell script
-curl -X GET https://test.modyo.com/api/admin/logs?user_type=User"   -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+curl -X GET https://test.modyo.com/api/admin/logs -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
 ```
 
-Esta consulta obtuvo todos los registros y los despliega en un JSON:
+La consulta devuelve los registros que alcanzas a ver, del más reciente al más antiguo, y los despliega en un JSON:
 
 ```json
 {
@@ -600,6 +602,143 @@ Esta consulta obtuvo todos los registros y los despliega en un JSON:
 }
 ```
 
-Si quieres conocer los registros de administradores, cambia el tipo de usuario por: `user_type=AdminUser`
+### Qué registros ves
+
+El alcance de la respuesta depende del usuario dueño del token:
+
+- Si es el dueño de la cuenta, tiene el rol **Full admin** a nivel de cuenta o pertenece a un grupo con ese rol, recibe todos los registros de la cuenta.
+- Cualquier otro administrador recibe solo sus propios registros cuando no acota la consulta, con `HTTP 200 OK` y sin ninguna advertencia en la respuesta.
+- Para ver la actividad de un contexto completo, agrega `realm_id`, `site_id` o `space_id` con el identificador de un contexto donde el usuario tenga un rol asignado, o donde tenga alcance completo por los permisos agrupados **Gestionar Clientes**, **Gestionar Canales** o **Gestionar Contenido**. Si envías más de uno, la validación del alcance se hace sobre el primero que esté presente en este orden: `realm_id`, `site_id` y `space_id`.
+- Si acotas la consulta a un contexto donde el usuario no tiene rol, vuelves a recibir solo sus propios registros de ese contexto, que suele ser una lista vacía.
+
+:::warning Atención
+Hasta 10.1, los usuarios con el rol **Default admin** a nivel de cuenta también recibían todos los registros. Desde 10.2 solo el dueño de la cuenta y el rol **Full admin** conservan ese alcance. Si tu integración consulta `/api/admin/logs` con un token que no tiene ese rol, agrega `realm_id`, `site_id` o `space_id` a la llamada: de lo contrario los registros que antes recibías dejan de aparecer, sin ningún error que lo advierta.
+:::
+
+### Filtros de la consulta
+
+`GET /api/admin/logs` acepta estos parámetros:
+
+- `type`: un tipo de registro, por ejemplo `entry_published_log`.
+- `types`: varios tipos en un solo valor, separados por coma y espacio, con el espacio codificado como `%20`. Si envías `type` y `types` en la misma llamada, manda `types`.
+- `not_in_type`: excluye tipos de registro, con el mismo formato de `types`.
+- `from_date` y `to_date`: rango de creación en formato ISO 8601, por ejemplo `2026-07-01T00:00:00-03:00`. Si los omites, la consulta abarca todo el historial hasta el final del día en curso. Una fecha que no se puede interpretar devuelve `HTTP 409 Conflict`.
+- `date_range`: atajo del rango anterior. Recibe dos fechas como arreglo (`date_range[]=2026-07-01&date_range[]=2026-07-15`) y las expande al inicio del primer día y al final del segundo. Tiene prioridad sobre `from_date` y `to_date`, y si alguna de las dos fechas no se puede interpretar la plataforma descarta el rango completo en silencio y responde con el historial sin filtrar por fecha.
+- `realm_id`, `site_id` y `space_id`: acotan los registros al realm, sitio o espacio indicado, y definen el alcance de la consulta.
+- `user_uuid`: registros de un administrador puntual, por su `uuid`. Con el valor literal `system` obtienes solo los registros automáticos, es decir, los que no tienen un administrador detrás.
+- `loggeable_type` y `loggeable_id`: el objeto afectado por la acción, por ejemplo `loggeable_type=Content::Entry`.
+- `application`: con el valor `core` acota a los objetos del núcleo de la plataforma, como sitios, espacios, entradas, roles, formularios y webhooks.
+- `query`: texto libre. Busca por prefijo en el título del registro y en el nombre y el correo de su autor.
+- `admin_actions`: con `true` deja fuera la actividad de los usuarios finales.
+- `sort_by` y `order`: orden del listado.
+- `page` y `per_page`: paginación, tal como se describe en [Paginación](/es/platform/core/api.html#paginacion).
+
+:::warning Atención
+`user_type` y `user_id` no filtran nada. Todavía aparecen entre los parámetros del recurso en `/api/admin/docs`, pero el listado los ignora: una llamada con `user_type=User` o con `user_type=AdminUser` devuelve el mismo resultado que la llamada sin parámetros. Si los usas para separar la actividad de los administradores de la de los usuarios finales, en realidad estás recibiendo el listado completo.
+:::
+
+### Separar la actividad de administración
+
+`admin_actions=true` es el filtro que sí distingue ambas actividades: excluye los registros de tipo `email_delivered_log`, `email_opened_log`, `email_spam_report_log`, `form_response_created_log`, `notification_opened_log` y `user_login_log`.
+
+```shell script
+curl -X GET "https://test.modyo.com/api/admin/logs?admin_actions=true" -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+Si el usuario del token no es el dueño de la cuenta ni tiene un rol a nivel de cuenta, `admin_actions=true` limita además la respuesta a los sitios donde tenga un rol asignado, e ignora el `site_id` que hayas enviado.
+
+No existe el filtro inverso. Para quedarte solo con la actividad de los usuarios finales, enumera los tipos que te interesan en `types`:
+
+```shell script
+curl -X GET "https://test.modyo.com/api/admin/logs?types=user_login_log,%20form_response_created_log" -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+### Orden de los resultados
+
+`sort_by` acepta `created_at`, `type` y `loggeable_type`, y `order` acepta `asc` y `desc`. De manera predeterminada el listado llega ordenado por `created_at` en `desc`, del registro más nuevo al más antiguo.
+
+:::tip Tip
+El catálogo Swagger publica `sort_by` con el valor de ejemplo `COMPLETAR`, que no es un valor válido. Usa `created_at`, `type` o `loggeable_type`.
+:::
+
+### Detalle y tipos de registro
+
+- `GET /api/admin/logs/{id}` devuelve un registro puntual.
+- `GET /api/admin/logs/types` devuelve los tipos de registro que existen en la cuenta y cuántos registros hay de cada uno. Es la forma de conocer los valores válidos de `type`, `types` y `not_in_type`.
+
+Ambas llamadas se rigen por el permiso agrupado **Ver Logs de Actividad**. El listado `GET /api/admin/logs` no exige un permiso puntual: lo que cambia según el usuario es el alcance de la respuesta.
+
+## Perfil del usuario autenticado
+
+El recurso `/api/admin/profile` trabaja siempre sobre el usuario dueño del token, sin recibir identificadores, y no exige permisos: basta con estar autenticado. Es el recurso que reemplaza a `GET /api/admin/admin_users/me`, que ya no existe.
+
+El catálogo Swagger de `/api/admin/docs` todavía no lista este recurso, por lo que sus llamadas son las siguientes:
+
+```http request
+GET    /api/admin/profile                              Perfil del usuario autenticado
+PUT    /api/admin/profile                              Actualiza nombre, apellido, idioma y avatar
+PUT    /api/admin/profile/update_protected_attributes  Actualiza nombre de usuario y correo
+DELETE /api/admin/profile/remove_otp                   Elimina el segundo factor
+GET    /api/admin/profile/sessions                     Lista las sesiones activas
+DELETE /api/admin/profile/revoke_session               Revoca sesiones activas
+```
+
+### Consultar y actualizar el perfil
+
+`GET /api/admin/profile` devuelve los datos del usuario del token: `id`, `uuid`, `name`, `first_name`, `last_name`, `email`, `username`, `avatar`, `lang`, `time_zone`, `active`, `created_at`, `updated_at`, `last_login_at`, `last_login_ip`, los roles asignados (`roles`) y las aplicaciones a las que tiene acceso (`application_access`).
+
+```shell script
+curl -X GET https://test.modyo.com/api/admin/profile -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+`PUT /api/admin/profile` actualiza solo `first_name`, `last_name`, `lang` y `avatar_id`. `lang` acepta `en`, `es` y `pt`, y `avatar_id` es el identificador de un avatar creado con `/api/admin/profile_avatar`.
+
+```shell script
+curl -X PUT https://test.modyo.com/api/admin/profile -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56' -H 'Content-Type: application/json' -d '{"first_name":"Sam","last_name":"Johnson","lang":"es"}'
+```
+
+:::tip Tip
+Si incluyes `username` o `email` en esta llamada, la plataforma los descarta y responde `HTTP 200 OK` con esos campos sin cambios. Para modificarlos usa la llamada de atributos protegidos.
+:::
+
+### Cambiar el nombre de usuario o el correo
+
+`username` y `email` son atributos protegidos: se actualizan solo con `PUT /api/admin/profile/update_protected_attributes`, y la llamada debe incluir `current_password` con la contraseña actual del usuario.
+
+```shell script
+curl -X PUT https://test.modyo.com/api/admin/profile/update_protected_attributes -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56' -H 'Content-Type: application/json' -d '{"email":"sam.johnson@modyo.com","current_password":"tu-contrasena-actual"}'
+```
+
+Ten en cuenta que:
+
+- El cambio de `username` se aplica de inmediato y responde `HTTP 200 OK`.
+- El cambio de `email` no se aplica de inmediato: la plataforma envía un correo de confirmación a la nueva dirección y la mantiene pendiente hasta que el usuario la confirma.
+- Si `current_password` es incorrecta o viene vacía, la respuesta es `HTTP 422 Unprocessable Entity` y nada se actualiza.
+
+:::danger Peligro
+Los intentos fallidos con contraseña incorrecta se acumulan. Al alcanzar el límite configurado para tu cuenta, la plataforma revoca todas las sesiones activas del usuario, así que quien esté trabajando en el panel de administración queda con la sesión cerrada. Controla el `HTTP 422` en tu integración y no reintentes en bucle.
+:::
+
+### Segundo factor
+
+`DELETE /api/admin/profile/remove_otp` elimina la configuración de segundo factor del usuario autenticado y responde `HTTP 200 OK`, incluso si el usuario no tenía segundo factor configurado.
+
+:::warning Atención
+Esta llamada no pide la contraseña actual, así que cualquier token válido del usuario alcanza para desactivar su segundo factor. Trata los tokens de la API de administración con el mismo cuidado que una contraseña.
+:::
+
+### Sesiones activas
+
+`GET /api/admin/profile/sessions` lista las sesiones vigentes del usuario, de la más reciente a la más antigua. Cada sesión trae su `uuid`, la fecha en que se abrió (`created_at`), la IP desde donde se abrió (`request_ip`), el navegador (`device_name`), el sistema operativo (`device_os`), el tipo de dispositivo (`device_type`, con valor `Desktop` o `Mobile`) y, cuando corresponde, el nombre del administrador que la abrió por impersonación (`impersonator`).
+
+`DELETE /api/admin/profile/revoke_session` revoca sesiones: con `grant_uuid` revocas una sesión puntual y con `all=true` revocas todas las sesiones activas. La respuesta es `HTTP 204 No Content`, y `HTTP 404 Not Found` si la sesión ya estaba revocada.
+
+```shell script
+curl -X DELETE "https://test.modyo.com/api/admin/profile/revoke_session?all=true" -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+:::tip Tip
+La sesión asociada a la llamada queda fuera de la revocación, incluso si envías su propio `grant_uuid`: la respuesta es `HTTP 204 No Content` y la sesión sigue activa.
+:::
 
 Para conocer más acerca de cómo hacer consultas a la información de Content vía API, ve nuestra guía y ejemplos en [API](/es/platform/content/public-api-reference).


### PR DESCRIPTION
## Cambios propuestos

Reescribe la documentación de los registros de actividad de la API de administración para que coincida con lo que hace el código en 10.2, y documenta el recurso `/api/admin/profile`, que hoy no aparece ni en la guía ni en el catálogo Swagger. Cierra los gaps API-ADMIN-03, API-ADMIN-04 y API-ADMIN-02.

### docs/es/platform/core/api.md

Sección **Registros (Logs)**:

- La introducción ya no ofrece "elegir entre logs de Usuarios o Administradores". Ahora explica qué guarda cada registro (tipo, administrador que ejecutó la acción, objeto afectado y contexto) y que la actividad de los usuarios finales llega con tipos propios como `user_login_log`.
- El ejemplo cURL queda sin `user_type` y sin la comilla doble suelta que arrastraba, y el texto que lo sigue ya no afirma que la consulta trae "todos los registros".
- Nueva sección **Qué registros ves** con la regla de alcance real: el dueño de la cuenta y el rol **Full admin** ven todo; cualquier otro administrador recibe solo sus propios registros salvo que acote con `realm_id`, `site_id` o `space_id` sobre un contexto donde tenga rol. Incluye un callout de atención por el cambio de 10.2, porque hasta 10.1 el rol **Default admin** también veía todo y ahora deja de verlo sin ningún error de por medio (API-ADMIN-04).
- Nueva sección **Filtros de la consulta** con los parámetros que el listado sí lee (`type`, `types`, `not_in_type`, `from_date`, `to_date`, `date_range`, `realm_id`, `site_id`, `space_id`, `user_uuid`, `loggeable_type`, `loggeable_id`, `application`, `query`, `admin_actions`, `sort_by`, `order`, `page` y `per_page`), más un callout que deja explícito que `user_type` y `user_id` no filtran nada aunque el Swagger los siga publicando (API-ADMIN-03).
- Nueva sección **Separar la actividad de administración**, con `admin_actions=true`, los seis tipos de registro que excluye, su efecto sobre los usuarios sin rol de cuenta y el reemplazo para el caso inverso (enumerar tipos en `types`).
- Nueva sección **Orden de los resultados** con los valores válidos de `sort_by` (`created_at`, `type`, `loggeable_type`), el orden por omisión y un tip que avisa que el catálogo Swagger publica el enum `COMPLETAR`, que no es un valor válido (API-ADMIN-03).
- Nueva sección **Detalle y tipos de registro** con `GET /api/admin/logs/{id}` y `GET /api/admin/logs/types`, y el permiso agrupado **Ver Logs de Actividad** que las rige.

Nueva sección **Perfil del usuario autenticado** (API-ADMIN-02):

- Presenta el recurso como el reemplazo de `GET /api/admin/admin_users/me`, que ya no existe, y lista sus cinco llamadas, que el catálogo Swagger todavía no publica.
- Documenta la lectura y actualización del perfil, con los campos de la respuesta y los únicos atributos que `PUT /api/admin/profile` modifica.
- Documenta el cambio de `username` y `email` con `current_password`, que el correo nuevo queda pendiente de confirmación, y un callout de peligro porque al superar el límite de intentos fallidos se revocan todas las sesiones activas del usuario.
- Documenta la eliminación del segundo factor, el listado de sesiones activas y su revocación, con los códigos de respuesta y el hecho de que la sesión asociada a la llamada nunca se revoca.

### docs/en/platform/core/api.md

Espejo en inglés de todo lo anterior, con los mismos anclajes y los labels en su versión del panel en inglés: **View Activity Logs**, **Manage Customers**, **Manage Channels**, **Manage Content**, **Full admin** y **Default admin**.

## Para el revisor

1. La ficha de API-ADMIN-04 dice que el afectado es "un Full admin que no sea owner de la cuenta". Eso es al revés: `is_owner?` (app/models/admin_user.rb:231) es verdadero para el usuario dueño, para el rol `account_owner` en la cuenta y para quien pertenezca a un grupo con ese rol, y `account_owner` es justamente el rol que el panel llama **Full admin** (config/roles/account_owner.yml:1-2). Lo que se eliminó en 10.2 fue `is_admin?`, es decir el rol `account_admin`, que el panel llama **Default admin** (config/roles/account_admin.yml:1-2). Documenté lo que hace el código: pierden el alcance total los **Default admin**, no los **Full admin**. Es el punto que el revisor debe mirar con más cuidado.

2. Esta tanda solo toca modyo-docs. Los dos parámetros fantasma siguen publicados en `/api/admin/docs` (app/controllers/docs/api/admin/logs.rb:51 y :65), igual que el enum `%w[COMPLETAR]` de `sort_by` (:109-113), y `Api::Admin::ProfileController` sigue fuera de `SWAGGERED_CLASSES` (app/controllers/api/admin/docs_controller.rb:56-132). La documentación advierte del desajuste con callouts, pero el arreglo durable es un PR en la plataforma; mientras no exista, los callouts que dicen "todavía aparecen" y "todavía no lista" son la única señal para el integrador.

3. `docs/es/platform/release-notes.md` no tiene sección 10.2, así que el cambio de comportamiento de `/logs` quedó como callout dentro de api.md en lugar de nota de versión, y la tanda solo autorizaba api.md.

4. `docs/es/platform/core/integrations/connect-modyo-salesforce.md:273` y su espejo en inglés siguen apuntando a `/api/admin/admin_users/me`, que ya no existe. Es material de la tanda 1 y no lo toqué; si esa tanda no lo corrige, queda una referencia muerta a un endpoint que esta página declara eliminado.

5. El límite de intentos fallidos de `update_protected_attributes` y el tiempo de bloqueo son configurables por operaciones, así que el texto dice "el límite configurado para tu cuenta" sin cifras, y el efecto se describe como cierre de sesión en el panel: un token de la API sigue funcionando después de la revocación porque la validación de session grants se omite para credenciales de tipo token.

6. `revoke_session` con `all=true` excluye la sesión asociada a la llamada; cuando el token no tiene un session grant asociado no hay ninguna que excluir. Por eso el tip habla de "la sesión asociada a la llamada" y no de "tu sesión". Tampoco documenté el comportamiento de un `grant_uuid` inexistente, porque el código no lo trata de forma explícita y no quise afirmar un código de respuesta que no pude verificar.

7. Los diez `old_string` se verificaron con conteo exacto contra los archivos de master: cada uno aparece una sola vez y ninguno contiene espacios al final de línea. Ojo con la primera edición en español: el anclaje termina en `usa:` porque la línea del archivo tiene dos espacios finales, que quedan intactos tras el reemplazo (van seguidos de una línea vacía, así que no cambian el render).

Closes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)
