### PR TITLE
Documenta los tres tipos de página, corrige las propiedades de la página de widget y elimina los widgets retirados

### DIFF
--- a/docs/en/platform/channels/liquid-markup/objects.md
+++ b/docs/en/platform/channels/liquid-markup/objects.md
@@ -697,31 +697,21 @@ Does not apply to public sites, as in these cases server responses are served fr
 
 ## widget
 
-These objects obtain relevant information about Widgets.
+These objects obtain relevant information about Widgets. The current subtypes are `custom_widget`, `rich_text_widget`, and `text_widget`.
 
 | Object                       | Description                                              | Example                                                     |
 |------------------------------|----------------------------------------------------------|-------------------------------------------------------------|
-| **widget.cache_key**         | The cache key associated with the widget.                | ```widgets/content_list_widgets/506-20220215151403000000``` |
+| **widget.cache_key**         | The cache key associated with the widget.                | ```widgets/rich_text_widgets/506-20220215151403000000```    |
 | **widget.created_at**        | The date the widget was created.                         | ```Tue, 15 Feb 2022 15:14:03 UTC +00:00```                  |
 | **widget.id**                | The ID associated with the respective widget.            | ```506```                                                   |
-| **widget.resolve_type**      | The type of the widget with underscore.                  | ```content_list_widget```                                   |
-| **widget.title**             | The widget title.                                        | ```Content list```                                          |
-| **widget.css_class**         | The CSS class associated with the widget.                | ```content-list-widget```                                   |
-| **widget.name**              | The widget name.                                         | ```Content list```                                          |
-| **widget.type**              | The widget type.                                         | ```content-list```                                          |
+| **widget.resolve_type**      | The type of the widget with underscore.                  | ```rich_text_widget```                                      |
+| **widget.title**             | The widget title.                                        | ```Welcome```                                               |
+| **widget.css_class**         | The CSS class associated with the widget.                | ```rich-text-widget```                                      |
+| **widget.name**              | The widget name.                                         | ```Welcome```                                               |
+| **widget.type**              | The widget type.                                         | ```rich-text```                                             |
 | **widget.use_default_title** | Boolean indicating if the widget uses the default title. | ```false```                                                 |
 | **widget.wid**               | The widget's wid.                                        | ```63ae60e2-d152-4c70-a5b0-ffa9916162e3```                  |
 | **widget.width**             | The width configured in the widget.                      | ```full```                                                  |
-
-### content_list_widget
-
-| Object                                 | Description                                             | Example                                                                                          |
-|----------------------------------------|---------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| **content_list_widget.context_params** | The context parameters associated with the widget.      | ```{:page=>1, :per_page=>10, :account=>#account_object, :user=>nil, :version_type=>:currents}``` |
-| **content_list_widget.entries**        | Array of Entry type objects associated with the widget. |                                                                                                  |
-| **content_list_widget.show_caption**   | Boolean if the show caption option is active.           | ```true```                                                                                       |
-| **content_list_widget.space_id**       | The ID of the Space associated with the widget.         | ```5```                                                                                          |
-| **content_list_widget.type_uid**       | The UID of the type associated with the widget.         | ```the-new-type```                                                                               |
 
 ### custom_widget
 

--- a/docs/en/platform/channels/pages.md
+++ b/docs/en/platform/channels/pages.md
@@ -6,7 +6,7 @@ search: true
 
 Pages allow you to create a structure for your site, add unstructured content, and customize the routes where that content is displayed.
 
-You can create four types of pages: **Widget page**, **Content page**, **Origination page**, and **Support page**. You choose the type when you create the page and you cannot change it afterwards.
+You can create three types of pages: **Widget page**, **Content page**, and **Origination page**. You choose the type when you create the page and you cannot change it afterwards.
 
 Widget pages are based on a modular scheme that allows you to create your custom site using HTML, JS, and CSS. You can drag and drop different predefined or custom widgets created by your team.
 
@@ -14,7 +14,6 @@ Content pages connect the Content modules with Channels. Here you can create the
 
 Origination pages display an [Origination](/en/platform/customers/origination.html) flow to end users. You can only create them if your plan includes Origination and the site is connected to a [realm](/en/platform/customers/realms.html). Each origination can be linked to a single page, and the page is always private: its segment restriction is configured in the origination, not in the page.
 
-Support pages allow end users to create and manage support tickets. You can only create them if your plan includes Support, they allow a single support page per site, and they are always private and restricted to authenticated users.
 
 To edit a page, click on the edit icon or on the page name to go to the edit view.
 
@@ -56,17 +55,17 @@ To create a new page, follow these steps:
 2. Select the site you want to add a new page.
 3. Click **Pages**.
 4. Click **New Page**.
-5. In **Type**, select the type of page you want to create: **Widget page**, **Content page**, **Origination page**, or **Support page**.
+5. In **Type**, select the type of page you want to create: **Widget page**, **Content page**, or **Origination page**.
 6. Fill in the fields required by the chosen type:
    - **Content page**: select the **Space** and the content **Type** that the page will display.
    - **Origination page**: select the **Origination** you want to display. Only published originations from the site's realm that do not have an associated page yet are listed.
-   - **Widget page** and **Support page**: they do not require additional fields.
+   - **Widget page**: it does not require additional fields.
 7. Enter the **Name**, the **Path**, and if necessary, select the **Parent page**, then press **Create**.
