### PR TITLE
Documentar el tag menu, actualizar el snippet del tema y completar las opciones del ítem de menú

### DIFF
--- a/docs/en/platform/channels/navigation.md
+++ b/docs/en/platform/channels/navigation.md
@@ -57,7 +57,7 @@ To create a Menu, follow these steps:
 7. Once finished, click **Publish**.
 
 :::tip Tip
-Your menu is now public, but it is not being called. You need to use a template to display it on the screen. Modyo offers a general-purpose snippet in **Snippets, General, menu** and is called in the `base` template using <pre v-pre>`{% snippet 'shared/general/menu' %}`</pre>.
+Your menu is now public, but it is not being called. You need to use a template to display it on the screen. Modyo offers a general-purpose snippet in **Snippets, General, menu**, which the **header** snippet calls twice (once for the desktop bar and once for the mobile side panel) and which reaches your pages because the `base` template includes <pre v-pre>`{% snippet 'shared/general/header' %}`</pre>.
 :::
 
 **Main Action**
@@ -70,8 +70,10 @@ Your menu is now public, but it is not being called. You need to use a template 
 In the right sidebar, you will see a bar that changes according to the item selected in the main area. In this section, you can see the options:
 
 - **Name**: Name of the element as it appears on the site.
-- **Associated Page**: Can be directly associated with a page or a custom URL.
-- **URL**: If you chose a custom URL in the previous item, you have different options to configure this item:
+- **Description**: Free text to accompany the item. It is not printed on the site by itself: it is available in Liquid as `menu_item.description` so you can use it in your own markup, for example as a subtitle for the item or as the text of a notification.
+- **Classes**: String to be used in a class attribute for a HTML tag, for example `mdi mdi-circle`. Just like the description, it is available in Liquid as `menu_item.classes` and you are the one who prints it in the `class` attribute of your markup. Check both attributes in [Objects](/en/platform/channels/liquid-markup/objects.html#menu).
+- **Link**: Destination of the item. You can choose one of the site pages, **URL** to write a custom address, or **Site Search** to point to the site's search page.
+- **URL**: If you chose **URL** in the previous item, you have different options to configure this item:
 	- HTTP(s): Points to an address using HTTP(s). Examples:
 		- http://www.example.com
 		- https://www.example.com
@@ -88,9 +90,76 @@ In the right sidebar, you will see a bar that changes according to the item sele
 		- sms:+569-123-45678,9-123-45678?body=hello%20there&param1=a%20value
 	- Email: Generates a link with the `mailto` URI. Examples:
 		- mailto:info@example.com?subject=subject&cc=cc@example.com
-- **Open in new tab**: Adds the `target='blank'` attribute to the menu item's HTML element, so that when clicked, it opens in a new tab.
+- **Open in a new tab**: Only appears when the destination is a **URL**. Adds the `target="_blank"` and `rel="noopener noreferrer"` attributes to the item's link, so that when clicked, it opens in a new tab.
 - **Private**: Makes the selected element visible only when there is an active user session on the site.
 - **Segments**: If segments are created, you can also segment this element so that users can see this menu item only when they have an active session and are also within the selected segments.
+
+## The menu tag
+
+The <span v-pre>`{% menu %}`</span> tag prints a full menu, dropdowns included, without you having to write the markup. It is the quick path: if you need full control over the HTML, build the menu by hand from `menus`, as shown in the examples below.
+
+### How to call it
+
+The tag takes no parameters: it reads the `menu` variable from the context, so you have to assign it first with the identifier of the menu you want to print.
+
+```liquid
+{% assign menu = menus['main'] %}
+{% menu %}
+```
+
+The variables you assign in a template or in a snippet are available in the snippets called from there, so you can do the `assign` once and reuse it.
+
+:::warning Attention
+If you call the tag without having assigned `menu`, or if the identifier does not match any menu on the site, the page prints an `<!-- Liquid Error -->` comment instead of the menu.
+:::
+
+### HTML it generates
+
+The tag always emits the same structure, designed for the Bootstrap dropdown system:
+
+```html
+<ul class="nav navbar-nav">
+	<li class='nav-item nav-item-home active'>
+		<a class='nav-link ' href='https://yoursite.com/my-site/home'><span>Home</span></a>
+	</li>
+	<li class='nav-item nav-item-products dropdown menu-item'>
+		<a class='nav-link dropdown-toggle' href='https://yoursite.com/my-site/products'><span>Products</span></a>
+		<div class='submenu-1 dropdown-menu'>
+			<a class='dropdown-item' href='https://yoursite.com/my-site/products/accounts'><span>Accounts</span> </a>
+		</div>
+	</li>
+</ul>
+```
+
+These are the hooks you have to apply your styles:
+
+| Element | Classes |
+| ------- | ------- |
+| Container list | `nav navbar-nav` |
+| Item | `nav-item` and `nav-item-` followed by the parameterized label of the item, for example `nav-item-my-products`. `dropdown menu-item` is added if the item has children, and `active` if the item matches the page being viewed |
+| Item link | `nav-link`, plus `dropdown-toggle` if the item has children |
+| Children container | `submenu-N dropdown-menu`, where `N` is the position of the parent item among the visible items, starting at 0 |
+| Child link | `dropdown-item` |
+
+The label of each item is wrapped in a `<span>`, both on the first and the second level.
+
+:::warning Attention
+The tag renders only two levels: the root items and their direct children. Even though navigation lets you nest up to three levels, grandchildren do not appear in the HTML generated by the tag. If you need the third level, build the menu by hand, the way the general `menu` snippet does.
+:::
+
+### Links it generates
+
+- If the item has the **Open in a new tab** option checked, the link is emitted with `target="_blank"` and `rel="noopener noreferrer"`.
+- URLs starting with `http://`, `https://`, `tel:`, `mailto:` or `sms:` are emitted as they are.
+- Any other URL is rewritten as absolute over the site's base URL. An item with the URL `/contact` is emitted as `https://yoursite.com/my-site/contact`, and an anchor such as `#section` is emitted as `https://yoursite.com/my-site/#section`, that is, pointing to the site's home page and not to the page the visitor is on.
+
+### Items that are displayed
+
+- Items marked as **Private** are not printed for visitors without a session.
+- If they also have segments associated, they are only printed for users whose session belongs to one of those segments.
+- Both rules apply equally to root items and to their children: if a parent item is hidden, its dropdown is not printed either.
+
+The resulting menu is reused as long as the page, the user and the menu version do not change, so the changes you publish in navigation are visible on the next visit.
 
 ## Menu Examples
 
@@ -98,39 +167,52 @@ The general `menu` snippet can satisfy the basic needs of a site, displaying a m
 
 The first lines encapsulated by <span v-pre>{{ }} or {% %}</span> belong to Liquid and are used to assign variables or start a loop to display menu information.
 
+Unlike the examples further below, this snippet does not assign the `menu` variable: it inherits it from the **header** snippet, which declares it on its first line with <span v-pre>`{% assign menu = menus['main'] %}`</span> and calls it twice from there. If you copy this markup into another template, remember to assign `menu` before using it.
+
 The following list describes the important variables for the menu:
 
-- menu: This variable takes the menu with identifier `main` within Modyo Platform -> Navigation.
+- menu: Menu that is going to be printed. It is inherited from the snippet that calls `menu`; if you build your own from scratch, assign it with <span v-pre>`{% assign menu = menus['main'] %}`</span>.
 - items_to_show: Takes the visible menu items.
 - active: Used to add a CSS class called `active` if this item is activated.
 - children_to_show: If the current item has children, it takes the items in this variable and displays them as the second level in the menu hierarchy.
+- grandchildren_to_show: If the child item has children, it takes the items in this variable and displays them as the third level inside the same dropdown.
 
-When you enter the Templates section of your site in Modyo Platform, you can click on the general `menu` snippet to see the HTML of the menu. It looks like this:
+When you enter the Templates section of your site in Modyo Platform, you can click on the general `menu` snippet to see the HTML of the menu. It	looks	like	this:
 
 `menu`
 
 ```html
-{% assign menu = menus['main'] %}
-<ul class="nav navbar-nav" role="menu" aria-label="Main menu {{responsive}}">
+<ul class="nav navbar-nav justify-content-end flex-grow-1" role="menu" aria-label="Main menu {{responsive}}">
 	{% assign items_to_show = menu.items | visible_items %}
 	{% for item in items_to_show %}
 	{% assign active = item.url | active_page: request.url %}
 	{% assign children_to_show = item.child_items | visible_items %}
-	{% if children_to_show.size > 0 %}
 	<li class="nav-item nav-item-{{ item.parameterized_label }} dropdown menu-item {{ active }}" role="none">
-		<a target="{{ item.target }}" rel="{{ item.target | item_rel}}" class="nav-link dropdown-toggle {% for child in children_to_show %}{% if child.url == request.url  %}active{% endif %}{% endfor %}" href="javascript:void(0)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdown{{ item.label | replace: ' ',''	| replace: 'ñ','n' | capitalize }}Button{{ responsive }}" role="menuitem">
-			{{ item.label }} <span class="sr-only">dropdown</span>
+		{% if children_to_show.size > 0 %}
+		<button type="button" class="nav-link {{ active }} dropdown-toggle {% for child in children_to_show %}{% if child.url == request.url %}active{% endif %}{% endfor %}" data-bs-toggle="dropdown" aria-expanded="false" id="dropdown{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }}Button{{ responsive }}" role="menuitem">
+			{{ item.label }} <span class="visually-hidden">dropdown</span>
+		</button>
+		{% else %}
+		<a target="{{ item.target }}" rel="{{ item.target | item_rel}}" class="nav-link {{ active }}" href="{{ item.url }}" id="dropdown{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }}Button{{ responsive }}" role="menuitem">
+			{{ item.label }}
 		</a>
-		<div class="submenu-{{ item.label | replace: ' ',''	| replace: 'ñ','n' | capitalize }} dropdown-menu" aria-labelledby="dropdown{{ item.label | replace: ' ',''	| replace: 'ñ','n' | capitalize }}Button{{responsive}}" aria-expanded="false">
+		{% endif %}
+		{% if children_to_show.size > 0 %}
+		<div class="dropdown-menu submenu-{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }}" aria-labelledby="dropdown{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }}Button{{responsive}}">
 			{% for child in children_to_show %}
 			<a target="{{ child.target }}" rel="{{ child.target | item_rel}}" class="dropdown-item" href="{{ child.url }}" {% if child.url == request.url %}aria-current="page"{% endif %}>
 				{{ child.label }}
 			</a>
+			{% assign grandchildren_to_show = child.child_items | visible_items %}
+			{% if grandchildren_to_show.size > 0 %}
+			{% for child in grandchildren_to_show %}
+			<a target="{{ child.target }}" rel="{{ child.target | item_rel}}" class="dropdown-item small ms-2" href="{{ child.url }}" {% if child.url == request.url %}aria-current="page"{% endif %}>
+				{{ child.label }}
+			</a>
+			{% endfor %}
+			{% endif %}
 			{% endfor %}
 		</div>
-		{% else %}
-	<li class="nav-item nav-item-{{ item.parameterized_label }} {{ active }}" role="none">
-		<a target="{{ item.target }}" class="nav-link" rel="{{ item.target | item_rel}}" href="{{ item.url }}" {% if item.url == request.url %}aria-current="page" {% endif %} role="menuitem" aria-label="{{ item.label }} {{responsive}}">{{ item.label }}</a>
 		{% endif %}
 	</li>
 	{% endfor %}
@@ -175,7 +257,7 @@ Next, we have a menu that also calls `main`, but now in list form, unlike the ge
 
 ### Three-level menu
 
-To display a three-level menu, you need to add another loop that considers whether the child items contain more items. For this, the `grandchildren` variable is assigned at the end of the first loop, and it must iterate over the children's items (i.e., the grandchild items):
+The general snippet already displays the third level as indented links inside the same dropdown. If you prefer to group them in a nested list, add another loop that considers whether the child items contain more items: the `grandchildren_to_show` variable is assigned at the end of the second loop, and it iterates over the grandchild items:
 
 ```html
 {% assign menu = menus['main'] %}

--- a/docs/en/platform/channels/navigation.md
+++ b/docs/en/platform/channels/navigation.md
@@ -71,7 +71,7 @@ In the right sidebar, you will see a bar that changes according to the item sele
 
 - **Name**: Name of the element as it appears on the site.
 - **Description**: Free text to accompany the item. It is not printed on the site by itself: it is available in Liquid as `menu_item.description` so you can use it in your own markup, for example as a subtitle for the item or as the text of a notification.
-- **Classes**: String to be used in a class attribute for a HTML tag, for example `mdi mdi-circle`. Just like the description, it is available in Liquid as `menu_item.classes` and you are the one who prints it in the `class` attribute of your markup. Check both attributes in [Objects](/en/platform/channels/liquid-markup/objects.html#menu).
+- **Classes**: String to be used in a class attribute for an HTML tag, for example `mdi mdi-circle`. Just like the description, it is available in Liquid as `menu_item.classes` and you are the one who prints it in the `class` attribute of your markup. Check both attributes in [Objects](/en/platform/channels/liquid-markup/objects.html#menu).
 - **Link**: Destination of the item. You can choose one of the site pages, **URL** to write a custom address, or **Site Search** to point to the site's search page.
 - **URL**: If you chose **URL** in the previous item, you have different options to configure this item:
 	- HTTP(s): Points to an address using HTTP(s). Examples:
@@ -177,7 +177,7 @@ The following list describes the important variables for the menu:
 - children_to_show: If the current item has children, it takes the items in this variable and displays them as the second level in the menu hierarchy.
 - grandchildren_to_show: If the child item has children, it takes the items in this variable and displays them as the third level inside the same dropdown.
 
-When you enter the Templates section of your site in Modyo Platform, you can click on the general `menu` snippet to see the HTML of the menu. It	looks	like	this:
+When you enter the Templates section of your site in Modyo Platform, you can click on the general `menu` snippet to see the HTML of the menu. It looks like this:
 
 `menu`
 

--- a/docs/es/platform/channels/navigation.md
+++ b/docs/es/platform/channels/navigation.md
@@ -57,7 +57,7 @@ Para crear un Menú, sigue estos pasos:
 7. Una vez terminado, haz clic en **Publicar**.
 
 :::tip Tip
-Tu menú en este momento ya es público, pero no se manda a llamar. Se necesita usar una plantilla para que se despliegue en pantalla. Modyo ofrece un snippet de uso general en **Snippets, General, menu** y es llamado en la plantilla `base` usando <pre v-pre>`{% snippet 'shared/general/menu' %}`</pre>.
+Tu menú en este momento ya es público, pero no se manda a llamar. Se necesita usar una plantilla para que se despliegue en pantalla. Modyo ofrece un snippet de uso general en **Snippets, General, menu**, que el snippet **header** invoca dos veces (una para la barra de escritorio y otra para el panel lateral en móvil) y que llega a tus páginas porque la plantilla `base` incluye <pre v-pre>`{% snippet 'shared/general/header' %}`</pre>.
 :::
 
 **Acción principal**
@@ -70,8 +70,10 @@ Tu menú en este momento ya es público, pero no se manda a llamar. Se necesita 
 En la sección lateral derecha, puedes ver una barra que cambia de acuerdo al ítem seleccionado en el área principal. En esta sección, puedes ver las opciones:
 
 - **Nombre**: Nombre del elemento que aparecerá en el sitio.
-- **Página asociada**: Se puede asociar directamente a una página o a una URL personalizada.
-- **URL**: Si escogiste una URL personalizada en el elemento anterior, tienes diferentes opciones para configurar este ítem:
+- **Descripción**: Texto libre para acompañar al ítem. No se imprime solo en el sitio: queda disponible en Liquid como `menu_item.description` para que lo uses en tu propio marcado, por ejemplo como bajada del ítem o como texto de una notificación.
+- **Clases**: Cadena que se utilizará en un atributo de clase para una etiqueta HTML, por ejemplo `mdi mdi-circle`. Al igual que la descripción, queda disponible en Liquid como `menu_item.classes` y eres tú quien la imprime en el atributo `class` de tu marcado. Revisa ambos atributos en [Objetos](/es/platform/channels/liquid-markup/objects.html#menu).
+- **Layout Page asociado**: Destino del ítem. Puedes elegir una de las páginas del sitio, **URL** para escribir una dirección personalizada, o **Búsqueda en el sitio** para apuntar al buscador del sitio.
+- **URL**: Si escogiste **URL** en el elemento anterior, tienes diferentes opciones para configurar este ítem:
 	- HTTP(s): Apunta a una dirección usando HTTP(s). Ejemplos:
 		- http://www.example.com
 		- https://www.example.com
@@ -88,9 +90,76 @@ En la sección lateral derecha, puedes ver una barra que cambia de acuerdo al í
 		- sms:+569-123-45678,9-123-45678?body=hello%20there&param1=a%20value
 	- Email: Genera un enlace con el URI `mailto`. Ejemplos:
 		- mailto:info@example.com?subject=subject&cc=cc@example.com
-- **Abrir en pestaña nueva**: Añade el atributo `target='blank'` al elemento HTML del ítem del menú, para que al hacer clic, se abra en una pestaña nueva.
+- **Abrir en una pestaña nueva**: Solo aparece cuando el destino es una **URL**. Añade los atributos `target="_blank"` y `rel="noopener noreferrer"` al enlace del ítem, para que al hacer clic se abra en una pestaña nueva.
 - **Privado**: Hace que el elemento seleccionado sea visible solo cuando hay una sesión de usuario activa en el sitio.
 - **Segmentos**: Si hay segmentos creados, también podrás segmentar este elemento para que los usuarios puedan ver este ítem de menú solo cuando tengan una sesión activa y que además se encuentren dentro de los segmentos seleccionados.
+
+## El tag menu
+
+El tag <span v-pre>`{% menu %}`</span> imprime un menú completo, con sus dropdowns, sin que tengas que escribir el marcado. Es el camino rápido: si necesitas control total sobre el HTML, arma el menú a mano recorriendo `menus`, como se muestra en los ejemplos de más abajo.
+
+### Cómo se invoca
+
+El tag no recibe parámetros: lee la variable `menu` del contexto, así que tienes que asignarla antes con el identificador del menú que quieres imprimir.
+
+```liquid
+{% assign menu = menus['main'] %}
+{% menu %}
+```
+
+Las variables que asignas en una plantilla o en un snippet quedan disponibles en los snippets que se invocan desde ahí, de modo que puedes hacer el `assign` una sola vez y reutilizarlo.
+
+:::warning Atención
+Si invocas el tag sin haber asignado `menu`, o si el identificador no corresponde a ningún menú del sitio, la página imprime un comentario `<!-- Liquid Error -->` en lugar del menú.
+:::
+
+### HTML que genera
+
+El tag emite siempre la misma estructura, pensada para el sistema de dropdown de Bootstrap:
+
+```html
+<ul class="nav navbar-nav">
+	<li class='nav-item nav-item-inicio active'>
+		<a class='nav-link ' href='https://tusitio.com/mi-sitio/inicio'><span>Inicio</span></a>
+	</li>
+	<li class='nav-item nav-item-productos dropdown menu-item'>
+		<a class='nav-link dropdown-toggle' href='https://tusitio.com/mi-sitio/productos'><span>Productos</span></a>
+		<div class='submenu-1 dropdown-menu'>
+			<a class='dropdown-item' href='https://tusitio.com/mi-sitio/productos/cuentas'><span>Cuentas</span> </a>
+		</div>
+	</li>
+</ul>
+```
+
+Estos son los ganchos que tienes para aplicar tus estilos:
+
+| Elemento | Clases |
+| -------- | ------ |
+| Lista contenedora | `nav navbar-nav` |
+| Ítem | `nav-item` y `nav-item-` seguido de la etiqueta del ítem parametrizada, por ejemplo `nav-item-mis-productos`. Se agrega `dropdown menu-item` si el ítem tiene hijos y `active` si el ítem corresponde a la página que se está viendo |
+| Enlace del ítem | `nav-link`, más `dropdown-toggle` si el ítem tiene hijos |
+| Contenedor de los hijos | `submenu-N dropdown-menu`, donde `N` es la posición del ítem padre entre los ítems visibles, partiendo de 0 |
+| Enlace de un hijo | `dropdown-item` |
+
+La etiqueta de cada ítem viene envuelta en un `<span>`, tanto en el primer nivel como en el segundo.
+
+:::warning Atención
+El tag renderiza solo dos niveles: los ítems raíz y sus hijos directos. Aunque la navegación te deja anidar hasta tres niveles, los nietos no aparecen en el HTML que genera el tag. Si necesitas el tercer nivel, arma el menú a mano, como hace el snippet general `menu`.
+:::
+
+### Enlaces que genera
+
+- Si el ítem tiene marcada la opción **Abrir en una pestaña nueva**, el enlace se emite con `target="_blank"` y `rel="noopener noreferrer"`.
+- Las URLs que empiezan con `http://`, `https://`, `tel:`, `mailto:` o `sms:` se emiten tal cual.
+- Cualquier otra URL se reescribe como absoluta sobre la URL base del sitio. Un ítem con la URL `/contacto` se emite como `https://tusitio.com/mi-sitio/contacto`, y un ancla como `#seccion` se emite como `https://tusitio.com/mi-sitio/#seccion`, es decir, apuntando a la portada del sitio y no a la página en la que está el visitante.
+
+### Ítems que se muestran
+
+- Los ítems marcados como **Privado** no se imprimen para los visitantes sin sesión.
+- Si además tienen segmentos asociados, solo se imprimen para los usuarios cuya sesión pertenece a alguno de esos segmentos.
+- Las dos reglas se aplican por igual a los ítems raíz y a sus hijos: si un ítem padre queda oculto, su dropdown tampoco se imprime.
+
+El menú resultante se reutiliza mientras no cambien la página, el usuario ni la versión del menú, así que los cambios que publiques en la navegación se ven en la siguiente visita.
 
 ## Ejemplos de Menú
 
@@ -98,39 +167,52 @@ El snippet general `menu` puede satisfacer las necesidades básicas de un sitio,
 
 Las primeras líneas encapsuladas por <span v-pre>{{ }} o {% %}</span> pertenecen a Liquid y se utilizan para asignar variables o comenzar un bucle para desplegar información del menú.
 
+A diferencia de los ejemplos que vienen más abajo, este snippet no asigna la variable `menu`: la hereda del snippet **header**, que la declara en su primera línea con <span v-pre>`{% assign menu = menus['main'] %}`</span> y desde ahí lo invoca dos veces. Si copias este marcado a otra plantilla, acuérdate de asignar `menu` antes de usarlo.
+
 El siguiente listado describe las variables importantes para el menú:
 
-- menu: Esta variable toma el menú con identificador `main` dentro de Modyo Platform -> Navegación.
+- menu: Menú que se va a imprimir. Se hereda del snippet que invoca a `menu`; si armas el tuyo desde cero, asígnalo con <span v-pre>`{% assign menu = menus['main'] %}`</span>.
 - items_to_show: Toma los ítems de menú que son visibles.
 - active: Utilizado para agregar una clase CSS llamada `active` en caso de que este ítem sea activado.
 - children_to_show: Si existen hijos del ítem actual, toma los ítems en esta variable y los despliega como segundo nivel en la jerarquía del menú.
+- grandchildren_to_show: Si existen hijos del ítem hijo, toma los ítems en esta variable y los despliega como tercer nivel dentro del mismo dropdown.
 
-Al entrar a la sección de Plantillas de tu sitio en Modyo Platform, podrás hacer clic en el snippet general `menu` para ver el HTML del menú. Se ve de la siguiente manera:
+Al entrar a la sección de Plantillas de tu sitio en Modyo Platform, podrás hacer clic en el snippet general `menu` para ver el HTML del menú. Se ve de la siguiente manera:
 
 `menu`
 
 ```html
-{% assign menu = menus['main'] %}
-<ul class="nav navbar-nav" role="menu" aria-label="Main menu {{responsive}}">
+<ul class="nav navbar-nav justify-content-end flex-grow-1" role="menu" aria-label="Main menu {{responsive}}">
 	{% assign items_to_show = menu.items | visible_items %}
 	{% for item in items_to_show %}
 	{% assign active = item.url | active_page: request.url %}
 	{% assign children_to_show = item.child_items | visible_items %}
-	{% if children_to_show.size > 0 %}
 	<li class="nav-item nav-item-{{ item.parameterized_label }} dropdown menu-item {{ active }}" role="none">
-		<a target="{{ item.target }}" rel="{{ item.target | item_rel}}" class="nav-link dropdown-toggle {% for child in children_to_show %}{% if child.url == request.url  %}active{% endif %}{% endfor %}" href="javascript:void(0)" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdown{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }}Button{{ responsive }}" role="menuitem">
-			{{ item.label }} <span class="sr-only">dropdown</span>
+		{% if children_to_show.size > 0 %}
+		<button type="button" class="nav-link {{ active }} dropdown-toggle {% for child in children_to_show %}{% if child.url == request.url %}active{% endif %}{% endfor %}" data-bs-toggle="dropdown" aria-expanded="false" id="dropdown{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }}Button{{ responsive }}" role="menuitem">
+			{{ item.label }} <span class="visually-hidden">dropdown</span>
+		</button>
+		{% else %}
+		<a target="{{ item.target }}" rel="{{ item.target | item_rel}}" class="nav-link {{ active }}" href="{{ item.url }}" id="dropdown{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }}Button{{ responsive }}" role="menuitem">
+			{{ item.label }}
 		</a>
-		<div class="submenu-{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }} dropdown-menu" aria-labelledby="dropdown{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }}Button{{responsive}}" aria-expanded="false">
+		{% endif %}
+		{% if children_to_show.size > 0 %}
+		<div class="dropdown-menu submenu-{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }}" aria-labelledby="dropdown{{ item.label | replace: ' ','' | replace: 'ñ','n' | capitalize }}Button{{responsive}}">
 			{% for child in children_to_show %}
 			<a target="{{ child.target }}" rel="{{ child.target | item_rel}}" class="dropdown-item" href="{{ child.url }}" {% if child.url == request.url %}aria-current="page"{% endif %}>
 				{{ child.label }}
 			</a>
+			{% assign grandchildren_to_show = child.child_items | visible_items %}
+			{% if grandchildren_to_show.size > 0 %}
+			{% for child in grandchildren_to_show %}
+			<a target="{{ child.target }}" rel="{{ child.target | item_rel}}" class="dropdown-item small ms-2" href="{{ child.url }}" {% if child.url == request.url %}aria-current="page"{% endif %}>
+				{{ child.label }}
+			</a>
+			{% endfor %}
+			{% endif %}
 			{% endfor %}
 		</div>
-		{% else %}
-	<li class="nav-item nav-item-{{ item.parameterized_label }} {{ active }}" role="none">
-		<a target="{{ item.target }}" class="nav-link" rel="{{ item.target | item_rel}}" href="{{ item.url }}" {% if item.url == request.url %}aria-current="page" {% endif %} role="menuitem" aria-label="{{ item.label }} {{responsive}}">{{ item.label }}</a>
 		{% endif %}
 	</li>
 	{% endfor %}
@@ -175,7 +257,7 @@ A continuación, tenemos un menú que también llama a `main`, pero ahora en for
 
 ### Menú tres niveles
 
-Para poder desplegar un menú de tres niveles, se tiene que agregar otro bucle que considere si los items hijos contienen más items. Para esto, se asigna la variable `grandchildren` al final del primer bucle y este tiene que iterar sobre los items de los hijos (osase los items nietos):
+El snippet general ya despliega el tercer nivel como enlaces indentados dentro del mismo dropdown. Si prefieres agruparlos en una lista anidada, agrega otro bucle que considere si los ítems hijos contienen más ítems: se asigna la variable `grandchildren_to_show` al final del segundo bucle y se itera sobre los ítems nietos:
 
 ```html
 {% assign menu = menus['main'] %}

--- a/docs/es/platform/channels/navigation.md
+++ b/docs/es/platform/channels/navigation.md
@@ -177,7 +177,7 @@ El siguiente listado describe las variables importantes para el menú:
 - children_to_show: Si existen hijos del ítem actual, toma los ítems en esta variable y los despliega como segundo nivel en la jerarquía del menú.
 - grandchildren_to_show: Si existen hijos del ítem hijo, toma los ítems en esta variable y los despliega como tercer nivel dentro del mismo dropdown.
 
-Al entrar a la sección de Plantillas de tu sitio en Modyo Platform, podrás hacer clic en el snippet general `menu` para ver el HTML del menú. Se ve de la siguiente manera:
+Al entrar a la sección de Plantillas de tu sitio en Modyo Platform, podrás hacer clic en el snippet general `menu` para ver el HTML del menú. Se ve de la siguiente manera:
 
 `menu`
 


### PR DESCRIPTION
## Cambios propuestos

Cierra los gaps **LIQUID-TAGS-06** (que unifica LIQUID-TAGS-X04) y **CHANNELS-19**, ambos sobre la página de Navegación.

### docs/es/platform/channels/navigation.md y docs/en/platform/channels/navigation.md

**Nueva sección "El tag menu" / "The menu tag"**

El tag <span v-pre>`{% menu %}`</span> se mencionaba en la primera línea de la página y nunca se especificaba. Ahora tiene su ficha completa:

- El prerrequisito de asignar la variable `menu` antes de invocarlo, con el ejemplo <span v-pre>`{% assign menu = menus['main'] %}`</span>, y el aviso de que sin ella (o con un identificador que no existe) la página imprime `<!-- Liquid Error -->` en lugar del menú.
- El HTML exacto que emite, con un ejemplo y una tabla de los ganchos de CSS: `nav navbar-nav` en la lista, `nav-item nav-item-<etiqueta parametrizada>` en cada ítem, más `dropdown menu-item` cuando tiene hijos y `active` cuando corresponde a la página actual, `nav-link` (con `dropdown-toggle` si hay hijos) en el enlace, y `submenu-N dropdown-menu` con `dropdown-item` para los hijos.
- La advertencia de que el tag renderiza solo dos niveles, aunque la navegación permita anidar tres.
- Los enlaces: `target="_blank" rel="noopener noreferrer"` cuando el ítem lo tiene marcado, paso directo de las URLs `http`, `https`, `tel:`, `mailto:` y `sms:`, y reescritura absoluta del resto sobre la URL base del sitio (incluidas las anclas, que terminan apuntando a la portada).
- Qué ítems se muestran: los privados quedan ocultos para visitantes sin sesión y se aplican las restricciones por segmento, tanto en la raíz como en los hijos.

**Snippet publicado en "Ejemplos de Menú"**

El bloque de código que la página presentaba como el snippet general `menu` correspondía a un tema anterior: hacía su propio `assign`, arrancaba en `<ul class="nav navbar-nav">` y usaba marcado de Bootstrap 4 (`data-toggle`, `sr-only`, `href="javascript:void(0)"`). Quien lo copiaba se quedaba con un menú sin estilos y con el dropdown roto. Se reemplaza por el snippet real: ya no hace el `assign`, arranca en `<ul class="nav navbar-nav justify-content-end flex-grow-1">`, usa `button` con `data-bs-toggle` y `visually-hidden`, y despliega el tercer nivel.

Aprovechando eso se explica la herencia de contexto entre snippets: el `assign` vive ahora en el snippet **header**, que invoca dos veces al snippet **menu** (barra de escritorio y panel lateral en móvil), y la plantilla `base` incluye al **header**, no al **menu**. Se corrigió el tip que decía lo contrario, se agregó `grandchildren_to_show` al listado de variables y se reencuadró el ejemplo "Menú tres niveles" como una alternativa de marcado, porque el snippet real ya cubre ese nivel.

**Opciones del ítem de menú**

Se completa la lista de la barra lateral, que omitía tres cosas:

- **Descripción**: texto libre disponible en Liquid como `menu_item.description`.
- **Clases**: cadena que se inyecta en el atributo `class` del marcado propio, disponible como `menu_item.classes`, con el ejemplo `mdi mdi-circle` de la propia ayuda de la pantalla.
- **Búsqueda en el sitio**: tercera opción del selector de destino, además de una página del sitio y una URL personalizada.

De paso se corrigen los labels que no coincidían con el panel ("Página asociada" pasa a **Layout Page asociado**, "Abrir en pestaña nueva" a **Abrir en una pestaña nueva", y sus equivalentes en inglés **Link** y **Open in a new tab**) y el atributo que se documentaba como `target='blank'`, que en realidad es `target="_blank"` acompañado de `rel="noopener noreferrer"`.

Los atributos Liquid del ítem ya estaban documentados en Objetos, así que se referencian en vez de repetirlos.

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)
