### PR TITLE
Corregir y completar el catálogo de disparadores de webhook por contexto

### DIFF
--- a/docs/en/platform/core/webhooks.md
+++ b/docs/en/platform/core/webhooks.md
@@ -10,9 +10,9 @@ A webhook is an automatic _POST_ action to a given URL with certain information.
 
 To enable them, you must check the top of the page and then proceed to create all the webhooks you want.
 
-Webhooks can be created from actions of sites or spaces.
+Webhooks can be created from actions of apps, spaces, or realms. The **Context type** you pick defines which triggers the **Trigger (Log types)** selector offers you: every context has its own catalog and no trigger is available in all of them.
 
-When creating a webhook, you must have the URL to which you want to send the information, select the type of log and site (if necessary) that will trigger the webhook, and then save the changes.
+When creating a webhook, you must have the URL to which you want to send the information, pick the **Context type**, narrow the **Context** down to one app, space, or realm, or leave **All** to listen to every one of that type, select one or more triggers in **Trigger (Log types)**, since the selector accepts several, and then save the changes.
 
 After this, you will be able to see all active webhooks in the list.
 
@@ -29,66 +29,88 @@ To create a webhook, follow these steps:
 1. From the administration page, click **Settings**, then select **Webhooks**.
 2. Click **+ New Webhook**.
 3. Type the name and the URL you want to call.
-4. Select the sites or spaces you want to activate the webhook.
-5. Select the log type that will activate the webhook.
-6. Add the necessary headers for the call.
-7. Click **Save**.
+4. In **Context type**, pick **App**, **Space**, or **Realm**.
+5. In **Context**, pick the app, space, or realm that will trigger the webhook, or leave **All**.
+6. In **Trigger (Log types)**, select one or more triggers from the catalog of the context you picked.
+7. Add the necessary headers for the call.
+8. Click **Save**.
 
 
-Site webhooks are:
+::: tip Tip
+The value in the `trigger_uid` column is what travels in the payload's `trigger_uid` field, so it is the data your endpoint uses to tell one trigger from another.
+:::
 
-- Page created
-- Page deleted
-- Page published
-- Page unpublished
-- Page updated
-- Login
-- Logout
-- Navigation approved
-- Navigation published
-- Navigation sent for review
-- Navigation updated
-- Profile updated
-- Site created
-- Site deleted
-- Site disabled
-- Site enabled
-- Site hidden
-- Site staged
-- Site visible
-- Site updated
-- Templates approved
-- Templates sent for review
-- Templates updated
-- Theme installed
-- Theme restored
-- Theme updated
-- Widget approved
-- Widget cloned
-- Widget created
-- Widget published
-- Widget restored
-- Widget sent for review
-- Widget unpublished
-- Widget updated
+The triggers of the **App** context type are:
 
-Space webhooks are:
+| Trigger | `trigger_uid` |
+| --- | --- |
+| Page created | `layout_page_created_log` |
+| Page deleted | `layout_page_deleted_log` |
+| Page published | `layout_page_published_log` |
+| Page unpublished | `layout_page_unpublished_log` |
+| Page updated | `layout_page_updated_log` |
+| Menu approved | `menu_approved_log` |
+| Menu published | `menu_published_log` |
+| Menu sent to review | `menu_sent_to_review_log` |
+| Menu updated | `menu_updated_log` |
+| App created | `site_created_log` |
+| App deleted | `site_deleted_log` |
+| App disabled | `site_disabled_log` |
+| App enabled | `site_enabled_log` |
+| App draft | `site_draft_log` |
+| App updated | `site_updated_log` |
+| Template approved | `site_template_approved_log` |
+| Templates sent to review | `site_template_sent_to_review_log` |
+| Template updated | `site_template_updated_log` |
+| Template published | `site_template_published_log` |
+| Widget approved | `widget_definition_approved_log` |
+| Widget Cloned | `widget_definition_cloned_log` |
+| Widget Created | `widget_definition_created_log` |
+| Widget Published | `widget_definition_published_log` |
+| Widget Restored | `widget_definition_restored_log` |
+| Widget sent to review | `widget_definition_sent_to_review_log` |
+| Widget unpublished | `widget_definition_unpublished_log` |
+| Widget Updated | `widget_definition_updated_log` |
 
-- Category created
-- Category deleted
-- Category updated
-- Entry approved
-- Entry created
-- Entry published
-- Entry sent for review
-- Entry unpublished
-- Entry updated
-- Space created
-- Space updated
-- Type created
-- Type deleted
-- Type updated
+Signing in, signing out, and profile updates are recorded in the activity, but they are not triggers of this context. If you need your end users' session events, create the webhook from the realm.
 
