### PR TITLE
Corregir las vistas de error y actualizar el layout base en la documentación de Plantillas

### DIFF
--- a/docs/en/platform/channels/templates.md
+++ b/docs/en/platform/channels/templates.md
@@ -56,7 +56,7 @@ Modyo offers three predefined layouts:
 
 - **Home**: Exclusively for the main page of the site.
 - **Base**: All pages, except the home page, use this layout.
-- **Error**: Used in error views (404, 401), showcasing a clean design.
+- **Error**: Used in the site's three error views (**404**, **disabled**, and **template**), showcasing a clean design.
 
 To create a new layout:
 1. In the **Templates** section, click on the **Views** tab
@@ -65,30 +65,40 @@ To create a new layout:
 
 This allows you to define a new base structure for use on pages.
 
-You can use this code as a base that contains everything necessary for your pages to use the elements of the site, such as the header, footer, service worker, and Google Tag Manager configuration. You can also modify the code as needed.
-
+When you create a layout, Modyo initializes it with a minimal structure. If you want your pages to use every element of the site, such as the header, the footer, the service worker, and the Google Tag Manager configuration, replace that content with the same code that ships in the **Base** layout and adjust it as needed:
 
 ```liquid
-{% html5 %}
+{% html5 %} <!-- HTML header with browser directives -->
 <head>
   {% snippet 'shared/general/head' %}
 </head>
-
-{% body %}
+{% body %} <!-- Body with automatic context classes -->
 {% snippet 'shared/general/body_tag_manager' %}
+<div id="modyo-site-alert-wrapper"></div>
 {% snippet 'shared/general/header' %}
-
-{{ site.breadcrumb }}
-<div id="main-layout">
-{{ content_for_layout }}
-</div>
-
-<script>{% snippet "shared/serviceworker/register_js" %}</script>
+<main id="content">
+  <div id="breadcrumb" class="mt-8">
+    <div class="container breadcrumb-inner">
+      {{ site.breadcrumb }}
+    </div>
+  </div>
+  {{ content_for_layout }}
+</main>
+<script nonce="{{csp_nonce}}">{% snippet "shared/service_worker/register_js" %}</script>
 {% snippet 'shared/general/footer' %}
-
 {% endbody %}
 {% endhtml5 %}
 ```
+
+If you write your own layout, watch out for these three details:
+
+- `<div id="modyo-site-alert-wrapper"></div>` is the container where the site injects its alerts. If you leave it out, the alerts are not displayed.
+- `<main id="content">` wraps the page content and is the anchor used by the theme and by the site's error views.
+- The <span v-pre>`nonce="{{csp_nonce}}"`</span> attribute is required on every inline `<script>` or `<style>` tag when your web app's [Content-Security-Policy](/en/platform/channels/sites#content-security-policy-csp) includes the nonce directive. Without it, the browser blocks the script and the service worker is never registered.
+
+:::warning Attention
+The path of the snippet that registers the service worker is `shared/service_worker/register_js`, with an underscore between `service` and `worker`. If you write it any other way, the snippet does not resolve and the registration is not injected into the page.
+:::
 
 To apply a new layout to a page, follow these steps:
 1. Go to the **Pages** section
@@ -125,12 +135,17 @@ It is necessary that your account's CDN is in the cloud for changes to be reflec
 
 ## Errors in Views
 
-In the views section, you can customize four types of errors:
+In the **Views** tab, inside the **errors** group, you can customize the three error views that the site ships with. All of them are rendered with the **Error** layout:
 