-8. Customize the page according to the type: adding or editing widgets on the widget page, editing the **Index** and the **Show** on the content page, or editing the flow views on the origination and support pages.
+8. Customize the page according to the type: adding or editing widgets on the widget page, editing the **Index** and the **Show** on the content page, or editing the flow views on the origination page.
 9. Once finished, click **Publish**.
 
 :::warning Attention
-If your plan does not include Origination or Support, those types are not shown in the selector. If they are shown but you cannot select them, a prerequisite is missing: the origination page requires the site to be connected to a realm, and the support page requires the site not to have a support page already.
+If your plan does not include Origination, that type is not shown in the selector. If it is shown but you cannot select it, a prerequisite is missing: the origination page requires the site to be connected to a realm.
 :::
 
 To learn about the types of widgets you can add, see [Widget Page](/en/platform/channels/pages.html#widget-page).
@@ -147,7 +146,7 @@ Once a widget is selected in the central section, the focus will shift to the si
 
 ### Properties
 
-In this tab you will find the widget page controls, in the same order they appear in the panel. **Grid** and **Delegate child routes to this page** only exist here and on the home page: content, origination, and support pages do not have those controls.
+In this tab you will find the widget page controls, in the same order they appear in the panel. **Grid** and **Delegate child routes to this page** only exist here and on the home page: content and origination pages do not have those controls.
 
 - **Name**: The name of the page.
 - **Parent page**: The page under which this one is nested. You can only choose widget pages of the site that are published, scheduled, or unpublished.

--- a/docs/en/platform/channels/pages.md
+++ b/docs/en/platform/channels/pages.md
@@ -6,9 +6,15 @@ search: true
 
 Pages allow you to create a structure for your site, add unstructured content, and customize the routes where that content is displayed.
 
-You can create two types of pages: widget or content. Widget pages are based on a modular scheme that allows you to create your custom site using HTML, JS, and CSS. You can drag and drop different predefined or custom widgets created by your team.
+You can create four types of pages: **Widget page**, **Content page**, **Origination page**, and **Support page**. You choose the type when you create the page and you cannot change it afterwards.
+
+Widget pages are based on a modular scheme that allows you to create your custom site using HTML, JS, and CSS. You can drag and drop different predefined or custom widgets created by your team.
 
 Content pages connect the Content modules with Channels. Here you can create the index that contains the entries and the structure for all of them using HTML, JS, CSS, and Liquid.
+
+Origination pages display an [Origination](/en/platform/customers/origination.html) flow to end users. You can only create them if your plan includes Origination and the site is connected to a [realm](/en/platform/customers/realms.html). Each origination can be linked to a single page, and the page is always private: its segment restriction is configured in the origination, not in the page.
+
+Support pages allow end users to create and manage support tickets. You can only create them if your plan includes Support, they allow a single support page per site, and they are always private and restricted to authenticated users.
 
 To edit a page, click on the edit icon or on the page name to go to the edit view.
 
@@ -50,14 +56,24 @@ To create a new page, follow these steps:
 2. Select the site you want to add a new page.
 3. Click **Pages**.
 4. Click **New Page**.
-5. Select the type of page (**Widget** or **Content**) you want to create.
-6. Enter the Layout Name, Path, and if necessary, select the parent layout, then press **Create**.
-7. Customize the page according to the type: adding or editing widgets for Widget Page, or editing the Index and Show for Content Page.
-8. Once finished, click **Publish**.
+5. In **Type**, select the type of page you want to create: **Widget page**, **Content page**, **Origination page**, or **Support page**.
+6. Fill in the fields required by the chosen type:
+   - **Content page**: select the **Space** and the content **Type** that the page will display.
+   - **Origination page**: select the **Origination** you want to display. Only published originations from the site's realm that do not have an associated page yet are listed.
+   - **Widget page** and **Support page**: they do not require additional fields.
+7. Enter the **Name**, the **Path**, and if necessary, select the **Parent page**, then press **Create**.
+8. Customize the page according to the type: adding or editing widgets on the widget page, editing the **Index** and the **Show** on the content page, or editing the flow views on the origination and support pages.
+9. Once finished, click **Publish**.
 
-To learn about the types of widgets you can add, see [Widgets](/en/platform/channels/pages#widget-page).
+:::warning Attention
+If your plan does not include Origination or Support, those types are not shown in the selector. If they are shown but you cannot select them, a prerequisite is missing: the origination page requires the site to be connected to a realm, and the support page requires the site not to have a support page already.
+:::
 
-To learn more about content pages, see [Content Page](/en/platform/channels/pages#content-page).
+To learn about the types of widgets you can add, see [Widget Page](/en/platform/channels/pages.html#widget-page).
+
+To learn more about content pages, see [Content Page](/en/platform/channels/pages.html#content-page).
+
+To learn more about origination pages, see [Create an Origination Page](/en/platform/customers/origination.html#create-an-origination-page).
 
 **Main action**: It is the green button in the upper right that can take different forms:
 
@@ -79,9 +95,9 @@ The central grid is where you can position your widgets. You can move them using
 
 In the right sidebar, there are three tabs:
 
-- Add widgets: Allows you to select widgets from a list to add them to the grid.
-- Edit widget: Allows you to change properties and filters for each widget.
-- Properties: Allows you to modify the name, excerpt, path, parent, privacy, page grid, and meta tags.
+- **Add**: Allows you to select widgets from a list to add them to the grid.
+- **Edit**: Allows you to change the configuration options of the selected widget.
+- **Properties**: Allows you to modify the page's name, parent page, layout, path, excerpt, route delegation, grid, privacy, and custom meta tags.
 
 
 ### Inserting an image with Liquid
@@ -113,31 +129,35 @@ It is necessary that your account's CDN is in the cloud for changes to be reflec
 
 ## Widget Page
 
-Here you can customize your page using preset widgets from the following list:
-
+In the sidebar's **Add** tab you will find two groups. Under **Blocks** are the preset widgets that Modyo ships:
 
 - **HTML**: Allows you to enter HTML and CSS code without validations. It will not allow you to enter Javascript code.
 - **Rich text**: Allows you to use a rich text editor, in which you can format text and switch between code view and rich text.
 :::warning Attention
 The rich text widget has an automatic formatter, so the code you write in the code view may be affected.
 :::
-- **Content list**: Displays content lists using filters by space, type, language, tags, and category. To modify how these widgets look, you must do so in the Widgets section in [Templates](/en/platform/channels/templates).
-- **Featured content**: Displays a list of entries as "hero" images in a carousel.
-- **Custom**: You will find a list of all the widgets you have created and published in the widget builder.
+
+Under **Widgets** are your custom widgets, that is, the ones you created and published in the [widget builder](/en/platform/channels/widgets.html). There you have a shortcut to five of them, and with **View all widgets** you open the site's complete list.
+
+:::tip Tip
+The **Content list** and **Featured content** widgets no longer exist in the product. To display entry lists and their detail, use a [Content Page](/en/platform/channels/pages.html#content-page), and to build carousels or custom highlights, create a [custom widget](/en/platform/channels/widgets.html).
+:::
 
 Once a widget is selected in the central section, the focus will shift to the side tab, where you can find different configuration options for the widget. If you select a custom widget, you will find a link to go directly to its editing view in [widget builder](/en/platform/channels/widgets) and the list of variables the widget is using. If you want to overwrite the value of a particular variable for that instance of the widget on that page, you must select the checkbox to the left of the variable and change the value it takes.
 
 ### Properties
 
-In this tab you will find common properties options for all pages:
+In this tab you will find the widget page controls, in the same order they appear in the panel. **Grid** and **Delegate child routes to this page** only exist here and on the home page: content, origination, and support pages do not have those controls.
 
-- Name
-- Parent
-- Path
-- Excerpt
-- Grid
-- Privacy
-- Custom meta tags
+- **Name**: The name of the page.
+- **Parent page**: The page under which this one is nested. You can only choose widget pages of the site that are published, scheduled, or unpublished.
+- **Layout**: The site's published layout template that wraps the page. You manage them in [Templates](/en/platform/channels/templates.html).
+- **Path**: The relative path of the page, for example `my-awesome-page`.
+- **Excerpt**: A summary of up to 255 characters that is used in the page's meta tags.
+- **Delegate child routes to this page**: See [Route delegation](/en/platform/channels/pages.html#route-delegation).
+- **Grid**: See [Grids](/en/platform/channels/pages.html#grids).
+- **Privacy**: See [Privacy](/en/platform/channels/pages.html#privacy).
+- **Custom meta tags**: See [Meta tags](/en/platform/channels/pages.html#meta-tags).
 
 :::warning Attention
 Modyo has reserved paths for pages, so you cannot use them as paths for your custom pages:
@@ -177,6 +197,32 @@ Modyo has reserved paths for pages, so you cannot use them as paths for your cus
 <li>widget_manager</li>
 </ul></td>
 </tr></table>
+:::
+
+### Grids
+
+The grid defines the zones of the page where you can drop widgets. When you change the grid, widgets are rearranged into the zones of the new grid. In the selector you choose among nine grids, identified by the same value that `grid.resolve_type` returns in Liquid:
+
+| Grid                         | Zones                                             |
+|------------------------------|---------------------------------------------------|
+| `full_grid`                  | A single full-width main zone.                    |
+| `full_two_cols_grid`         | Full-width main zone plus two columns.            |
+| `full_three_cols_grid`       | Full-width main zone plus three columns.          |
+| `side_left_grid`             | Main zone plus a left sidebar.                    |
+| `side_right_grid`            | Main zone plus a right sidebar.                   |
+| `side_left_one_col_grid`     | Main zone, left sidebar, and a full-width zone.   |
+| `side_right_one_col_grid`    | Main zone, right sidebar, and a full-width zone.  |
+| `side_left_three_cols_grid`  | Main zone, left sidebar, and three columns.       |
+| `side_right_three_cols_grid` | Main zone, right sidebar, and three columns.      |
+
+To iterate over the widgets of each zone from your templates, see the [grid](/en/platform/channels/liquid-markup/objects.html#grid) objects.
+
+### Route delegation
+
+When you enable **Delegate child routes to this page**, Modyo serves this same page for any sub-route that does not match another page of the site, and your JavaScript router takes absolute control of those sub-routes.
+
+:::tip Tip
+On content pages you do not need to delegate routes: the **Index** resolves the list route and the **Show** resolves the sub-route of each entry.
 :::
 
 ## Content Page
@@ -257,10 +303,6 @@ The excerpt is added as part of the meta tags to improve SEO. This is possible f
 ```html
 <meta name="description" content="{{ page.excerpt }}"/>
 ```
-
-#### Route delegation
-
-Enables route delegation to allow absolute control over the page's sub-routes through the JavaScript router.
 
 ## Privacy
 

--- a/docs/es/platform/channels/liquid-markup/objects.md
+++ b/docs/es/platform/channels/liquid-markup/objects.md
@@ -713,31 +713,21 @@ No aplica para sitios públicos, ya que en estos casos las respuestas del servid
 
 ## widget
 
-Estos objetos obtienen la información relevante a los Widgets.
+Estos objetos obtienen la información relevante a los Widgets. Los subtipos vigentes son `custom_widget`, `rich_text_widget` y `text_widget`.
 
 | Objeto                       | Descripción                                                | Ejemplo                                                     |
 |------------------------------|------------------------------------------------------------|-------------------------------------------------------------|
-| **widget.cache_key**         | La key del cache asociada al widget.                       | ```widgets/content_list_widgets/506-20220215151403000000``` |
+| **widget.cache_key**         | La key del cache asociada al widget.                       | ```widgets/rich_text_widgets/506-20220215151403000000```    |
 | **widget.created_at**        | La fecha de creación del widget.                           | ```Tue, 15 Feb 2022 15:14:03 UTC +00:00```                  |
 | **widget.id**                | El ID asociado al widget respectivo.                       | ```506```                                                   |
-| **widget.resolve_type**      | El tipo del widget con underscore.                         | ```content_list_widget```                                   |
-| **widget.title**             | El título del widget.                                      | ```Content list```                                          |
-| **widget.css_class**         | La clase de css asociado al widget.                        | ```content-list-widget```                                   |
-| **widget.name**              | El nombre del widget.                                      | ```Content list```                                          |
-| **widget.type**              | El tipo del widget.                                        | ```content-list```                                          |
+| **widget.resolve_type**      | El tipo del widget con underscore.                         | ```rich_text_widget```                                      |
+| **widget.title**             | El título del widget.                                      | ```Bienvenida```                                            |
+| **widget.css_class**         | La clase de css asociado al widget.                        | ```rich-text-widget```                                      |
+| **widget.name**              | El nombre del widget.                                      | ```Bienvenida```                                            |
+| **widget.type**              | El tipo del widget.                                        | ```rich-text```                                             |
 | **widget.use_default_title** | Booleano indicando si el widget usa el titulo por defecto. | ```false```                                                 |
 | **widget.wid**               | El wid del widget.                                         | ```63ae60e2-d152-4c70-a5b0-ffa9916162e3```                  |
 | **widget.width**             | El ancho configurado en el widget.                         | ```full```                                                  |
-
-### content_list_widget
-
-| Objeto                                 | Descripción                                             | Ejemplo                                                                                          |
-|----------------------------------------|---------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| **content_list_widget.context_params** | Los parametros de contexto asociado al widget.          | ```{:page=>1, :per_page=>10, :account=>#account_object, :user=>nil, :version_type=>:currents}``` |
-| **content_list_widget.entries**        | Arreglo de Objetos de tipo Entries asociadas al widget. |                                                                                                  |
-| **content_list_widget.show_caption**   | Booleano si la opción de show caption está activa.      | ```true```                                                                                       |
-| **content_list_widget.space_id**       | El id del Espacio asociado al widget.                   | ```5```                                                                                          |
-| **content_list_widget.type_uid**       | El uid del type asociado al widget.                     | ```the-new-type```                                                                               |
 
 ### custom_widget
 

--- a/docs/es/platform/channels/pages.md
+++ b/docs/es/platform/channels/pages.md
@@ -6,9 +6,15 @@ search: true
 
 Las Páginas (o pages) permiten crear una estructura para tu sitio, añadir contenido no estructurado y personalizar las rutas donde se muestra ese contenido.
 
-Puedes crear dos tipos de páginas: de widgets o de contenido. Las páginas de widgets se basan en un esquema modular que permite crear tu sitio a medida usando HTML, JS y CSS. Podrás arrastrar y acomodar diferentes widgets predefinidos o personalizados creados por tu equipo.
+Puedes crear cuatro tipos de páginas: **Página de Widget**, **Página de contenido**, **Página de originación** y **Página de soporte**. Eliges el tipo al crear la página y no puedes cambiarlo después.
+
+Las páginas de widget se basan en un esquema modular que permite crear tu sitio a medida usando HTML, JS y CSS. Podrás arrastrar y acomodar diferentes widgets predefinidos o personalizados creados por tu equipo.
 
 Las páginas de contenido conectan los módulos de Content con Channels. Aquí podrás crear el índice que contiene las entradas y la estructura para todas ellas usando HTML, JS, CSS y Liquid.
+
+Las páginas de originación despliegan un flujo de [Originación](/es/platform/customers/origination.html) a los usuarios finales. Solo puedes crearlas si tu plan incluye Originación y el sitio está conectado a un [reino](/es/platform/customers/realms.html). Cada originación se puede vincular a una sola página, y la página siempre es privada: su restricción por segmentos se configura en la originación, no en la página.
+
+Las páginas de soporte permiten a los usuarios finales crear y gestionar tickets de soporte. Solo puedes crearlas si tu plan incluye Soporte, admiten una sola página de soporte por sitio y son siempre privadas y restringidas a usuarios autenticados.
 
 Para editar una página, haz clic en el icono de edición o en el nombre de la página para ir a la vista de edición.
 
@@ -50,14 +56,24 @@ Para crear una nueva página, sigue estos pasos:
 2. Selecciona el sitio al que desees agregar una nueva página.
 3. Haz clic en **Pages**.
 4. Haz clic en **Nueva Página**.
-5. Selecciona el tipo de página (**Widget** o **Content**) que quieres crear.
-6. Ingresa el Nombre del Layout, la Ruta y, si es necesario, selecciona el layout padre, luego presiona **Crear**.
-7. Personaliza la página según el tipo: agregando o editando widgets para Página de Widget, o editando el Index y Show para Página de Contenido.
-8. Una vez terminado, haz clic en **Publicar**.
+5. En **Tipo**, selecciona el tipo de página que quieres crear: **Página de Widget**, **Página de contenido**, **Página de originación** o **Página de soporte**.
+6. Completa los campos que pide el tipo elegido:
+   - **Página de contenido**: selecciona el **Espacio** y el **Tipo** de contenido que va a desplegar la página.
+   - **Página de originación**: selecciona la **Originación** que quieres desplegar. Solo aparecen las originaciones publicadas del reino del sitio que todavía no tienen una página asociada.
+   - **Página de Widget** y **Página de soporte**: no piden campos adicionales.
+7. Ingresa el **Nombre**, la **Ruta** y, si es necesario, selecciona la **Página padre**, luego presiona **Crear**.
+8. Personaliza la página según el tipo: agregando o editando widgets en la página de widget, editando el **Index** y el **Show** en la página de contenido, o editando las vistas del flujo en las páginas de originación y de soporte.
+9. Una vez terminado, haz clic en **Publicar**.
 
-Para conocer los tipos de widgets que puedes agregar, consulta [Widgets](/es/platform/channels/pages#pagina-de-widget).
+:::warning Atención
+Si tu plan no incluye Originación o Soporte, esos tipos no aparecen en el selector. Si aparecen pero no puedes seleccionarlos, falta una precondición: la página de originación necesita que el sitio esté conectado a un reino, y la página de soporte necesita que el sitio no tenga ya una página de soporte.
+:::
 
-Para conocer más acerca de páginas de contenido, consulta [Página de Contenido](/es/platform/channels/pages#pagina-de-contenido).
+Para conocer los tipos de widgets que puedes agregar, consulta [Página de Widget](/es/platform/channels/pages.html#pagina-de-widget).
+
+Para conocer más acerca de páginas de contenido, consulta [Página de Contenido](/es/platform/channels/pages.html#pagina-de-contenido).
+
+Para conocer más acerca de páginas de originación, consulta [Crear una Página de Originación](/es/platform/customers/origination.html#crear-una-pagina-de-originacion).
 
 **Acción principal**: Es el botón verde en la parte superior derecha que puede tomar distintas formas:
 
@@ -79,9 +95,9 @@ La grilla central es donde puedes posicionar tus widgets. Puedes moverlos utiliz
 
 En la sección lateral derecha, hay tres pestañas:
 
-- Añadir widgets: Permite seleccionar widgets de un listado para añadirlos a la grilla.
-- Editar widget: Permite cambiar propiedades y filtros para cada widget.
-- Propiedades: Permite modificar el nombre, excerpt, ruta, padre, privacidad, grilla de la página y meta tags.
+- **Añadir**: Permite seleccionar widgets de un listado para añadirlos a la grilla.
+- **Editar**: Permite cambiar las opciones de configuración del widget seleccionado.
+- **Propiedades**: Permite modificar el nombre, la página padre, el layout, la ruta, el extracto, la delegación de rutas, la grilla, la privacidad y los meta tags personalizados de la página.
 
 
 ### Insertar una imagen con Liquid
@@ -113,31 +129,35 @@ Es necesario que el CDN de tu cuenta esté en la nube para que los cambios se re
 
 ## Página de Widget
 
-Aquí puedes personalizar tu página usando widgets preestablecidos de la siguiente lista:
-
+En la pestaña **Añadir** de la barra lateral encuentras dos grupos. Bajo **Bloques** están los widgets preestablecidos que trae Modyo:
 
 - **HTML**: Te permite ingresar código HTML y CSS sin validaciones. No te permitirá ingresar código Javascript.
 - **Texto enriquecido**: Te permitirá hacer uso de un editor de texto enriquecido, en el que puedes darle formato al texto y cambiar entre la vista de código y texto enriquecido.
 :::warning Atención
 El widget de texto enriquecido cuenta con un formateador automático, por lo que el código que escribas en la vista de código puede verse afectado.
 :::
-- **Listado de contenido**: Muestra listados de contenido haciendo uso de filtros por espacio, tipo, idioma, tags, y categoría. Para modificar como se ven estos widgets, debes hacerlo en la sección de Widgets en [Templates](/es/platform/channels/templates).
-- **Contenido destacado**: Muestra un listado de entradas como imágenes "hero" en un carrusel.
-- **Personalizado**: Encontrarás un listado de todos los widgets que has creado y publicado en el widget builder.
+
+Bajo **Widgets** están tus widgets personalizados, es decir, los que creaste y publicaste en el [widget builder](/es/platform/channels/widgets.html). Ahí tienes un acceso directo a cinco de ellos y con **Ver todos los widgets** abres el listado completo del sitio.
+
+:::tip Tip
+Los widgets **Listado de contenido** y **Contenido destacado** ya no existen en el producto. Para desplegar listados de entradas y su detalle usa una [Página de Contenido](/es/platform/channels/pages.html#pagina-de-contenido), y para carruseles o destacados a medida crea un [widget personalizado](/es/platform/channels/widgets.html).
+:::
 
 Una vez seleccionado un widget en la sección central, el foco pasará a la pestaña lateral, donde podrás encontrar distintas opciones de configuración del widget y en caso de seleccionar un widget personalizado, encontrarás un link para ir directamente a su vista de edición en [widget builder](/es/platform/channels/widgets) y el listado de variables que el widget está usando. Si quieres sobrescribir el valor de una variable en particular para esa instancia del widget en esa página, debes seleccionar el checkbox a la izquierda de la variable y cambiar el valor que toma.
 
 ### Propiedades
 
-En esta pestaña encontrarás opciones propiedades comunes de todas las páginas:
+En esta pestaña encontrarás los controles de la página de widget, en el mismo orden en que aparecen en el panel. **Grilla** y **Delegar rutas hijas a esta página** solo existen aquí y en la página home: las páginas de contenido, de originación y de soporte no tienen esos controles.
 
-- Nombre
-- Padre
-- Ruta
-- Extracto
-- Grilla
-- Privacidad
-- Meta tags personalizados
+- **Nombre**: El nombre de la página.
+- **Página padre**: La página bajo la cual se anida esta. Solo puedes elegir páginas de widget del sitio que estén publicadas, programadas o despublicadas.
+- **Layout**: La plantilla de layout publicada del sitio que envuelve la página. Las administras en [Plantillas](/es/platform/channels/templates.html).
+- **Ruta**: El path relativo de la página, por ejemplo `mi-increible-pagina`.
+- **Extracto**: Un resumen de hasta 255 caracteres que se usa en los meta tags de la página.
+- **Delegar rutas hijas a esta página**: Revisa [Delegación de rutas](/es/platform/channels/pages.html#delegacion-de-rutas).
+- **Grilla**: Revisa [Grillas](/es/platform/channels/pages.html#grillas).
+- **Privacidad**: Revisa [Privacidad](/es/platform/channels/pages.html#privacidad).
+- **Meta tags personalizados**: Revisa [Meta tags](/es/platform/channels/pages.html#meta-tags).
 
 :::warning Atención
 Modyo cuenta con rutas reservadas para las página, por lo que no podrás usarlos como rutas de tus páginas personalizadas:
@@ -177,6 +197,32 @@ Modyo cuenta con rutas reservadas para las página, por lo que no podrás usarlo
 <li>widget_manager</li>
 </ul></td>
 </tr></table>
+:::
+
+### Grillas
+
+La grilla define las zonas de la página en las que puedes soltar widgets. Al cambiar de grilla, los widgets se reacomodan en las zonas de la grilla nueva. En el selector eliges entre nueve grillas, identificadas por el mismo valor que devuelve `grid.resolve_type` en Liquid:
+
+| Grilla                       | Zonas                                                                   |
+|------------------------------|-------------------------------------------------------------------------|
+| `full_grid`                  | Una zona principal a todo el ancho.                                     |
+| `full_two_cols_grid`         | Zona principal a todo el ancho más dos columnas.                        |
+| `full_three_cols_grid`       | Zona principal a todo el ancho más tres columnas.                       |
+| `side_left_grid`             | Zona principal más una barra lateral a la izquierda.                    |
+| `side_right_grid`            | Zona principal más una barra lateral a la derecha.                      |
+| `side_left_one_col_grid`     | Zona principal, barra lateral a la izquierda y una zona a todo el ancho.|
+| `side_right_one_col_grid`    | Zona principal, barra lateral a la derecha y una zona a todo el ancho.  |
+| `side_left_three_cols_grid`  | Zona principal, barra lateral a la izquierda y tres columnas.           |
+| `side_right_three_cols_grid` | Zona principal, barra lateral a la derecha y tres columnas.             |
+
+Para recorrer los widgets de cada zona desde tus plantillas, revisa los objetos de [grilla](/es/platform/channels/liquid-markup/objects.html#grid).
+
+### Delegación de rutas
+
+Al activar **Delegar rutas hijas a esta página**, Modyo entrega esta misma página para cualquier sub-ruta que no corresponda a otra página del sitio, y tu router de JavaScript toma el control absoluto de esas sub-rutas.
+
+:::tip Tip
+En las páginas de contenido no necesitas delegar rutas: el **Index** resuelve la ruta del listado y el **Show** resuelve la sub-ruta de cada entrada.
 :::
 
 ## Página de Contenido
@@ -257,10 +303,6 @@ El extracto se agrega como parte de los meta tags para mejorar el SEO. Esto es p
 ```html
 <meta name="description" content="{{ page.excerpt }}"/>
 ```
-
-#### Delegación de rutas
-
-Habilita la delegación de rutas para permitir el control absoluto de las sub-rutas de la página a través del router de JavaScript.
 
 ## Privacidad
 

--- a/docs/es/platform/channels/pages.md
+++ b/docs/es/platform/channels/pages.md
@@ -6,7 +6,7 @@ search: true
 
 Las Páginas (o pages) permiten crear una estructura para tu sitio, añadir contenido no estructurado y personalizar las rutas donde se muestra ese contenido.
 
-Puedes crear cuatro tipos de páginas: **Página de Widget**, **Página de contenido**, **Página de originación** y **Página de soporte**. Eliges el tipo al crear la página y no puedes cambiarlo después.
+Puedes crear tres tipos de páginas: **Página de Widget**, **Página de contenido** y **Página de originación**. Eliges el tipo al crear la página y no puedes cambiarlo después.
 
 Las páginas de widget se basan en un esquema modular que permite crear tu sitio a medida usando HTML, JS y CSS. Podrás arrastrar y acomodar diferentes widgets predefinidos o personalizados creados por tu equipo.
 
@@ -14,7 +14,6 @@ Las páginas de contenido conectan los módulos de Content con Channels. Aquí p
 
 Las páginas de originación despliegan un flujo de [Originación](/es/platform/customers/origination.html) a los usuarios finales. Solo puedes crearlas si tu plan incluye Originación y el sitio está conectado a un [reino](/es/platform/customers/realms.html). Cada originación se puede vincular a una sola página, y la página siempre es privada: su restricción por segmentos se configura en la originación, no en la página.
 
-Las páginas de soporte permiten a los usuarios finales crear y gestionar tickets de soporte. Solo puedes crearlas si tu plan incluye Soporte, admiten una sola página de soporte por sitio y son siempre privadas y restringidas a usuarios autenticados.
 
 Para editar una página, haz clic en el icono de edición o en el nombre de la página para ir a la vista de edición.
 
@@ -56,17 +55,17 @@ Para crear una nueva página, sigue estos pasos:
 2. Selecciona el sitio al que desees agregar una nueva página.
 3. Haz clic en **Pages**.
 4. Haz clic en **Nueva Página**.
-5. En **Tipo**, selecciona el tipo de página que quieres crear: **Página de Widget**, **Página de contenido**, **Página de originación** o **Página de soporte**.
+5. En **Tipo**, selecciona el tipo de página que quieres crear: **Página de Widget**, **Página de contenido** o **Página de originación**.
 6. Completa los campos que pide el tipo elegido:
    - **Página de contenido**: selecciona el **Espacio** y el **Tipo** de contenido que va a desplegar la página.
    - **Página de originación**: selecciona la **Originación** que quieres desplegar. Solo aparecen las originaciones publicadas del reino del sitio que todavía no tienen una página asociada.
-   - **Página de Widget** y **Página de soporte**: no piden campos adicionales.
+   - **Página de Widget**: no pide campos adicionales.
 7. Ingresa el **Nombre**, la **Ruta** y, si es necesario, selecciona la **Página padre**, luego presiona **Crear**.
-8. Personaliza la página según el tipo: agregando o editando widgets en la página de widget, editando el **Index** y el **Show** en la página de contenido, o editando las vistas del flujo en las páginas de originación y de soporte.
+8. Personaliza la página según el tipo: agregando o editando widgets en la página de widget, editando el **Index** y el **Show** en la página de contenido, o editando las vistas del flujo en la página de originación.
 9. Una vez terminado, haz clic en **Publicar**.
 
 :::warning Atención
-Si tu plan no incluye Originación o Soporte, esos tipos no aparecen en el selector. Si aparecen pero no puedes seleccionarlos, falta una precondición: la página de originación necesita que el sitio esté conectado a un reino, y la página de soporte necesita que el sitio no tenga ya una página de soporte.
+Si tu plan no incluye Originación, ese tipo no aparece en el selector. Si aparece pero no puedes seleccionarlo, falta una precondición: la página de originación necesita que el sitio esté conectado a un reino.
 :::
 
 Para conocer los tipos de widgets que puedes agregar, consulta [Página de Widget](/es/platform/channels/pages.html#pagina-de-widget).
@@ -147,7 +146,7 @@ Una vez seleccionado un widget en la sección central, el foco pasará a la pest
 
 ### Propiedades
 
-En esta pestaña encontrarás los controles de la página de widget, en el mismo orden en que aparecen en el panel. **Grilla** y **Delegar rutas hijas a esta página** solo existen aquí y en la página home: las páginas de contenido, de originación y de soporte no tienen esos controles.
+En esta pestaña encontrarás los controles de la página de widget, en el mismo orden en que aparecen en el panel. **Grilla** y **Delegar rutas hijas a esta página** solo existen aquí y en la página home: las páginas de contenido y de originación no tienen esos controles.
 
 - **Nombre**: El nombre de la página.
 - **Página padre**: La página bajo la cual se anida esta. Solo puedes elegir páginas de widget del sitio que estén publicadas, programadas o despublicadas.


### PR DESCRIPTION
## Cambios propuestos

Corrige tres desalineaciones de `channels/pages.md` contra el producto y purga de `objects.md` un objeto de Liquid que ya no existe. Cierra **CHANNELS-03**, **CHANNELS-17** y **CHANNELS-10** (que unifica **LIQUID-OBJETOS-16**).

### `platform/channels/pages.md`

**Los cuatro tipos de página (CHANNELS-03).** La página abría diciendo que existen dos tipos cuando el modal ofrece cuatro, y el tipo "Página de originación" no se mencionaba en ninguna parte de Channels pese a ser seleccionable en el mismo selector. Ahora la apertura enumera los cuatro con la capitalización real del panel y explica qué hace cada uno. Se agregan las precondiciones que hoy dejaban al administrador buscando un control que no ve: la página de originación exige que el plan incluya Originación y que el sitio esté conectado a un reino, la página de soporte exige que el plan incluya Soporte y admite una sola por sitio, y ambas son privadas por construcción (en la de originación la restricción por segmentos se configura en la originación, no en la página).

El procedimiento "Crear una Página" pasa de 8 a 9 pasos: el paso 5 ya nombra los cuatro tipos, el nuevo paso 6 detalla los campos que pide cada uno (Espacio y Tipo para contenido, Originación para originación, ninguno para widget y soporte) y el paso 7 corrige "Nombre del Layout" por el label real, **Nombre**. Se agrega un callout que explica la diferencia entre "el tipo no aparece" (falta en el plan) y "el tipo aparece deshabilitado" (falta la precondición), y un link a la sección que ya existe en `customers/origination.md`.

**Propiedades, Layout y Grilla (CHANNELS-17).** La lista de la pestaña Propiedades se presentaba como "propiedades comunes de todas las páginas" incluyendo **Grilla**, que solo existe en las páginas de widget y en la home. Ahora la sección declara su alcance real, enumera los nueve controles en el mismo orden en que aparecen en el panel y suma el selector **Layout**, que faltaba por completo y que es un campo distinto de **Página padre** (elige la plantilla de layout publicada del sitio que envuelve la página).

Se agrega la sección **Grillas** con las nueve grillas disponibles y las zonas de cada una, que hasta ahora solo estaban documentadas del lado Liquid en `objects.md`.

**Delegación de rutas (CHANNELS-17).** Estaba anidada dentro de "Página de Contenido", donde el control no existe. Pasa a ser sección hermana bajo "Página de Widget", con el título intacto para no romper el link "Aprender más" que el propio panel abre hacia este anclaje, y se aclara que en las páginas de contenido las sub-rutas las resuelven **Index** y **Show**, sin necesidad de delegar nada.

**Widgets retirados (CHANNELS-10).** La lista de widgets preestablecidos ofrecía "Listado de contenido" y "Contenido destacado", que ya no existen en el producto. Queda solo lo que el modal entrega hoy: **HTML** y **Texto enriquecido** bajo **Bloques**, y los widgets personalizados publicados bajo **Widgets**, con su acceso a **Ver todos los widgets**. Se agrega un Tip que dice explícitamente que esos dos widgets fueron retirados y con qué se resuelven esas capacidades ahora (página de contenido o widget personalizado), para no dejar al lector buscándolos en el panel.

Además, los nombres de las tres pestañas de la barra lateral pasan a los labels reales: **Añadir**, **Editar** y **Propiedades**.

### `platform/channels/liquid-markup/objects.md`

Se elimina la sección `### content_list_widget`: ese drop no existe, los únicos subtipos son `custom_widget`, `rich_text_widget` y `text_widget`, y ahora la introducción de `## widget` lo dice. Los ejemplos de la tabla `## widget` que seguían usando `content_list` como valor de muestra (`cache_key`, `resolve_type`, `title`, `css_class`, `name` y `type`) se reemplazan por los de un widget de texto enriquecido, coherentes entre sí.

Los cambios van en español y en inglés.

## Para el revisor

Tres cosas que conviene mirar con cuidado:

1. **Anclajes que usa el propio panel.** `has_router.hint` en `es.yml:1406` y `en.yml:1406` enlaza a `pages.html#delegacion-de-rutas` y `pages.html#route-delegation`. La sección se movió de nivel y de lugar, pero el TÍTULO quedó idéntico a propósito para que esos dos anclajes sigan resolviendo. Si en la revisión se cambia el título, hay que cambiar también el locale de la plataforma.

2. **Grillas documentadas por identificador, no por label de UI.** El selector no muestra texto: `LayoutGridSelector.js:34-51` pasa `grid.type` crudo como label y `lists.scss:78-136` lo esconde con `text-indent: -999px` y lo reemplaza por thumbnails. Como no hay label en el locale, documenté los nueve identificadores (los mismos que devuelve `grid.resolve_type`) con la descripción de sus zonas, en vez de inventar nombres entre comillas. Si el equipo prefiere describir los thumbnails en palabras, es un cambio de criterio, no una corrección.

3. **Alcance deliberadamente acotado.** Los tipos originación y soporte quedan enumerados con sus precondiciones y su privacidad forzada, pero NO documenté sus pestañas de edición (las vistas Comenzar / Reanudar / Reanudar (Invitado) / Completada de originación, ni Cases / Detalle del Case / Nuevo Case de soporte, ni sus opciones de Visualización). Eso es material para una tanda propia: el módulo Support no tiene ninguna página en `docs/es/platform`, por eso desde aquí no hay link a dónde mandar al lector. La página de originación sí enlaza a `origination.html#crear-una-pagina-de-originacion`, que ya existe.

Dato menor que dejé fuera por no pedirlo la tanda: la pestaña Propiedades de la página de contenido tiene además un checkbox "Usar categorías" (`pages/content/PageProps.js:100-102`) que la doc no menciona. Y `objects.md:427` conserva un volcado larguísimo de `page.content` de un sitio demo que incluye la cadena "Content list"; es un ejemplo de dump, no una referencia a un widget vigente, así que no lo toqué.

Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)