+The triggers of the **Space** context type are:
+
+| Trigger | `trigger_uid` |
+| --- | --- |
+| Category created | `category_created_log` |
+| Category deleted | `category_deleted_log` |
+| Category updated | `category_updated_log` |
+| Entry approved | `entry_approved_log` |
+| Entry created | `entry_created_log` |
+| Entry published | `entry_published_log` |
+| Entry sent to review | `entry_sent_to_review_log` |
+| Entry unpublished | `entry_unpublished_log` |
+| Entry updated | `entry_updated_log` |
+| Space created | `space_created_log` |
+| Space updated | `space_updated_log` |
+| Type created | `type_created_log` |
+| Type deleted | `type_deleted_log` |
+| Type updated | `type_updated_log` |
+| Type sent to reindex | `type_reindex_log` |
+| Reindex of type canceled | `type_cancel_reindex_log` |
+| Asset created | `asset_created_log` |
+| Asset updated | `asset_updated_log` |
+
+
+The triggers of the **Realm** context type are:
+
+| Trigger | `trigger_uid` |
+| --- | --- |
+| User created | `user_created_log` |
+| User updated | `user_updated_log` |
+| User enabled | `user_enabled_log` |
+| User disabled | `user_disabled_log` |
+| User deleted | `user_deleted_log` |
+
+::: warning Attention
+These five triggers are the only ones the **Realm** context type offers from **Settings** > **Webhooks**, and they cover the user management your team does. They are not the same ones you see in **Realm Settings** > **Webhooks**, which listens to the realm's end-user events and does not include **User disabled**. If you need both groups of events, create one webhook in each place.
+:::
 
 ### Payload example
 
@@ -132,15 +154,50 @@ To create a webhook, follow these steps:
 1. From a realm, click **Realm Settings**, then select **Webhooks**.
 2. Click **+ New Webhook**.
 3. Type the name and the URL you want to call.
-4. Select the type of log that will activate the webhook.
+4. In **Trigger (Log types)**, select one or more triggers from the end-user event catalog.
 5. Add the necessary headers for the call.
 6. Click **Save**.
 
-Realm webhooks with their respective payloads:
+The available triggers are the realm's 24 end-user events:
 
-- Form response created
-- Form response updated
-- Origination response created
+| Trigger | `trigger_uid` | Fires when |
+| --- | --- | --- |
+| Form response created | `form_response_created_log` | An end user submits a form response. |
+| Form response updated | `form_response_updated_log` | An already submitted form response is updated. |
+| Origination submission created | `origination_submission_created_log` | An origination submission is created. |
+| Origination submission started | `origination_submission_started_log` | The end user enters the first task and the submission becomes started. |
+| Origination submission task submitted | `origination_submission_task_submitted_log` | The end user submits a task of the submission. |
+| Origination submission completed | `origination_submission_completed_log` | The submission becomes completed. |
+| Origination submission canceled | `origination_submission_canceled_log` | Someone cancels the submission. |
+| Origination submission canceled due to expiration | `origination_submission_canceled_overdue_log` | The platform cancels an overdue submission on its own. New in 10.2. |
+| Origination submission task updated | `origination_submission_task_updated_log` | The data of a task of the submission is updated. |
+| Origination task response started | `origination_task_response_started_log` | A task of the submission becomes in progress. New in 10.2. |
+| Origination task response completed | `origination_task_response_completed_log` | A task of the submission becomes completed. New in 10.2. |
+| Origination task response reopened | `origination_task_response_reopened_log` | An already completed task goes back to in progress. New in 10.2. |
+| Origination task response assigned | `origination_task_response_assigned_log` | The assignee of a task of the submission changes. New in 10.2. |
+| Login | `user_login_log` | An end user signs in. |
+| Login with code | `user_otp_login_log` | An end user's code is verified successfully. |
+| Logout | `user_logout_log` | An end user signs out. |
+| Login attempt failed | `user_login_attempt_failed_log` | A sign-in attempt fails. |
+| Login with code attempt failed | `user_otp_login_attempt_failed_log` | The submitted code cannot be verified. |
+| User created | `user_created_log` | An end user is created. |
+| User updated | `user_updated_log` | An end user is updated. |
+| User enabled | `user_enabled_log` | An end user is enabled. |
+| User signup | `user_signup_log` | An end user signs up. |
+| User password reset | `user_password_reset_log` | A password reset is requested. |
+| User deleted | `user_deleted_log` | An end user is deleted. |
+
+::: warning Attention
+This form has no **Context type** or **Context** selectors: the webhook is always scoped to the realm you create it from. **User disabled** is not on this list, because it only exists in the **Realm** context type webhooks you create from **Settings** > **Webhooks**.
+:::
+
+::: tip Tip
+The same trigger can reach you in two shapes. When the end user performs the action from the site, the payload is compact and carries the event in `e_c` and `e_a`. When an administrator performs it from the admin panel, or the platform performs it on its own, the payload carries the full log, with `trigger_uid`, `trigger_entity`, and the event detail inside `options`. Keep your endpoint ready for both.
+:::
+
+These are the payload examples of the origination triggers:
+
+- Origination submission created
 ``` javascript
 {
    "ip":"172.71.194.146",
@@ -156,7 +213,7 @@ Realm webhooks with their respective payloads:
    "submission_uuid":"4c23599f-2aa6-4a8c-b2ae-66be46b7b938"
 }
 ```
