### PR TITLE
Actualizar la documentación de Seguridad en CORS, política de contraseñas, expiración de sesión y bloqueo por intentos fallidos

### DIFF
--- a/docs/en/platform/core/security.md
+++ b/docs/en/platform/core/security.md
@@ -17,19 +17,37 @@ This guide presents the most relevant recommendations for achieving this objecti
 In this section, you can set the password security policy for team members. The available options are:
 
 - **Minimum password length value**: This value determines the minimum length a password must have; it must be between 12 and 128 characters.
-- **Require at least one lowercase letter (a - z)**: This option ensures that the password contains at least one lowercase letter.
-- **Require at least one capital letter (A - Z)**: This option ensures that the password contains at least one capital letter.
-- **Require at least one non-alphanumeric character (! @ # $ % ^ & * () _ + - = [] {} |)**: This option requires that team members' passwords contain at least one of the specified special characters.
+- **Require at least one lowercase letter from Latin alphabet (a to z)**: This option ensures that the password contains at least one lowercase letter.
+- **Require at least one uppercase letter from Latin alphabet (A to Z)**: This option ensures that the password contains at least one uppercase letter.
+- **Require at least one of these special characters**: This option requires that team members' passwords contain at least one of the symbols that the checkbox itself lists in parentheses. The default set is `! @ # $ % ^ & * ( ) _ + º - = [ ] { } | " . ' ¿ / ¡ : ;`, and the list you see on screen is always the one your installation validates.
 
 When saving this configuration, existing users will have to comply with these conditions when changing their password.
 
+:::warning Attention
+When you enable **Require at least one of these special characters**, the password is also limited to that alphabet: only letters from `a` to `z`, uppercase or lowercase, digits, and the symbols on the list are accepted. Any other character causes the password to be rejected, even if it is long and meets all the other conditions. This includes accented vowels, `ñ`, and symbols such as `~`, `<`, or `>`.
+:::
+
+## Lockout after failed login attempts
+
+In addition to the password policy, Modyo protects the login process against brute force attacks. After 10 consecutive failed attempts, the user is temporarily locked out for 15 minutes, and the error message tells them how long is left before the lockout is lifted:
+
+_Consecutive failed logins limit exceeded. Your account has been temporarily disabled. Please wait 14 minutes for your account to be unlocked._
+
+This protection applies both to team members signing in to the admin panel and to end users signing in to a realm. The lockout is released only by waiting: there is no manual unlock action in the panel, you have to wait for the time to elapse.
+
+:::tip Tip
+This temporary lockout is different from the _inactive_ status of the [User inactivity period policy](#user-inactivity-period-policy). If a team member reports being unable to sign in, check which of the two cases applies: the failed attempts lockout clears on its own after 15 minutes, whereas the inactive status remains until the user reactivates their account or an account owner activates it again.
+:::
+
 ## Session expiration policy
 
-In this section, you can configure how long a session will remain active.
+In this section, you can configure how long a session will remain active. Both fields are fixed option lists: you choose one of the available values, you do not type a free-form time.
 
-**Session Expiration**: At the end of the selected time, Modyo automatically closes the user's session.
+**Session expiration**: At the end of the selected time, Modyo automatically closes the user's session. The options are 15 minutes, 30 minutes, 1 hour, 2 hours, 12 hours, 1 day, 1 week, 2 weeks, 1 month, and 3 months. If the duration defined in your installation does not match any of them, it also appears as one more option on the list.
 
-**User inactivity period**: When a user is inactive, the session is automatically closed after the selected time has elapsed. Navigation, keyboard, and mouse actions are considered user activities. This option protects the user if they leave their workstation unattended.
+**User idle period**: When a user is inactive, the session is automatically closed after the selected time has elapsed. Navigation, keyboard, and mouse actions are considered user activities. This option protects the user if they leave their workstation unattended. To be able to choose a value, first check the **Enable user idle period** box; the options are 5 minutes, 15 minutes, 30 minutes, 1 hour, and 6 hours.
+
+This session closing is measured in minutes and only ends the open session. Do not confuse it with the [User inactivity period policy](#user-inactivity-period-policy), which is measured in days and marks the user as inactive so that they cannot sign in again.
 
 ## User inactivity period policy
 
@@ -52,9 +70,21 @@ You can locate this option when editing a user in the **Team** section, in the *
 
 ## HTTP access control (Cross-Origin Resource Sharing CORS)
 
-Enables the Cross-Origin Resource Sharing (CORS) functionality to allow access to Modyo resources from other websites.
+The **Cross Origin Resource Sharing** section defines which domains can access Modyo resources. It has three controls:
 
-To grant access to external domains, write them separated by commas, for example, `http://api.mydomain.com, http://mysubdomain.mydomain.com`. By default, wildcards are not allowed in this section. To enable them, you must manually disable SSL through a ticket sent to the [Modyo support area](https://support.modyo.com/hc/en-us).
+- **Enable CORS**: turns the feature on. When you check it, the custom domains of your apps are included automatically, without you having to list them.
+- **Allow all origins**: adds the `*` wildcard to the list of allowed origins, so that any domain can consume your public information in JSON format. When you check it, Modyo asks for confirmation with the notice "If enabled, all domains will have access to your public JSON information. Would you like to continue?".
+- **Alternative origins**: text field to grant access to external domains. Write them separated by commas, for example, `http://api.mydomain.com, http://mysubdomain.mydomain.com`. Wildcards are not accepted in this field: if you include a `*`, the configuration is not saved. From each entry, Modyo keeps only the scheme, the domain, and the port, and discards paths.
+
+When you are done, click **Save**.
+
+:::warning Attention
+**Allow all origins** is enabled from this same screen, with no need to open a support ticket or make any other change to your installation. Because it puts your account's public information within reach of any domain, reserve it for development or testing environments and, in production, list the domains in **Alternative origins**.
+:::
+
+:::tip Tip
+The automatic inclusion covers the primary domain of each app. If you publish an app on an alternative domain, or if the origin making the calls uses a different scheme or port, add it in **Alternative origins**, because the origin comparison is exact.
+:::
 
 ## Content Delivery Token (JWT - JSON Web Token)
 

--- a/docs/es/platform/core/security.md
+++ b/docs/es/platform/core/security.md
@@ -45,7 +45,7 @@ En esta sección puedes configurar el tiempo que permanecerá activa una sesión
 
 **Expiración de sesión**: Al concluirse el tiempo seleccionado, Modyo cierra la sesión del usuario automáticamente. Las opciones son 15 minutos, 30 minutos, 1 hora, 2 horas, 12 horas, 1 día, 1 semana, 2 semanas, 1 mes y 3 meses. Si la duración definida en tu instalación no coincide con ninguna de ellas, aparece además como una opción más de la lista.
 
-**Período de inactividad del usuario**: Cuando un usuario está inactivo se cierra la sesión automáticamente, una vez transcurrido el tiempo seleccionado. Se considera acciones de navegación, teclado y mouse como actividades de usuario. Esta opción protege al usuario en caso de dejar su estación de trabajo desatendida. Para poder elegir un valor, primero marca la casilla **Activar el periodo de inactividad del usuario**; las opciones son 5 minutos, 15 minutos, 30 minutos, 1 hora y 6 horas.
+**Período de inactividad del usuario**: Cuando un usuario está inactivo se cierra la sesión automáticamente, una vez transcurrido el tiempo seleccionado. Se consideran las acciones de navegación, teclado y mouse como actividades de usuario. Esta opción protege al usuario en caso de dejar su estación de trabajo desatendida. Para poder elegir un valor, primero marca la casilla **Activar el periodo de inactividad del usuario**; las opciones son 5 minutos, 15 minutos, 30 minutos, 1 hora y 6 horas.
 
 Este cierre de sesión se mide en minutos y solo termina la sesión abierta. No lo confundas con la [Política de Periodo de Inactividad de los Usuarios](#politica-de-periodo-de-inactividad-de-los-usuarios), que se mide en días y marca al usuario como inactivo para que no pueda volver a iniciar sesión.
 

--- a/docs/es/platform/core/security.md
+++ b/docs/es/platform/core/security.md
@@ -17,19 +17,37 @@ Esta guía te presenta las recomendaciones más relevantes para lograr este obje
 En esta sección puedes establecer la política de seguridad de contraseñas para los miembros del equipo.  Las opciones disponibles son:
 
 - **Valor mínimo de longitud de contraseña**: Este valor determina la longitud mínima que debe tener una contraseña, debe tener entre 12 y 128 caracteres.
-- **Requerir por lo menos una letra minúscula (a - z)**: Esta opción garantiza que la contraseña contenga al menos una letra minúscula.
-- **Requerir por lo menos una letra mayúscula (A - Z)**: Esta opción garantiza que la contraseña contenga al menos una letra mayúscula.
-- **Requerir por lo menos un carácter no alfanumérico (! @ # $ % ^ & * () _ + - = [] {} |)**: Esta opción exige que las contraseñas de los miembros del equipo contengan al menos uno de los caracteres especiales indicados.
+- **Requerir por lo menos una letra minúscula del alfabeto Latino (a - z)**: Esta opción garantiza que la contraseña contenga al menos una letra minúscula.
+- **Requerir por lo menos una letra mayúscula del alfabeto Latino (A - Z)**: Esta opción garantiza que la contraseña contenga al menos una letra mayúscula.
+- **Se requiere al menos uno de estos caracteres especiales**: Esta opción exige que las contraseñas de los miembros del equipo contengan al menos uno de los símbolos que la propia casilla enumera entre paréntesis. El conjunto predeterminado es `! @ # $ % ^ & * ( ) _ + º - = [ ] { } | " . ' ¿ / ¡ : ;`, y el listado que ves en pantalla es siempre el que valida tu instalación.
 
 Al guardar esta configuración, los usuarios deberán cumplir con estas condiciones al momento de cambiar su contraseña.
 
+:::warning Atención
+Al activar **Se requiere al menos uno de estos caracteres especiales**, la contraseña también queda limitada a ese alfabeto: solo se aceptan letras de la `a` a la `z`, en mayúscula o minúscula, dígitos y los símbolos del listado. Cualquier otro carácter hace que la contraseña se rechace, aunque sea larga y cumpla el resto de las condiciones. Esto incluye las vocales acentuadas, la `ñ` y símbolos como `~`, `<` o `>`.
+:::
+
+## Bloqueo por Intentos Fallidos de Inicio de Sesión
+
+Además de la política de contraseñas, Modyo protege el inicio de sesión frente a ataques de fuerza bruta. Tras 10 intentos fallidos consecutivos, el usuario queda bloqueado temporalmente durante 15 minutos y el mensaje de error le indica cuánto falta para el desbloqueo:
+
+_Se superó el límite de inicios de sesión fallidos. Tu cuenta ha sido deshabilitada temporalmente. Por favor, espere 14 minutos para que tu cuenta se desbloquee._
+
+Esta protección aplica tanto a los miembros del equipo que entran al panel de administración como a los usuarios finales que inician sesión en un reino. El bloqueo se libera solo por tiempo: no hay una acción de desbloqueo manual en el panel, hay que esperar a que se cumpla el plazo.
+
+:::tip Tip
+Este bloqueo temporal es distinto del estado _inactivo_ de la [Política de Periodo de Inactividad de los Usuarios](#politica-de-periodo-de-inactividad-de-los-usuarios). Si un miembro del equipo reporta que no puede entrar, revisa cuál de los dos casos aplica: el bloqueo por intentos fallidos se levanta por sí solo a los 15 minutos, mientras que el estado inactivo se mantiene hasta que el usuario reactiva su cuenta o un dueño de la cuenta lo vuelve a activar.
+:::
+
 ## Política de Expiración de Sesiones
 
-En esta sección puedes configurar el tiempo que permanecerá activa una sesión.
+En esta sección puedes configurar el tiempo que permanecerá activa una sesión. Los dos campos son listas de opciones fijas: eliges uno de los valores disponibles, no escribes un tiempo libre.
 
-**Expiración de sesión**: Al concluirse el tiempo seleccionado, Modyo cierra la sesión del usuario automáticamente.
+**Expiración de sesión**: Al concluirse el tiempo seleccionado, Modyo cierra la sesión del usuario automáticamente. Las opciones son 15 minutos, 30 minutos, 1 hora, 2 horas, 12 horas, 1 día, 1 semana, 2 semanas, 1 mes y 3 meses. Si la duración definida en tu instalación no coincide con ninguna de ellas, aparece además como una opción más de la lista.
 
-**Período de inactividad de usuario**: Cuando un usuario está inactivo se cierra la sesión automáticamente, una vez transcurrido el tiempo seleccionado. Se considera acciones de navegación, teclado y mouse como actividades de usuario. Esta opción protege al usuario en caso de dejar su estación de trabajo desatendida.
+**Período de inactividad del usuario**: Cuando un usuario está inactivo se cierra la sesión automáticamente, una vez transcurrido el tiempo seleccionado. Se considera acciones de navegación, teclado y mouse como actividades de usuario. Esta opción protege al usuario en caso de dejar su estación de trabajo desatendida. Para poder elegir un valor, primero marca la casilla **Activar el periodo de inactividad del usuario**; las opciones son 5 minutos, 15 minutos, 30 minutos, 1 hora y 6 horas.
+
+Este cierre de sesión se mide en minutos y solo termina la sesión abierta. No lo confundas con la [Política de Periodo de Inactividad de los Usuarios](#politica-de-periodo-de-inactividad-de-los-usuarios), que se mide en días y marca al usuario como inactivo para que no pueda volver a iniciar sesión.
 
 ## Política de Periodo de Inactividad de los Usuarios
 
@@ -52,9 +70,21 @@ Puedes localizar esta opción al editar un usuario en la sección **Equipo**, en
 
 ## Control de Acceso HTTP (Cross-Origin Resource Sharing CORS)
 
-Habilita la funcionalidad de Compartir Recursos de Origen Cruzado (CORS) para permitir el acceso a los recursos de Modyo desde otras páginas web.
+La sección **Cross Origin Resource Sharing** define desde qué dominios se puede acceder a los recursos de Modyo. Tiene tres controles:
 
-Para dar acceso a dominios externos, escríbelos separados por comas, por ejemplo `http://api.mydomain.com, http://mysubdomain.mydomain.com`. Por defecto, los wildcards no están permitidos en esta sección. Para habilitarlos, deberás deshabilitar manualemente el SSL a través de un ticket enviado area de [soporte de Modyo](https://support.modyo.com/hc/en-us).
+- **Habilitar CORS**: activa la funcionalidad. Al marcarla, los dominios personalizados de tus aplicaciones se incluyen automáticamente, sin que tengas que listarlos.
+- **Permitir todos los orígenes**: agrega el comodín `*` a la lista de orígenes permitidos, de modo que cualquier dominio puede consumir la información pública en formato JSON. Al marcarla, Modyo pide confirmación con el aviso "Si está activado, todos los dominios tendrán acceso al JSON público ¿Te gustaría continuar?".
+- **Orígenes alternativos**: campo de texto para dar acceso a dominios externos. Escríbelos separados por comas, por ejemplo `http://api.mydomain.com, http://mysubdomain.mydomain.com`. En este campo no se aceptan comodines: si incluyes un `*`, la configuración no se guarda. De cada entrada, Modyo conserva solo el esquema, el dominio y el puerto, y descarta las rutas.
+
+Cuando termines, haz clic en **Guardar**.
+
+:::warning Atención
+**Permitir todos los orígenes** se activa desde esta misma pantalla, sin necesidad de abrir un ticket de soporte ni de hacer ningún otro cambio en tu instalación. Como deja la información pública de tu cuenta al alcance de cualquier dominio, resérvala para ambientes de desarrollo o pruebas y, en producción, enumera los dominios en **Orígenes alternativos**.
+:::
+
+:::tip Tip
+La inclusión automática cubre el dominio principal de cada aplicación. Si publicas una aplicación en un dominio alternativo, o si el origen que hace las llamadas usa otro esquema u otro puerto, agrégalo en **Orígenes alternativos**, porque la comparación del origen es exacta.
+:::
 
 ## Token de Entrega de Contenido (JWT - JSON Web Token)
 


### PR DESCRIPTION
## Cambios propuestos

Actualiza la página de Seguridad para que refleje la pantalla real de **Configuración > Seguridad**: quita la instrucción de abrir un ticket de soporte para usar comodines en CORS, completa la política de contraseñas, enumera las opciones de expiración de sesión y documenta el bloqueo por intentos fallidos de inicio de sesión.

Cierra los gaps ROLES-SEGURIDAD-17, ROLES-SEGURIDAD-EX-01, ROLES-SEGURIDAD-EX-03 y ROLES-SEGURIDAD-19.

### docs/es/platform/core/security.md

- **Política de Contraseñas** (ROLES-SEGURIDAD-EX-01): corrige los nombres de las tres casillas, que en el panel son "Requerir por lo menos una letra minúscula del alfabeto Latino (a - z)", "Requerir por lo menos una letra mayúscula del alfabeto Latino (A - Z)" y "Se requiere al menos uno de estos caracteres especiales". Completa el conjunto de símbolos, al que le faltaban nueve caracteres (`º " . ' ¿ / ¡ : ;`), y aclara que el listado que manda es el que muestra la casilla en pantalla. Agrega un aviso con lo que más consultas genera: al activar esa opción la contraseña queda restringida a letras de la `a` a la `z`, dígitos y esos símbolos, así que las vocales acentuadas, la `ñ` o caracteres como `~`, `<` y `>` se rechazan aunque la contraseña sea larga.
- **Bloqueo por Intentos Fallidos de Inicio de Sesión** (ROLES-SEGURIDAD-19): sección nueva, ubicada junto a la política de contraseñas. Documenta que tras 10 intentos fallidos consecutivos el usuario queda bloqueado 15 minutos, que el mensaje de error indica el tiempo restante, que aplica igual al panel de administración y a los usuarios finales de un reino, y que el bloqueo se libera solo por tiempo. Incluye un Tip que lo diferencia del estado inactivo, que es la confusión habitual cuando un administrador reporta que no puede entrar.
- **Política de Expiración de Sesiones** (ROLES-SEGURIDAD-EX-03): enumera los valores de los dos selectores, que son conjuntos cerrados. **Expiración de sesión** ofrece 15 minutos, 30 minutos, 1 hora, 2 horas, 12 horas, 1 día, 1 semana, 2 semanas, 1 mes y 3 meses, más la duración de la instalación si es distinta; **Período de inactividad del usuario** ofrece 5, 15 y 30 minutos, 1 hora y 6 horas y requiere marcar antes la casilla **Activar el periodo de inactividad del usuario**. Corrige el label del campo, que decía "de usuario" en lugar de "del usuario", y separa explícitamente los dos conceptos de inactividad que la página mezclaba: el cierre de sesión en minutos y el marcado del usuario como inactivo en días.
- **Control de Acceso HTTP (CORS)** (ROLES-SEGURIDAD-17): elimina la afirmación falsa de que para usar comodines hay que deshabilitar el SSL mediante un ticket de soporte. La sección se reescribe con sus tres controles reales: **Habilitar CORS**, que además incluye automáticamente los dominios personalizados de tus aplicaciones; **Permitir todos los orígenes**, que es autoservicio, pide confirmación y agrega el comodín `*`; y **Orígenes alternativos**, el único lugar donde efectivamente no se aceptan comodines. Agrega el aviso de exposición del JSON público y una nota sobre que la comparación del origen es exacta, por lo que los dominios alternativos, otros esquemas u otros puertos hay que listarlos.

### docs/en/platform/core/security.md

Espejo en inglés de los cuatro cambios, con los labels tomados del locale en inglés del panel ("Require at least one of these special characters", "Enable user idle period", "User idle period", "Enable CORS", "Allow all origins", "Alternative origins") y una sección nueva "Lockout after failed login attempts".

## Para el revisor

1. Los labels de la política de contraseñas ya no son los que estaban publicados: la casilla de símbolos hoy se llama "Se requiere al menos uno de estos caracteres especiales" y las de minúscula/mayúscula agregan "del alfabeto Latino" (config/locales/admin/es.yml:6844-6850). Los cambié para que coincidan con la pantalla; si el revisor tiene una captura antigua, va a parecer una discrepancia y no lo es.
2. El conjunto de símbolos es parametrizable por instalación (PasswordPolicy::PASSWORD_SYMBOLS se resuelve al arrancar), así que documenté el conjunto predeterminado y remití al listado de la casilla, sin nombrar la configuración del operador. Si en el futuro se acota el conjunto, la página sigue siendo correcta.
3. Mismo gap, otra página fuera de esta tanda: docs/es/platform/customers/settings.md:364 y su espejo en inglés repiten la lista incompleta "! @ # $ % ^ & * () _ + - = [] {} |" para la política de contraseñas del reino. No la toqué porque la tanda apunta solo a security.md; queda pendiente para la tanda de Customers.
4. En la lista de **Expiración de sesión** hablé de "la duración definida en tu instalación" para cubrir el valor extra que EXPIRE_AFTER agrega desde la configuración de sesión de la aplicación, sin nombrar variables ni parámetros de operaciones. Es el único punto donde la lista puede verse distinta a la documentada.
5. Del bloqueo por intentos fallidos afirmé solo lo verificable en el repo: límite 10, ban de 900 segundos, mensaje con tiempo restante y ausencia de acción de desbloqueo en el panel. No afirmé nada sobre si un intento nuevo durante el bloqueo reinicia el contador, porque eso depende de la implementación de Authlogic 6.6.0 y la gema no está en el árbol para confirmarlo. Dato adicional que dejé fuera a propósito: para usuarios de un reino, la API de administración acepta failed_login_count al actualizar un usuario (app/controllers/api/admin/customers/users_controller.rb:245), o sea que por API se puede levantar el bloqueo; si quieres documentarlo, corresponde a la página de la API de Customers.
6. Preexistente y no tocado: docs/es/platform/key-concepts.md:75 enlaza a /es/platform/core/security#politica-de-contrasena, un anclaje que ya no coincide con el título "Política de Contraseñas". No cambié ningún encabezado existente, así que ese enlace queda igual de roto que antes.

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)
