### PR TITLE
Corregir las validaciones mal documentadas de Tipos de contenido y el cupo por plan

### DIFF
--- a/docs/en/platform/content/types.md
+++ b/docs/en/platform/content/types.md
@@ -47,7 +47,7 @@ Cardinality refers to the number of entries that can exist for that content type
 :::
 
 :::warning Attention
-Please note that there is a limit of 50 Content Types per Space.
+The number of content types you can create per space is set by your account plan, and the default is 50. If you try to create one beyond the quota, creation fails with the message "You've reached the maximum number of content types on this space". If you need a larger quota, talk to your Modyo account manager.
 :::
 
 In the creation interface, you'll find an empty template in the center of the screen and on the right side, a table with three tabs:
@@ -77,6 +77,13 @@ This field allows you to enter single-line texts. It has the following restricti
 - **Minimum length**: Allows you to require a minimum number of characters for the entered text.
 - **Maximum length**: Allows you to limit the maximum number of characters for the entered text.
 - **Validation by regular expression**: Allows you to add a regular expression to validate that the entered text, when creating or modifying an entry, complies with a certain format.
+- **Unique**: Requires that the value isn't repeated in other entries of the same type. This is the platform's only uniqueness validation, and Single-line text is the only field that offers it. If the value is already in use, the entry isn't saved and the field shows "Must be unique".
+
+The scope of **Unique** is the whole type: the comparison goes through every entry of the type, including drafts, scheduled entries, and translations into other languages. Backup versions and the entry you are editing are left out, so republishing an entry never collides with itself. An empty field is never considered repeated.
+
+:::warning Attention
+**Unique** has no effect on a field that lives inside a **Group**. The checkbox is still displayed when you configure the field, but the validation isn't evaluated and repeated values are saved without an error. If you need to guarantee uniqueness, keep the field outside the group.
+:::
 
 ### Rich text
 
@@ -99,7 +106,11 @@ This field allows you to add a list from which you can select more than one opti
 
 ### Multiple choice
 
-This field allows you to add a text field in which you can type to select an option; it can be predetermined or proposed.
+This field allows you to pick one or more values from a search box that filters as you type. The search box only offers the values defined in the type: when you edit an entry, you can't propose a new value from the field. Values are managed in **Allowed values**, when you configure the field.
+
+:::warning Attention
+If you load this field through the API, send the exact labels of the allowed values or the identifiers the API returns. Text that doesn't match any label is silently discarded: the entry is saved without that value and without an error message. A numeric identifier that doesn't belong to the field, on the other hand, prevents the entry from being saved.
+:::
 
 ### Allowed values
 
@@ -120,17 +131,21 @@ This field allows you to add a question or statement (True or False).
 
 ### Integer
 
-This field allows you to add an integer. By default, the value must be in the range of `-65325` to `+65325`. However, you can adjust these limits by applying the following restrictions:
+This field allows you to add an integer between `-2147483648` and `2147483647`. You can narrow that range with the following restrictions:
 
-- **Minimum length**: Sets the minimum number of characters for the entered text.
-- **Maximum length**: Sets the maximum number of characters for the entered text.
+- **Min value**: Rejects values lower than the number you set.
+- **Max value**: Rejects values higher than the number you set.
+
+Both restrictions bound the value of the number, not the number of digits. Leave them empty to apply no such limit. If the number falls outside the range, the entry isn't saved and the field shows "Invalid number. Must be greater than or equal to 18" or "Invalid number. Must be less than or equal to 120", with the limits you configured.
 
 ### Decimal
 
-Use this field to enter a decimal number. The number must be, obligatorily, between `-65325` and `+65325`. However, it can be limited by making use of the restrictions:
+Use this field to enter a number with decimals. It supports up to two decimal places and values between `-9999999999999.99` and `9999999999999.99`. If you save more than two decimal places, the value is rounded without warning you: `10.567` is stored as `10.57`. You can narrow the range with the following restrictions:
 
-- **Minimum length**: Allows you to set a minimum number of characters for the entered text.
-- **Maximum length**: Allows you to limit the maximum number of characters for the entered text.
+- **Min value**: Rejects values lower than the number you set.
+- **Max value**: Rejects values higher than the number you set.
+
+Both restrictions bound the value of the number, not the number of digits, and they only accept whole numbers: to require a positive amount, for example, use `0` as **Min value**. If the number falls outside the range, the entry isn't saved and the field shows "Invalid number. Must be less than or equal to", with the limit you configured.
 
 ### Date
 