-- Origination response started
+- Origination submission started
 ``` javascript
 {
    "ip":"172.71.194.146",
@@ -172,7 +229,7 @@ Realm webhooks with their respective payloads:
    "submission_uuid":"4c23599f-2aa6-4a8c-b2ae-66be46b7b938"
 }
 ```
-- Origination response task submitted
+- Origination submission task submitted
 ``` javascript
 {
    "ip":"172.71.195.36",
@@ -189,7 +246,7 @@ Realm webhooks with their respective payloads:
    "submission_uuid":"4c23599f-2aa6-4a8c-b2ae-66be46b7b938"
 }
 ```
-- Origination response completed
+- Origination submission completed
 ``` javascript
 {
    "id":35914440,
@@ -217,7 +274,7 @@ Realm webhooks with their respective payloads:
    "trigger_entry_space_uid":null
 }
 ```
-- Origination response canceled
+- Origination submission canceled
 ``` javascript
 {
    "ip":"172.71.195.41",
@@ -233,17 +290,57 @@ Realm webhooks with their respective payloads:
    "submission_uuid":"04bf572a-9e00-4474-ae8a-6a0bc17d4c1a"
 }
 ```
-- Login
-- Login with code
-- Logout
-- Error trying to log in
-- Error trying to log in with code
-- User created
-- User updated
-- User enabled
-- User registration
-- Restore password
-- User deleted
+- Origination submission canceled due to expiration
+``` javascript
+{
+   "id":35914462,
+   "account_id":381,
+   "automated":true,
+   "site_id":null,
+   "space_id":null,
+   "user_id":null,
+   "value_1":null,
+   "value_2":null,
+   "value_3":null,
+   "request_ip":null,
+   "request_user_agent":null,
+   "loggeable_id":419,
+   "loggeable_type":"Origination::Submission",
+   "options":null,
+   "created_at":"2026-07-02T09:15:04.000-04:00",
+   "log_type_id":415412,
+   "realm_id":681,
+   "trigger_uid":"origination_submission_canceled_overdue_log",
+   "trigger_name":"Origination submission canceled overdue log",
+   "trigger_entity":"Origination::Submission",
+   "trigger_entity_id":419,
+   "trigger_entry_uuid":null,
+   "trigger_content_uuid":null,
+   "trigger_entry_space_uid":null
+}
+```
+This is the only trigger on the list that nobody performs: it arrives with `automated` set to `true` and without `user_id`, because the platform is the one canceling the overdue submission.
+
+- Origination task response completed
+``` javascript
+{
+   "e_c":"origination_task_response",
+   "e_a":"completed_log",
+   "account_id":381,
+   "uid":2300345,
+   "idsite":4521,
+   "submission_uuid":"4c23599f-2aa6-4a8c-b2ae-66be46b7b938",
+   "origination_uid":"ori",
+   "realm_uid":"jordana",
+   "realm_id":681,
+   "task_uid":"datos-personales",
+   "task_response_id":9871,
+   "task_response_type":"Origination::UserInputTaskResponse",
+   "ua":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+   "ip":"172.71.194.146"
+}
+```
+The origination task response started, reopened, and assigned triggers use the same shape, with `e_a` set to `started_log`, `reopened_log`, or `assigned_log`, and `task_uid` tells you which task of the origination the event belongs to.
 
 :::tip Tip
 The webhook is called via a POST when the selected log type is generated. Once the webhook is created, you can send a test notification with false information to test that your URL is correctly receiving POSTs from Modyo.

--- a/docs/en/platform/core/webhooks.md
+++ b/docs/en/platform/core/webhooks.md
@@ -36,7 +36,7 @@ To create a webhook, follow these steps:
 8. Click **Save**.
 
 
-::: tip Tip
+:::tip Tip
 The value in the `trigger_uid` column is what travels in the payload's `trigger_uid` field, so it is the data your endpoint uses to tell one trigger from another.
 :::
 
@@ -108,7 +108,7 @@ The triggers of the **Realm** context type are:
 | User disabled | `user_disabled_log` |
 | User deleted | `user_deleted_log` |
 
-::: warning Attention
+:::warning Attention
 These five triggers are the only ones the **Realm** context type offers from **Settings** > **Webhooks**, and they cover the user management your team does. They are not the same ones you see in **Realm Settings** > **Webhooks**, which listens to the realm's end-user events and does not include **User disabled**. If you need both groups of events, create one webhook in each place.
 :::
 
@@ -187,11 +187,11 @@ The available triggers are the realm's 24 end-user events:
 | User password reset | `user_password_reset_log` | A password reset is requested. |
 | User deleted | `user_deleted_log` | An end user is deleted. |
 