-- **Disabled**: Displayed when the site you are trying to access is [disabled](/en/platform/channels/sites).
-- **404**: If in the [site restrictions](/en/platform/channels/sites#privacy) configuration you decide to show 404 instead of redirecting to the home page, this error appears when entering an undefined URL.
-- **Privacy**: Shown when you do not have permissions to access the [site](/en/platform/channels/sites#privacy) or one of its [pages](/en/platform/channels/pages#privacy).
-- **Template**: Visible when the loaded page has a Liquid syntax error. It is unlikely that you will see this view, as from Modyo 8.1 onwards, the platform performs a syntax check before saving and publishing changes to Templates.
+- **disabled**: Displayed when the site you are trying to access is [disabled](/en/platform/channels/sites).
+- **404**: Displayed when you enter a URL that does not resolve, and also when a signed-in user opens a private page whose [segments](/en/platform/customers/segments) do not apply to them. If you enable **Redirect to home when a URL is not found** in the web app settings, the visitor goes to the home page instead of seeing this view.
+- **template**: Visible when the loaded page has a Liquid syntax error. It is unlikely that you will see this view, as from Modyo 8.1 onwards, the platform performs a syntax check before saving and publishing changes to Templates.
+
+There is no error view for privacy. When a visitor without a session requests a private site or page, the platform does not render any error view: it redirects them to the site's login page, or to the signup page if the web app is configured that way, and returns them to the URL they requested once they sign in.
+
+:::tip Tip
+As of Modyo 10.2, origination pages also respond with the **404** view and the site's styles when the URL does not resolve. They previously returned an empty body, so any customization you make to this view is also reflected on those URLs.
+:::
 
 ## CSS and JavaScript
 

--- a/docs/es/platform/channels/templates.md
+++ b/docs/es/platform/channels/templates.md
@@ -56,7 +56,7 @@ Modyo ofrece tres layouts predefinidos:
 
 - **Home**: Exclusivamente para la página principal del sitio.
 - **Base**: Todas las páginas, excepto la de inicio, usan este layout.
-- **Error**: Empleado en las vistas de error (404, 401), presentando un diseño limpio.
+- **Error**: Empleado en las tres vistas de error del sitio (**404**, **disabled** y **template**), presentando un diseño limpio.
 
 Para crear un nuevo layout:
 1. En la sección de **Plantillas** da click en la pestaña **Vistas**
@@ -65,30 +65,40 @@ Para crear un nuevo layout:
 
 Esto te permite definir una nueva estructura base para usar en las páginas.
 
-Puedes usar como base este código que contiene todo lo necesario para que tus páginas usen los elementos del sitio, como el encabezado, pie de página, service worker y la configuración de Google Tag Manager. También puedes modificar el código, según requieras.
-
+Al crear un layout, Modyo lo inicializa con una estructura mínima. Si quieres que tus páginas usen todos los elementos del sitio, como el encabezado, el pie de página, el service worker y la configuración de Google Tag Manager, reemplaza ese contenido por el mismo código que trae el layout **Base** y ajústalo según requieras:
 
 ```liquid
-{% html5 %}
+{% html5 %} <!-- HTML header with browser directives -->
 <head>
   {% snippet 'shared/general/head' %}
 </head>
-
-{% body %}
+{% body %} <!-- Body with automatic context classes -->
 {% snippet 'shared/general/body_tag_manager' %}
+<div id="modyo-site-alert-wrapper"></div>
 {% snippet 'shared/general/header' %}
-
-{{ site.breadcrumb }}
-<div id="main-layout">
-{{ content_for_layout }}
-</div>
-
-<script>{% snippet "shared/serviceworker/register_js" %}</script>
+<main id="content">
+  <div id="breadcrumb" class="mt-8">
+    <div class="container breadcrumb-inner">
+      {{ site.breadcrumb }}
+    </div>
+  </div>
+  {{ content_for_layout }}
+</main>
+<script nonce="{{csp_nonce}}">{% snippet "shared/service_worker/register_js" %}</script>
 {% snippet 'shared/general/footer' %}
-
 {% endbody %}
 {% endhtml5 %}
 ```
+
+Si escribes tu propio layout, cuida estos tres detalles:
+
+- `<div id="modyo-site-alert-wrapper"></div>` es el contenedor donde el sitio inyecta sus alertas. Si lo omites, las alertas no se muestran.
+- `<main id="content">` envuelve el contenido de la página y es el ancla que usan el tema y las vistas de error del sitio.
+- El atributo <span v-pre>`nonce="{{csp_nonce}}"`</span> es obligatorio en cada tag `<script>` o `<style>` inline cuando la política de [Content-Security-Policy](/es/platform/channels/sites#content-security-policy-csp) de tu aplicación web incluye la directiva nonce. Sin él, el navegador bloquea el script y el service worker nunca se registra.
+
+:::warning Atención
+La ruta del snippet que registra el service worker es `shared/service_worker/register_js`, con guión bajo entre `service` y `worker`. Si la escribes de otra forma, el snippet no se resuelve y el registro no se inyecta en la página.
+:::
 
 Para aplicar un layout nuevo a una página, sigue estos pasos:
 1. Ve a la sección **Páginas**
@@ -125,12 +135,17 @@ Es necesario que el CDN de tu cuenta esté en la nube para que los cambios se re
 
 ## Errores en Vistas
 
-En la sección de vistas puedes personalizar cuatro tipos de errores:
+En la pestaña **Vistas**, dentro del grupo **errors**, puedes personalizar las tres vistas de error que trae el sitio. Todas se renderizan con el layout **Error**:
 
-- **Deshabilitado**: Se muestra cuando el sitio al que intentas acceder está [deshabilitado](/es/platform/channels/sites).
-- **404**: Si en la configuración de [restricciones del sitio](/es/platform/channels/sites#privacidad) decides mostrar el 404 en lugar de redireccionar a la página de inicio, se muestra este error al ingresar a una URL no definida.
-- **Privacy**: Se muestra cuando no tienes permisos para acceder al [sitio](/es/platform/channels/sites#privacidad) o a una de sus [páginas](/es/platform/channels/pages#privacidad).
-- **Template**: Visible cuando la página cargada tiene un error de sintaxis de Liquid. Es poco probable que veas esta vista, debido a que a partir de Modyo 8.1 la plataforma realiza una verificación de la sintaxis antes de guardar y publicar cambios en Plantillas.
+- **disabled**: Se muestra cuando el sitio al que intentas acceder está [deshabilitado](/es/platform/channels/sites).
+- **404**: Se muestra al entrar a una URL que no resuelve y también cuando un usuario con sesión iniciada abre una página privada cuyos [segmentos](/es/platform/customers/segments) no le corresponden. Si en la configuración de la aplicación web activas **Redireccionar al home cuando una URL no se encuentra**, el visitante va a la página de inicio en lugar de ver esta vista.
+- **template**: Visible cuando la página cargada tiene un error de sintaxis de Liquid. Es poco probable que veas esta vista, debido a que a partir de Modyo 8.1 la plataforma realiza una verificación de la sintaxis antes de guardar y publicar cambios en Plantillas.
+
+No existe una vista de error para la privacidad. Cuando un visitante sin sesión pide un sitio o una página privada, la plataforma no renderiza ninguna vista de error: lo redirige a la página de inicio de sesión del sitio, o a la de registro si así está configurada la aplicación web, y lo devuelve a la URL que pedía una vez que inicia sesión.
+
+:::tip Tip
+Desde Modyo 10.2, las páginas de originación también responden con la vista **404** y los estilos del sitio cuando la URL no resuelve. Antes devolvían un cuerpo vacío, así que cualquier personalización que hagas a esta vista se refleja también en esas URLs.
+:::
 
 ## CSS y JavaScript
 


### PR DESCRIPTION
## Cambios propuestos

Actualiza la página de Plantillas para que las vistas de error y el layout base que ofrece copiar correspondan a lo que la plataforma realmente instala. Cierra los gaps **CHANNELS-20** y **LIQUID-TAGS-X05**.

### `docs/es/platform/channels/templates.md`

**Layouts (LIQUID-TAGS-X05)**

- El bloque "usa como base este código" se reemplaza por el layout que la plataforma instala hoy (`app/views/layouts/site/base.html.liquid`). El código publicado estaba desfasado en tres puntos que degradan el resultado de quien lo copia:
  - El `<script>` inline iba **sin** `nonce="{{csp_nonce}}"`. Cuando la política de CSP del sitio incluye la directiva nonce, el navegador bloquea ese script y el service worker nunca se registra. La página de Aplicaciones Web ya exige ese nonce, así que las dos páginas se contradecían entre sí.
  - La ruta del snippet era `shared/serviceworker/register_js`, que **no existe**. El archivo real es `app/views/site/shared/service_worker/_register_js.html.liquid`, o sea `shared/service_worker/register_js` con guión bajo. Se agrega un callout de atención sobre ese detalle.
  - Faltaban el contenedor de alertas `<div id="modyo-site-alert-wrapper"></div>` y el `<main id="content">` que usa el tema actual, y el breadcrumb iba suelto en vez de dentro de su contenedor.
- Se agrega una lista corta que explica para qué sirve cada uno de esos tres elementos, con enlace a la sección de Content-Security-Policy de Aplicaciones Web en vez de repetir ahí la explicación del nonce.
- El texto introductorio pasa de "puedes usar como base este código" a explicar el flujo real: al crear un layout, Modyo lo inicializa con una estructura mínima y tú la reemplazas por la del layout **Base**.
- Se corrige la descripción del layout **Error**: decía que se usa "en las vistas de error (404, 401)" y no existe ninguna vista 401. Se usa en las tres vistas de error reales.

**Errores en Vistas (CHANNELS-20)**

- La página enumeraba **cuatro** vistas de error cuando el tema solo provee **tres**: `disabled`, `404` y `template`. Se elimina la vista **Privacy**, que no existe en el código.
- Se explica qué pasa realmente en el caso que la doc atribuía a esa vista inexistente: cuando un visitante sin sesión pide un sitio o una página privada no se renderiza ningún error, se lo redirige a la página de inicio de sesión del sitio (o a la de registro, según la configuración de la aplicación web) y se lo devuelve a la URL que pedía una vez que inicia sesión.
- Se precisa el caso de la vista **404**: además de las URLs que no resuelven, se muestra cuando un usuario con sesión iniciada abre una página privada cuyos segmentos no le corresponden, y se aclara el efecto de la opción **Redireccionar al home cuando una URL no se encuentra**.
- Se nombran las vistas con el nombre que muestra el Template Builder (`disabled`, `404`, `template`, dentro del grupo `errors`), en vez de nombres traducidos que no aparecen en el panel, y se indica que las tres se renderizan con el layout **Error**.
- Se agrega un tip sobre 10.2: las páginas de originación ahora responden con esta misma vista **404** con los estilos del sitio, donde antes devolvían un cuerpo vacío. Cualquier personalización de la vista se refleja también en esas URLs.
- De paso se eliminan dos enlaces a `sites#privacidad`, un ancla que no existe en la página de Aplicaciones Web.

### `docs/en/platform/channels/templates.md`

Espejo exacto de los cambios anteriores, con los labels de UI en inglés (**Redirect to home when a URL is not found**) y los enlaces apuntando a `/en/`.

## Para el revisor

1. Cambio de nombres visibles. La sección de errores pasa de **Deshabilitado** / **404** / **Privacy** / **Template** a **disabled** / **404** / **template**. Es intencional: el Template Builder muestra el nombre crudo del archivo (site_template.rb `def name`) y el grupo derivado de la ruta (template_serializer.rb:57-60), o sea "errors", "disabled", "404", "template", sin traducir. Si el equipo prefiere mantener los nombres castellanizados, el cambio a revertir es solo la lista de bullets; la corrección de fondo (son tres, no cuatro) se mantiene igual.

2. Enlaces rotos que dejo de propagar. Los dos enlaces eliminados apuntaban a `/es/platform/channels/sites#privacidad` y `/en/platform/channels/sites#privacy`, anclas que hoy NO existen: en sites.md "Privacidad" es texto en negrita (línea 202), no un encabezado. No los reemplacé por otro enlace a sites.md para no inventar un ancla; sí enlazo a `#content-security-policy-csp`, que sí existe (sites.md:657 en ambos idiomas). Quedan enlaces `#privacidad` rotos en otras páginas (por ejemplo sites.md:613), fuera del alcance de esta tanda.

3. La ficha CHANNELS-20 describe mal el caso de segmentos. Dice que a quien no pertenece a los segmentos requeridos "no se renderiza una vista de error, se lo redirige al login del sitio o a la página anterior/home". El código dice otra cosa: sin usuario es RESTRICTED -> login_required (redirección), pero con usuario fuera de los segmentos es DENIED -> NotFoundError -> `site_404`, o sea SÍ se renderiza la vista 404 (check_resource_restrictions.rb:33-45 y dispatch_controller.rb:314-327). Documenté el comportamiento del código, no el de la ficha. Solo se redirige al home en ese caso si el sitio tiene activo **Redireccionar al home cuando una URL no se encuentra** (renders_404.rb:41).

4. Contradicción pendiente en otra página. `docs/es/platform/channels/pages.md:267` afirma que quienes no pertenecen a los segmentos "serán redirigidos a la página anterior o al home del sitio", lo que contradice el código y ahora también contradice a templates.md. No lo toqué porque pages.md no está en el alcance de esta tanda y hay PRs abiertos sobre páginas vecinas. Conviene una tanda o issue aparte para alinear pages.md.

5. Riesgo de build VuePress. El único `{{ }}` que queda fuera de una cerca de código es `nonce="{{csp_nonce}}"` en las viñetas, y va envuelto en `<span v-pre>` siguiendo la convención mayoritaria del corpus (liquid-markup.md, filters.md, public-api-reference.md). Todo lo demás está dentro de ```liquid. Conviene igual correr `yarn docs:build` antes de mergear.

6. Fidelidad de indentación. El layout real usa tabs; en el bloque publicado uso dos espacios por legibilidad y consistencia con el resto de los ejemplos de la página. El contenido (snippets, nonce, contenedores, orden) es idéntico al de `app/views/layouts/site/base.html.liquid` en origin/master.

7. No hay página nueva, así que no toco `docs/.vuepress/config.js`.

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