@@ -163,13 +178,13 @@ This field allows you to attach multiple files to the entry, using the file mana
 
 Use this field to link an Entry to another existing and published Entry within the Space. This field has the following restrictions:
 
-- **Restrict type**: Allows you to select a default type so that only entries of the specified type can be selected as a link.
+- **Allowed content type**: Limits the link to entries of one type. You select a single type, and the default value is **All**, which doesn't restrict anything. If the linked entry isn't of the chosen type, the entry isn't saved and the field shows "Does not match with allowed value", followed by the name of the required type.
 
 ### Content list (link to many)
 
 This field allows you to link more than one existing Entry within the Space to another Entry. This field has the following restrictions:
 
-- **Restrict type**: Allows you to select a default type so that only entries of the selected type can be selected as a link.
+- **Allowed content type**: Limits the links to entries of one type. You select a single type, which applies to every entry you link, and the default value is **All**, which doesn't restrict anything. If any of the linked entries isn't of the chosen type, the entry isn't saved and the field shows "Does not match with allowed value", followed by the name of the required type.
 
 ### Group
 
@@ -184,7 +199,7 @@ You can validate the contents of the fields as follows:
 - **Required**: Check the **Required** box to force the group or field to be completed.
   - If you mark the group as required, at least one item within the group must be completed.
   - If you mark an item as required, that item must have content.
-- **Unique**: When you mark an entry as unique, its content cannot be repeated within the same group.
+- **Unique**: Doesn't apply inside a group. The checkbox does appear when you configure a [Single-line text](#single-line-text) field that lives inside the group, but the validation isn't evaluated and repeated values are saved without an error.
 
 :::tip Tip
 A group can host any type of field, except another group.

--- a/docs/es/platform/content/types.md
+++ b/docs/es/platform/content/types.md
@@ -47,7 +47,7 @@ La cardinalidad se refiere al número de entradas que pueden existir para ese ti
 :::
 
 :::warning Atención
-Es importante tener en cuenta que existe un límite de 50 Tipos de Contenido por Espacio.
+El número de tipos de contenido que puedes crear por espacio lo define el plan de tu cuenta, y por defecto son 50. Al intentar crear uno más allá del cupo, la creación falla con el mensaje "Has alcanzado el número máximo de tipos de contenido para el plan actual". Si necesitas un cupo mayor, conversa con tu ejecutivo de cuenta en Modyo.
 :::
 
 En la interfaz de creación, encontrarás una plantilla vacía en el centro de la pantalla y al lado derecho, una tabla con tres pestañas: 
@@ -77,6 +77,13 @@ Este campo te permite ingresar textos de una sola linea. Cuenta con las siguient
 - **Largo mínimo**: Permite exigir un mínimo de caracteres para el texto ingresado.
 - **Largo máximo**: Permite  limitar la cantidad máxima de caracteres para el texto ingresado.
 - **Validación por expresión regular**: Te permite añadir una expresión regular para validar que el texto ingresado, al crear o modificar una entrada, cumpla con un formato determinado.
+- **Único**: Exige que el valor no se repita en otras entradas del mismo tipo. Es la única validación de unicidad de la plataforma, y Texto de una línea es el único campo que la ofrece. Si el valor ya está en uso, la entrada no se guarda y el campo muestra "Debe ser único".
+
+El alcance de **Único** es el tipo completo: la comparación recorre todas las entradas del tipo, incluidas las que están en borrador o programadas y las traducciones a otros idiomas. Quedan fuera las versiones de respaldo y la propia entrada que estás editando, así que volver a publicar una entrada no choca consigo misma. Un campo vacío no se considera repetido.
+
+:::warning Atención
+**Único** no tiene efecto sobre un campo que está dentro de un **Grupo**. La casilla se sigue mostrando al configurar el campo, pero la validación no se evalúa y los valores repetidos se guardan sin error. Si necesitas garantizar unicidad, deja el campo fuera del grupo.
+:::
 
 ### Texto enriquecido
 
@@ -99,7 +106,11 @@ Este campo te permite agregar una lista de la cual puedes seleccionar más de un
 
 ### Opciones múltiples
 
-Este campo te permite agregar un campo de texto en el cual puedes escribir para seleccionar una opción; puede ser predeterminada o propuesta.
+Este campo te permite elegir uno o más valores desde un buscador que filtra a medida que escribes. El buscador solo ofrece los valores definidos en el tipo: al editar una entrada no puedes proponer un valor nuevo desde el campo. Los valores se administran en **Valores permitidos**, al configurar el campo.
+
+:::warning Atención
+Si cargas este campo por la API, envía las etiquetas exactas de los valores permitidos o los identificadores que devuelve la API. Un texto que no coincide con ninguna etiqueta se descarta en silencio: la entrada se guarda sin ese valor y sin mensaje de error. Un identificador numérico que no pertenece al campo, en cambio, impide guardar la entrada.
+:::
 
 ### Valores permitidos
 