-::: warning Attention
+:::warning Attention
 This form has no **Context type** or **Context** selectors: the webhook is always scoped to the realm you create it from. **User disabled** is not on this list, because it only exists in the **Realm** context type webhooks you create from **Settings** > **Webhooks**.
 :::
 
-::: tip Tip
+:::tip Tip
 The same trigger can reach you in two shapes. When the end user performs the action from the site, the payload is compact and carries the event in `e_c` and `e_a`. When an administrator performs it from the admin panel, or the platform performs it on its own, the payload carries the full log, with `trigger_uid`, `trigger_entity`, and the event detail inside `options`. Keep your endpoint ready for both.
 :::
 

--- a/docs/es/platform/core/webhooks.md
+++ b/docs/es/platform/core/webhooks.md
@@ -37,7 +37,7 @@ Para crear un webhook, sigue estos pasos:
 8. Haz click en **Guardar**
 
 
-::: tip Tip
+:::tip Tip
 El valor de la columna `trigger_uid` es el que viaja en el campo `trigger_uid` del payload, así que es el dato con el que tu endpoint distingue un disparador de otro.
 :::
 
@@ -109,7 +109,7 @@ Los disparadores del tipo de contexto **Reino** son:
 | Usuario deshabilitado | `user_disabled_log` |
 | Usuario borrado | `user_deleted_log` |
 
-::: warning Atención
+:::warning Atención
 Estos cinco disparadores son los únicos que ofrece el tipo de contexto **Reino** desde **Configuración** > **Webhooks**, y cubren la gestión de usuarios que hace tu equipo. No son los mismos que ves en **Configuración del reino** > **Webhooks**, que escucha los eventos de los usuarios finales del reino y no incluye **Usuario deshabilitado**. Si necesitas los dos grupos de eventos, crea un webhook en cada lugar.
 :::
 
@@ -188,11 +188,11 @@ Los disparadores disponibles son los 24 eventos de usuario final del reino:
 | Restaurar contraseña | `user_password_reset_log` | Se solicita la restauración de la contraseña. |
 | Usuario borrado | `user_deleted_log` | Se borra un usuario final. |
 
-::: warning Atención
+:::warning Atención
 Este formulario no tiene selectores de **Tipo de contexto** ni de **Contexto**: el webhook queda siempre acotado al reino desde el que lo creas. **Usuario deshabilitado** no está en esta lista, porque solo existe en los webhooks de tipo de contexto **Reino** que creas desde **Configuración** > **Webhooks**.
 :::
 
-::: tip Tip
+:::tip Tip
 Un mismo disparador puede llegarte en dos formas. Si la acción la hace el usuario final desde el sitio, el payload es compacto y trae el evento en `e_c` y `e_a`. Si la hace un administrador desde el panel, o si la plataforma la hace sola, el payload trae el log completo, con `trigger_uid`, `trigger_entity` y el detalle del evento dentro de `options`. Deja tu endpoint preparado para las dos.
 :::
 

--- a/docs/es/platform/core/webhooks.md
+++ b/docs/es/platform/core/webhooks.md
@@ -10,9 +10,9 @@ Un webhook es una acción _POST_ automática a una URL determinada con informaci
 
 Para habilitarlos, debes checkear la parte superior de la página y después proceder a crear todos los webhooks que quieras.
 
-Los webhooks se pueden crear a partir de acciones de sitios o espacios.
+Los webhooks se pueden crear a partir de acciones de aplicaciones, espacios o reinos. El **Tipo de contexto** que elijas define qué disparadores te ofrece el selector **Tipo de log**: cada contexto tiene su propio catálogo y ningún disparador está en todos.
 
-Al crear un webhook, debes tener la URL a la que quieres enviar la información, seleccionar el tipo de log y sitio (en caso de ser necesario) que gatillará el webhook y luego guardar los cambios.
+Al crear un webhook, debes tener la URL a la que quieres enviar la información, elegir el **Tipo de contexto**, acotar el **Contexto** a una aplicación, un espacio o un reino en particular, o dejar **Todos** para escuchar a todos los de ese tipo, seleccionar en **Tipo de log** uno o más disparadores, porque el selector es múltiple, y luego guardar los cambios.
 
 Luego de esto, podrás ver en la lista todos los webhooks que estén activos.
 
@@ -30,66 +30,88 @@ Para crear un webhook, sigue estos pasos:
 1. Desde la página de administración, haz click en **Configuración**, luego selecciona **Webhooks**.
 2. Haz click en **+ Nuevo Webhook**
 3. Escribe el nombre y la URL a la cual quieres llamar
-4. Selecciona los sitios o espacios que quieras que activen el webhook
-5. Selecciona el tipo de log que activará el webhook
-6. Agrega los headers necesarios para la llamada
-7. Haz click en **Guardar**
+4. En **Tipo de contexto**, elige **Aplicación**, **Espacio** o **Reino**
+5. En **Contexto**, elige la aplicación, el espacio o el reino que activará el webhook, o deja **Todos**
+6. En **Tipo de log**, selecciona uno o más disparadores del catálogo del contexto que elegiste
+7. Agrega los headers necesarios para la llamada
+8. Haz click en **Guardar**
 
 
-Los webhooks de sitio son:
+::: tip Tip
+El valor de la columna `trigger_uid` es el que viaja en el campo `trigger_uid` del payload, así que es el dato con el que tu endpoint distingue un disparador de otro.
+:::
 
-- Página creada
-- Página eliminada
-- Página publicada
-- Página despublicada
-- Página actualizada
-- Inicio de sesión
-- Cierre de sesión
-- Navegación aprobada
-- Navegación publicada
-- Navegación enviada a revisión
-- Navegación actualizada
-- Perfil actualizado
-- Sitio creado
-- Sitio eliminado
-- Sitio desactivado
-- Sitio habilitado
-- Sitio oculto
-- Sitio puesto en desarrollo
-- Sitio visible
-- Sitio actualizado
-- Templates aprobados
-- Templates enviados para su revisión
-- Templates actualizados
-- Tema instalado
-- Tema restablecido
-- Tema actualizado
-- Widget aprobado
-- Widget clonado
-- Widget creado
-- Widget publicado
-- Widget restaurado
-- Widget enviado a revisión
-- Widget despublicado
-- Widget actualizado
+Los disparadores del tipo de contexto **Aplicación** son:
 
-Los webhooks de espacios son:
+| Disparador | `trigger_uid` |
+| --- | --- |
+| Página creada | `layout_page_created_log` |
+| Página eliminada | `layout_page_deleted_log` |
+| Página publicada | `layout_page_published_log` |
+| Page despublicada | `layout_page_unpublished_log` |
+| Página actualizada | `layout_page_updated_log` |
+| Menú aprobado | `menu_approved_log` |
+| Navegación publicada | `menu_published_log` |
+| Navigation enviado a revisión | `menu_sent_to_review_log` |
+| Menú de navegación actualizado | `menu_updated_log` |
+| Aplicación creada | `site_created_log` |
+| Aplicación borrada | `site_deleted_log` |
+| Aplicación deshabilitada | `site_disabled_log` |
+| Aplicación habilitada | `site_enabled_log` |
+| Aplicación en estado editable | `site_draft_log` |
+| Aplicación actualizada | `site_updated_log` |
+| Plantilla aprobada | `site_template_approved_log` |
+| Plantilla enviada a revisión | `site_template_sent_to_review_log` |
+| Plantilla actualizada | `site_template_updated_log` |
+| Plantilla publicada | `site_template_published_log` |
+| Widget aprobado | `widget_definition_approved_log` |
+| Widget clonado | `widget_definition_cloned_log` |
+| Widget creado | `widget_definition_created_log` |
+| Widget publicado | `widget_definition_published_log` |
+| Widget restaurado | `widget_definition_restored_log` |
+| Widget enviado a revisión | `widget_definition_sent_to_review_log` |
+| Widget despublicado | `widget_definition_unpublished_log` |
+| Widget actualizado | `widget_definition_updated_log` |
 
-- Categoría creada
-- Categoría eliminada
-- Categoría actualizada
-- Entrada aprobada
-- Entrada creada
-- Entrada publicada
-- Entrada enviada a revisión
-- Entrada despublicada
-- Entrada actualizada
-- Espacio creado
-- Espacio actualizado
-- Tipo creado
-- Tipo eliminado
-- Tipo actualizado
+El inicio de sesión, el cierre de sesión y la actualización de perfil quedan registrados en la actividad, pero no son disparadores de este contexto. Si necesitas los eventos de sesión de tus usuarios finales, crea el webhook desde el reino.
 
+Los disparadores del tipo de contexto **Espacio** son:
+
+| Disparador | `trigger_uid` |
+| --- | --- |
+| Categoría creada | `category_created_log` |
+| Categoría borrada | `category_deleted_log` |
+| Categoría actualizada | `category_updated_log` |
+| Entrada aprobada | `entry_approved_log` |
+| Entrada creada | `entry_created_log` |
+| Entrada publicada | `entry_published_log` |
+| Entrada enviada a revisión | `entry_sent_to_review_log` |
+| Entrada despublicada | `entry_unpublished_log` |
+| Entrada actualizada | `entry_updated_log` |
+| Espacio creado | `space_created_log` |
+| Espacio modificado | `space_updated_log` |
+| Tipo creado | `type_created_log` |
+| Tipo eliminado | `type_deleted_log` |
+| Tipo modificado | `type_updated_log` |
+| Tipo enviado para reindexar | `type_reindex_log` |
+| Se canceló la reindexación del tipo | `type_cancel_reindex_log` |
+| Archivo creado | `asset_created_log` |
+| Archivo actualizado | `asset_updated_log` |
+
+
+Los disparadores del tipo de contexto **Reino** son:
+
+| Disparador | `trigger_uid` |
+| --- | --- |
+| Usuario creado | `user_created_log` |
+| Usuario actualizado | `user_updated_log` |
+| Usuario habilitado | `user_enabled_log` |
+| Usuario deshabilitado | `user_disabled_log` |
+| Usuario borrado | `user_deleted_log` |
+
+::: warning Atención
+Estos cinco disparadores son los únicos que ofrece el tipo de contexto **Reino** desde **Configuración** > **Webhooks**, y cubren la gestión de usuarios que hace tu equipo. No son los mismos que ves en **Configuración del reino** > **Webhooks**, que escucha los eventos de los usuarios finales del reino y no incluye **Usuario deshabilitado**. Si necesitas los dos grupos de eventos, crea un webhook en cada lugar.
+:::
 
 ### Ejemplo de Payload
 