@@ -120,17 +131,21 @@ Este campo te permite agregar una pregunta o afirmación (Verdadero/True o Falso
 
 ### Entero
 
-Este campo te permite agregar un número entero.  Por defecto, el valor debe estar en el rango de `-65325`a `+65325`. Sin embargo, puedes ajustar estos límites aplicando las siguientes restricciones:
+Este campo te permite agregar un número entero entre `-2147483648` y `2147483647`. Puedes acotar ese rango con las siguientes restricciones:
 
-- **Largo mínimo**: Establece el número mínimo de caracteres para el texto ingresado.
-- **Largo máximo**: Establece el número máximo de caracteres para el texto ingresado.
+- **Valor mínimo**: Rechaza los valores menores al número que indiques.
+- **Valor máximo**: Rechaza los valores mayores al número que indiques.
+
+Ambas restricciones acotan el valor del número, no la cantidad de dígitos. Déjalas vacías para no aplicar ese límite. Si el número queda fuera del rango, la entrada no se guarda y el campo muestra "Número inválido. Debe ser mayor o igual que 18" o "Número inválido. Debe ser menor o igual que 120", con los límites que hayas configurado.
 
 ### Decimal
 
-Utiliza este campo para ingresar un número decimal. El número debe ser, obligatoriamente, entre `-65325` y `+65325`. Sin embargo, se puede acotar haciendo uso de las restricciones:
+Utiliza este campo para ingresar un número con decimales. Admite hasta dos decimales y valores entre `-9999999999999.99` y `9999999999999.99`. Si guardas más de dos decimales, el valor se redondea sin avisarte: `10.567` queda almacenado como `10.57`. Puedes acotar el rango con las siguientes restricciones:
 
-- **Largo mínimo**: Permite establecer un mínimo de caracteres para el texto ingresado.
-- **Largo máximo**: Permite limitar la cantidad máxima de caracteres para el texto ingresado.
+- **Valor mínimo**: Rechaza los valores menores al número que indiques.
+- **Valor máximo**: Rechaza los valores mayores al número que indiques.
+
+Ambas restricciones acotan el valor del número, no la cantidad de dígitos, y solo aceptan números enteros: para exigir un monto positivo, por ejemplo, usa `0` como **Valor mínimo**. Si el número queda fuera del rango, la entrada no se guarda y el campo muestra "Número inválido. Debe ser menor o igual que", con el límite que hayas configurado.
 
 ### Fecha
 
@@ -163,13 +178,13 @@ Este campo te permite adjuntar múltiples archivos a la entrada, usando el gesto
 
 Utiliza este campo para vincular una Entrada a otra Entrada existente y publicada dentro del Espacio. Este campo tiene las siguientes restricciones:
 
-- **Restringir tipo**: Te permite seleccionar un tipo predeterminado para que solo se puedan seleccionar, como enlace, entradas del tipo especificado.
+- **Tipos de contenido permitidos**: Limita el enlace a las entradas de un tipo. Pese al plural del nombre, seleccionas un único tipo; el valor por defecto es **Todos**, que no restringe nada. Si la entrada enlazada no es del tipo elegido, la entrada no se guarda y el campo muestra "No calza con los valores permitidos", seguido del nombre del tipo exigido.
 
 ### Listado de Contenido (enlace a varias)
 
 Este campo te permite vincular más de una Entrada existente dentro del Espacio a otra Entrada. Este campo tiene las siguientes restricciones:
 
-- **Restringir tipo**: Te permite seleccionar un tipo predeterminado para solo se puedan seleccionar, como enlace, entradas del tipo seleccionado.
+- **Tipos de contenido permitidos**: Limita los enlaces a las entradas de un tipo. Pese al plural del nombre, seleccionas un único tipo, que aplica a todas las entradas que enlaces; el valor por defecto es **Todos**, que no restringe nada. Si cualquiera de las entradas enlazadas no es del tipo elegido, la entrada no se guarda y el campo muestra "No calza con los valores permitidos", seguido del nombre del tipo exigido.
 
 ### Grupo
 
@@ -184,7 +199,7 @@ Puedes validar el contenido de los campos de la siguiente forma:
 - **Requerido**: Marca la casilla **Requirido** para obligar a que se complete el grupo o campo.
   - Si marcas el grupo como requerido, al menos un elemento dentro del grupo deberá ser completado. 
   - Si marcas un elemento como requerido, ese elemento tiene que tener contenido.
-- **Unique**: Cuando marcas una entrada como única, no puede repetirse su contenido dentro del mismo grupo. 
+- **Único**: No aplica dentro de un grupo. La casilla aparece al configurar un campo de [Texto de una línea](#texto-de-una-linea) que esté dentro del grupo, pero la validación no se evalúa y los valores repetidos se guardan sin error.
 
 :::tip Tip
 Un grupo puede albergar cualquier tipo de campo, menos otro grupo. 

--- a/docs/es/platform/content/types.md
+++ b/docs/es/platform/content/types.md
@@ -47,7 +47,7 @@ La cardinalidad se refiere al número de entradas que pueden existir para ese ti
 :::
 
 :::warning Atención
-El número de tipos de contenido que puedes crear por espacio lo define el plan de tu cuenta, y por defecto son 50. Al intentar crear uno más allá del cupo, la creación falla con el mensaje "Has alcanzado el número máximo de tipos de contenido para el plan actual". Si necesitas un cupo mayor, conversa con tu ejecutivo de cuenta en Modyo.
+El número de tipos de contenido que puedes crear por espacio lo define el plan de tu cuenta, y por defecto es 50. Al intentar crear uno más allá del cupo, la creación falla con el mensaje "Has alcanzado el número máximo de tipos de contenido para el plan actual". Si necesitas un cupo mayor, conversa con tu ejecutivo de cuenta en Modyo.
 :::
 
 En la interfaz de creación, encontrarás una plantilla vacía en el centro de la pantalla y al lado derecho, una tabla con tres pestañas: 
@@ -196,7 +196,7 @@ No hay límite en la cantidad de campos que puedes incluir dentro de un grupo.
 
 Puedes validar el contenido de los campos de la siguiente forma: 
 
-- **Requerido**: Marca la casilla **Requirido** para obligar a que se complete el grupo o campo.
+- **Requerido**: Marca la casilla **Requerido** para obligar a que se complete el grupo o campo.
   - Si marcas el grupo como requerido, al menos un elemento dentro del grupo deberá ser completado. 
   - Si marcas un elemento como requerido, ese elemento tiene que tener contenido.
 - **Único**: No aplica dentro de un grupo. La casilla aparece al configurar un campo de [Texto de una línea](#texto-de-una-linea) que esté dentro del grupo, pero la validación no se evalúa y los valores repetidos se guardan sin error.


### PR DESCRIPTION
## Cambios propuestos

Corrige cinco imprecisiones de la página de Tipos de contenido, todas verificadas contra el código de la plataforma. Cierra CONTENT-03, CONTENT-04, CONTENT-23, CONTENT-24 y CONTENT-25.

El cambio toca `docs/es/platform/content/types.md` y su espejo `docs/en/platform/content/types.md`, con ediciones equivalentes en ambos idiomas.

### Crear un Tipo (CONTENT-25)

El callout publicaba el cupo de 50 tipos por espacio como si fuera una constante del producto. En realidad el tope lo fija el plan de la cuenta y 50 es solo el valor por defecto, así que ahora se dice explícitamente y se cita el mensaje que ve el administrador cuando lo alcanza. Un administrador que necesita más tipos ya no queda con la idea de que es una limitación técnica.

### Texto de una línea (CONTENT-23)

Faltaba la validación **Único**, que es la cuarta restricción del campo y el único lugar de la plataforma donde se ofrece. Se agrega el bullet, se documenta su alcance real (todas las entradas del tipo, incluidas borradores, programadas y traducciones; quedan fuera los respaldos y la propia entrada en edición) y se advierte que la validación no tiene efecto si el campo está dentro de un **Grupo**, aunque la casilla se siga mostrando.

### Opciones múltiples (CONTENT-03)

El texto decía que el valor "puede ser predeterminada o propuesta", lo que hacía creer que el editor de contenido puede proponer un valor nuevo desde el campo. No es así: el buscador solo filtra entre los valores definidos en el tipo. Se reescribe la descripción, se apunta a **Valores permitidos** como el lugar donde se administran los valores y se documenta el comportamiento por API, que tiene dos ramas distintas: un texto sin coincidencia se descarta en silencio, mientras que un identificador numérico ajeno al campo impide guardar la entrada.

### Entero y Decimal (CONTENT-04)

Las dos fichas describían sus restricciones como largo en caracteres, con los labels **Largo mínimo** y **Largo máximo**, que no existen en estos campos, y publicaban un rango de `-65325` a `+65325` que no aparece en ninguna parte del código. Se corrigen las tres cosas:

- Los labels reales son **Valor mínimo** y **Valor máximo**, y acotan el valor del número, no la cantidad de dígitos.
- El rango de Entero es `-2147483648` a `2147483647`.
- Decimal admite hasta dos decimales y valores hasta `9999999999999.99`; los decimales adicionales se redondean al guardar sin avisar, así que se documenta con un ejemplo.
- Se agregan los mensajes de error que ve el editor y la nota de que los cuadros de mínimo y máximo solo aceptan números enteros.

### Contenido y Listado de Contenido (CONTENT-24)

La validación se llamaba "Restringir tipo", un label que no existe en el panel. Se corrige a **Tipos de contenido permitidos** en ambos campos, se aclara que pese al plural se selecciona un único tipo, se menciona el valor por defecto **Todos** y se agrega el mensaje de error asociado.

### Grupo (CONTENT-23)

El bullet afirmaba que al marcar una entrada como única su contenido no puede repetirse dentro del mismo grupo. Es falso en los dos sentidos: la unicidad nunca fue intra-grupo y, sobre todo, la validación es un no-op para cualquier campo que esté dentro de un grupo. Se reemplaza por la descripción correcta, con enlace a la sección donde se explica el alcance real.

## Para el revisor

Cosas que conviene mirar con cuidado:

1. **Mensaje de cupo en inglés.** El locale trae `You´ve reached the maximum number of content types on this space` (en.yml:6530), con apóstrofo tipográfico erróneo y sin mencionar el plan, a diferencia del español. Lo cité normalizando el apóstrofo a `You've` para que la página no reproduzca el error de tipeo del producto, y mantuve la explicación del plan en prosa. Si prefieres cita literal, el old_string sigue siendo válido y solo hay que cambiar ese caracter.

2. **La ficha de CONTENT-03 cita un párrafo que no existe.** Decía que types.md:106 explica que las opciones se gestionan en la sección Valores permitidos del tipo. No hay tal párrafo: `grep -rn "Valores permitidos|Allowed values" docs/es docs/en` no devuelve nada, y la línea 106 es la descripción del campo Booleano. Agregué yo la mención a **Valores permitidos**, con el label verificado en es.yml:1255 / en.yml:1254.

3. **Nota de enteros en los cuadros de mínimo y máximo.** Está sostenida por `precision={0}` (FieldValidation.js:50) más el regex de FFNumber.js:20 (`\.\d{0,0}`), que rechaza decimales. Deliberadamente NO afirmé que no se puedan ingresar valores negativos, aunque el input lleve `min={0}`: ese atributo HTML no impide que un valor tecleado llegue al estado, y no quise publicar algo que no pude comprobar en el navegador. Si alguien lo valida en el panel, vale la pena agregarlo.

4. **Labels de largo en la página en inglés.** Fuera del alcance de esta tanda, pero el mismo defecto de CONTENT-04 existe en las secciones Single-line text y Rich text de la página en inglés: usan "Minimum length" / "Maximum length" cuando el panel dice **Min length** / **Max length** (en.yml:1240-1242). No lo toqué porque ninguna ficha lo pide. Queda como gap nuevo.

5. **Label del campo con tilde faltante en el locale.** es.yml:1069 trae `string: Texto de una linea`, sin acento. Como la página usa "Texto de una línea" en el encabezado y en todo el cuerpo, no puse ese label en negrita como cita de UI: en el bullet del Grupo lo dejé como enlace a la sección, que evita el conflicto entre el texto real del panel y la ortografía de la documentación.

6. **Cupo de espacios sin documentar.** CONTENT-25 sugiere darle el mismo tratamiento al cupo de espacios (`max_spaces`, default 50 en db/schema.rb:1343, mensaje en es.yml:6535). Lo dejé fuera porque pertenece a spaces.md y esta tanda declara solo types.md. Conviene planificarlo como edición aparte.

7. **Salto de anclaje entre idiomas.** Los dos enlaces nuevos son de misma página (`#texto-de-una-linea` y `#single-line-text`), verificados contra el slugify de VuePress. Si en el futuro se renombra alguno de esos encabezados, hay que actualizar el bullet del Grupo en el idioma correspondiente.

Closes #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)