@@ -133,14 +155,49 @@ Para crear un webhook, sigue estos pasos:
 1. Desde un reino, haz click en **Configuración del reino**, luego selecciona **Webhooks**
 2. Haz click en **+ Nuevo Webhook**.
 3. Escribe el nombre y la URL a la cual quieres llamar.
-4. Selecciona el tipo de log que activará el webhook.
+4. En **Tipo de log**, selecciona uno o más disparadores del catálogo de eventos de usuario final.
 5. Agrega los headers necesarios para la llamada. 
 6. Haz click en **Guardar**.
 
-Los webhooks de reino con sus payloads respectivos:
+Los disparadores disponibles son los 24 eventos de usuario final del reino:
 
-- Respuesta de formulario creada
-- Respuesta de formulario actualizada
+| Disparador | `trigger_uid` | Se dispara cuando |
+| --- | --- | --- |
+| Respuesta de formulario creada | `form_response_created_log` | Un usuario final envía una respuesta a un formulario. |
+| Respuesta de formulario actualizada | `form_response_updated_log` | Se actualiza una respuesta de formulario ya enviada. |
+| Respuesta de originación creada | `origination_submission_created_log` | Se crea la respuesta de una originación. |
+| Respuesta de originación iniciada | `origination_submission_started_log` | El usuario final entra a la primera tarea y la respuesta queda iniciada. |
+| Tarea de respuesta de originación enviada | `origination_submission_task_submitted_log` | El usuario final envía una tarea de la respuesta. |
+| Respuesta de originación completada | `origination_submission_completed_log` | La respuesta queda completada. |
+| Respuesta de originación cancelada | `origination_submission_canceled_log` | Alguien cancela la respuesta. |
+| Respuesta de originación cancelada por vencimiento | `origination_submission_canceled_overdue_log` | La plataforma cancela sola una respuesta que pasó su fecha de vencimiento. Nuevo en 10.2. |
+| Tarea de respuesta de originación actualizada | `origination_submission_task_updated_log` | Se actualizan los datos de una tarea de la respuesta. |
+| Respuesta a tarea de originación iniciada | `origination_task_response_started_log` | Una tarea de la respuesta pasa a en curso. Nuevo en 10.2. |
+| Respuesta a tarea de originación completada | `origination_task_response_completed_log` | Una tarea de la respuesta queda completada. Nuevo en 10.2. |
+| Respuesta a tarea de originación reabierta | `origination_task_response_reopened_log` | Una tarea ya completada vuelve a quedar en curso. Nuevo en 10.2. |
+| Respuesta a tarea de originación asignada | `origination_task_response_assigned_log` | Cambia el responsable asignado a una tarea de la respuesta. Nuevo en 10.2. |
+| Inicio de sesión | `user_login_log` | Un usuario final ingresa. |
+| Iniciar sesión con código | `user_otp_login_log` | Se verifica correctamente el código de un usuario final. |
+| Cerrar sesión | `user_logout_log` | Un usuario final cierra su sesión. |
+| Error al intentar iniciar sesión | `user_login_attempt_failed_log` | Falla un intento de inicio de sesión. |
+| Error al intentar iniciar sesión con código | `user_otp_login_attempt_failed_log` | No se puede verificar el código introducido. |
+| Usuario creado | `user_created_log` | Se crea un usuario final. |
+| Usuario actualizado | `user_updated_log` | Se actualiza un usuario final. |
+| Usuario habilitado | `user_enabled_log` | Se habilita un usuario final. |
+| Registro de usuario | `user_signup_log` | Un usuario final se registra. |
+| Restaurar contraseña | `user_password_reset_log` | Se solicita la restauración de la contraseña. |
+| Usuario borrado | `user_deleted_log` | Se borra un usuario final. |
+
+::: warning Atención
+Este formulario no tiene selectores de **Tipo de contexto** ni de **Contexto**: el webhook queda siempre acotado al reino desde el que lo creas. **Usuario deshabilitado** no está en esta lista, porque solo existe en los webhooks de tipo de contexto **Reino** que creas desde **Configuración** > **Webhooks**.
+:::
+
+::: tip Tip
+Un mismo disparador puede llegarte en dos formas. Si la acción la hace el usuario final desde el sitio, el payload es compacto y trae el evento en `e_c` y `e_a`. Si la hace un administrador desde el panel, o si la plataforma la hace sola, el payload trae el log completo, con `trigger_uid`, `trigger_entity` y el detalle del evento dentro de `options`. Deja tu endpoint preparado para las dos.
+:::
+
+Estos son los payloads de ejemplo de los disparadores de originación:
+
 - Respuesta de originación creada
 ``` javascript
 {
@@ -234,17 +291,57 @@ Los webhooks de reino con sus payloads respectivos:
    "submission_uuid":"04bf572a-9e00-4474-ae8a-6a0bc17d4c1a"
 }
 ```
-- Login
-- Login with code
-- Logout
-- Error trying to log in
-- Error trying to log in with code
-- User created
-- User updated
-- User enabled
-- User registration
-- Restore password
-- User deleted
+- Respuesta de originación cancelada por vencimiento
+``` javascript
+{
+   "id":35914462,
+   "account_id":381,
+   "automated":true,
+   "site_id":null,
+   "space_id":null,
+   "user_id":null,
+   "value_1":null,
+   "value_2":null,
+   "value_3":null,
+   "request_ip":null,
+   "request_user_agent":null,
+   "loggeable_id":419,
+   "loggeable_type":"Origination::Submission",
+   "options":null,
+   "created_at":"2026-07-02T09:15:04.000-04:00",
+   "log_type_id":415412,
+   "realm_id":681,
+   "trigger_uid":"origination_submission_canceled_overdue_log",
+   "trigger_name":"Origination submission canceled overdue log",
+   "trigger_entity":"Origination::Submission",
+   "trigger_entity_id":419,
+   "trigger_entry_uuid":null,
+   "trigger_content_uuid":null,
+   "trigger_entry_space_uid":null
+}
+```
+Este disparador es el único de la lista que nadie ejecuta: llega con `automated` en `true` y sin `user_id`, porque es la plataforma la que cancela la respuesta vencida.
+
+- Respuesta a tarea de originación completada
+``` javascript
+{
+   "e_c":"origination_task_response",
+   "e_a":"completed_log",
+   "account_id":381,
+   "uid":2300345,
+   "idsite":4521,
+   "submission_uuid":"4c23599f-2aa6-4a8c-b2ae-66be46b7b938",
+   "origination_uid":"ori",
+   "realm_uid":"jordana",
+   "realm_id":681,
+   "task_uid":"datos-personales",
+   "task_response_id":9871,
+   "task_response_type":"Origination::UserInputTaskResponse",
+   "ua":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+   "ip":"172.71.194.146"
+}
+```
+Los disparadores de respuesta a tarea de originación iniciada, reabierta y asignada usan la misma estructura, con `e_a` en `started_log`, `reopened_log` o `assigned_log`, y `task_uid` te dice a qué tarea de la originación corresponde el evento.
 
 :::tip Tip
 El webhook es llamado a través de un POST cuando se genera un log del tipo seleccionado. Una vez creado el webhook, podrás enviar una notificación de prueba con información falsa para probar que tu URL está recibiendo correctamente los POSTs desde Modyo.


### PR DESCRIPTION
## Cambios propuestos

Esta página era el catálogo de referencia de los disparadores de webhook y las tres listas estaban mal: la de sitio tenía 8 eventos que no existen y le faltaba uno, la de espacios le faltaban 4, la de reino le faltaban 6 y el catálogo del contexto Reino que se crea desde la cuenta no aparecía en ninguna parte. Un integrador que configuraba un webhook siguiendo esta página podía quedarse esperando notificaciones de un evento inexistente.

### docs/es/platform/core/webhooks.md y docs/en/platform/core/webhooks.md

**Introducción y pasos de creación.** Ahora se explica que el **Tipo de contexto** puede ser **Aplicación**, **Espacio** o **Reino**, que el **Contexto** se puede acotar a uno solo o dejar en **Todos**, y que el selector **Tipo de log** es múltiple, así que un webhook puede escuchar varios disparadores. Los pasos numerados nombran los tres selectores tal como aparecen en el formulario.

**Disparadores del contexto Aplicación.** Se depuró la lista para que coincida con lo que ofrece el selector: se eliminaron los 8 que no son disparadores de este contexto (inicio de sesión, cierre de sesión, perfil actualizado, sitio oculto, sitio visible y los tres de Tema), se agregó **Plantilla publicada**, y se alinearon todos los labels con los del panel, que hoy dice "Aplicación" y "Plantilla" donde la doc decía "Sitio" y "Templates". La lista pasó a tabla con el `trigger_uid` de cada disparador, que es el valor que viaja en el payload y el único modo de mapear una opción del selector con lo que llega al endpoint. Se agrega además una nota de que los eventos de sesión de los usuarios finales se escuchan desde el reino, no desde este contexto.

**Disparadores del contexto Espacio.** Se agregaron los 4 que faltaban: **Tipo enviado para reindexar**, **Se canceló la reindexación del tipo**, **Archivo creado** y **Archivo actualizado**. Los dos de archivos son los que sirven para integraciones de sincronización de multimedia y hasta ahora no había forma de saber que existían. También pasó a tabla con `trigger_uid`.

**Disparadores del contexto Reino creados desde la cuenta.** Sección nueva. Se documenta que el formulario de **Configuración** > **Webhooks** también ofrece el tipo de contexto **Reino** y que en ese caso el selector solo trae 5 disparadores de gestión de usuarios, distintos de los 24 eventos de usuario final del otro formulario. Se aclara que **Usuario deshabilitado** existe solo en esta lista y que, si se necesitan los dos grupos de eventos, hay que crear un webhook en cada lugar.

**Disparadores del webhook de reino.** Se completó el catálogo a los 24 eventos de usuario final, en tabla con `trigger_uid` y con una columna de cuándo se dispara cada uno. Se agregaron los 6 que faltaban: **Respuesta de originación cancelada por vencimiento**, **Tarea de respuesta de originación actualizada** y las cuatro de **Respuesta a tarea de originación** iniciada, completada, reabierta y asignada. Cinco de ellos son nuevos en 10.2 y quedan marcados como tales: son justo los que permiten seguir el ciclo de vida de las tareas de una originación desde un sistema externo. También se tradujeron al español los 11 labels de eventos de usuario que estaban en inglés en la página española, y en la versión en inglés se alinearon los rótulos de los payloads con los labels reales del panel.

**Payloads.** Se documenta que un mismo disparador puede llegar en dos formas, la compacta con `e_c` y `e_a` cuando la acción la hace el usuario final desde el sitio, y la completa del log con `trigger_uid` cuando la hace un administrador o la plataforma sola. Se agregan dos payloads de ejemplo nuevos: el de la cancelación por vencimiento, que es el único que llega con `automated` en `true` y sin `user_id`, y el de una respuesta a tarea de originación completada.

Cierra ROLES-SEGURIDAD-08, ROLES-SEGURIDAD-09, ROLES-SEGURIDAD-10 y ROLES-SEGURIDAD-11.

## Para el revisor

Tres cosas para mirar con cuidado.

1. Dos labels de la tabla de contexto Aplicación se ven como erratas nuestras y no lo son: **Page despublicada** (`layout_page_unpublished_log`) y **Navigation enviado a revisión** (`menu_sent_to_review_log`). Ese es el texto literal de `admin.logs.*.title` en config/locales/admin/es.yml:4452 y :4577, o sea lo que el integrador lee en el selector. Los transcribí verbatim a propósito para que la tabla sirva para buscar la opción en el panel. Si se "corrigen" en la doc, deja de calzar con el panel; la corrección real va en el locale, en otra issue. En la misma línea, `menu_approved_log` es "Menú aprobado" pero `menu_published_log` es "Navegación publicada" y `menu_updated_log` es "Menú de navegación actualizado": el locale mezcla Menú y Navegación y la tabla refleja esa mezcla.

2. Cambié "Sitio" por **Aplicación** en toda la tabla de ese contexto porque es lo que dice el panel hoy (`admin.content.contexts.site` y `admin.logs.site_*_log.title` en es.yml usan Aplicación). Es un cambio de vocabulario visible respecto del resto de la documentación, que sigue hablando de sitios. Si el equipo prefiere mantener "Sitio" en la prosa, la tabla igual tiene que decir Aplicación para calzar con el selector.

3. La ficha ROLES-SEGURIDAD-10 pedía dejar la entrada correspondiente en las notas de versión 10.2. No lo hice: docs/es/platform/release-notes.md todavía no tiene sección 10.2, empieza en 10.1.16, y la tanda solo declara webhooks.md como página. Queda pendiente para cuando se abra la sección de 10.2.

Además, dos cosas que dejé fuera de alcance a propósito y conviene anotar. El payload de ejemplo que ya existía para **Tarea de respuesta de originación enviada** muestra `task_id`, mientras que el código actual manda `task_uuid`, `task_uid` y `changes` (app/controllers/site/originations_controller.rb:739-751): el ejemplo está viejo, pero corregirlo no es parte de estos gaps. Y el primer payload de ejemplo de la página, el de entrada creada, incluye `type` y `user_type`, que ya no son columnas de la tabla logs (db/schema.rb:880-898); mismo caso.

Sobre la marca de versión: la ficha decía "cinco nuevos en 10.2" sin precisar cuáles. Lo resolví comparando con releases/10.1-stable:app/models/realm.rb:36-42. Los cinco nuevos son `origination_submission_canceled_overdue_log` y los cuatro `origination_task_response_*`; `origination_submission_task_updated_log` ya estaba en 10.1, así que lo documenté como faltante en la doc pero sin marcarlo como nuevo. Site::LOGHOOKS y Content::Space::LOGHOOKS son idénticos en 10.1 y en master, o sea que los gaps 08 y 09 son deuda pura de documentación y no hay nada de master que invalide las fichas.

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)
