### PR TITLE
Documentar el control de acceso de Insights, los rangos de fecha y las capacidades reales de los dashboards

### DIFF
--- a/docs/en/platform/insights/README.md
+++ b/docs/en/platform/insights/README.md
@@ -8,12 +8,15 @@ Modyo Insights is the platform's business intelligence center, where all data ge
 
 ## What is Modyo Insights?
 
-**Modyo Insights** centralizes and processes information from all Modyo modules to provide you with:
+**Modyo Insights** centralizes and processes information from Modyo modules and presents it in five fixed dashboards. Each one gathers the counters, charts, and filters of one module:
 
-- **Unified dashboards**: Consolidated visualization of metrics from Channels, Content, Customers, Payments, and Origination in one place
-- **Cross-analysis**: Data correlation between different modules to identify patterns and opportunities
-- **Integrated metrics**: KPIs that combine published content information, user behavior, transactions, and team activity
-- **Holistic reports**: 360° view of your digital ecosystem performance
+- [Apps](/en/platform/insights/apps.html): traffic and navigation of your web applications
+- [Customers](/en/platform/insights/customers.html): user activity, campaigns, and forms of a realm
+- [Digital Factory](/en/platform/insights/digital-factory.html): team activity on content, widgets, and pages
+- [Payments](/en/platform/insights/payments.html): orders, payment methods, and income of a realm
+- [Origination](/en/platform/insights/origination.html): origination submissions, conversion funnel, and abandonment
+
+Each dashboard is an independent screen, with its own filters and its own period. Insights does not correlate data across modules, does not generate downloadable reports, and does not allow you to create or customize dashboards. In addition, each member sees only the dashboards their role allows.
 
 ## Data Sources
 
@@ -56,16 +59,55 @@ Modyo Insights offers different data presentation formats depending on the type 
 
 - **Key Performance Indicators (KPIs)**: Main metrics and counters showing current status in summary form
 - **Time-series charts**: Line and bar visualizations to analyze trends and evolution over time
-- **Data tables**: Detailed information with sorting and filtering capabilities for specific analysis
-- **Heat maps**: Visual representation of activity patterns and event concentration
-- **Comparative charts**: Visualizations that allow contrasting metrics between different periods or segments
+- **Lists**: Name and value panels, such as **Recent Campaigns** and **Recent Forms** in the Customers dashboard. They are not tables: they show up to five rows and cannot be sorted or filtered
+- **Heat maps**: Visual representation of activity patterns, such as **Activity by User** in the Digital Factory dashboard
+- **Pie and funnel charts**: Visualizations of proportion over the total, such as **Engagement** in the Customers dashboard or the **Conversion Funnel** in the Origination one
 
 ## Analysis Capabilities
 
 Data can be analyzed and segmented using:
 
-- **Time filters**: Predefined or custom date ranges for historical analysis
-- **Contextual segmentation**: Specific filters based on the type of data being viewed
-- **Comparisons**: Period-over-period analysis to measure evolution and growth
-- **Drill-down**: Navigation from general metrics to specific details
-- **Custom views**: Dashboard configuration according to your business needs
+- **Time filters**: The date range selector, shared by the five dashboards
+- **Contextual segmentation**: The filters specific to each dashboard, such as site, space, realm, segment, origination, order state, or payment method
+- **Comparisons**: The variation percentage of each counter against the previous period
+- **Link to detail**: In the **Recent Campaigns** and **Recent Forms** panels of the Customers dashboard, each row links to that campaign's record or to that form's responses
+
+## Date Range and Period Comparison
+
+The five dashboards share the same date range selector in the filter bar, with a closed set of options:
+
+- **Last 7 days**
+- **Last 30 days**
+- **Month to date**: from the first day of the current month until today
+- **Last 3 months**
+- **Last 6 months**
+- **Last 12 months**
+- **Custom Range**: you choose the start and end dates, and confirm with **Select**
+
+When you open a dashboard, the preselected range is **Last 7 days** in Apps and **Last 3 months** in Customers, Digital Factory, Payments, and Origination.
+
+Counters that show a percentage and an arrow compare the selected range against a period of the same length immediately before it. If you choose **Last 30 days**, the comparison is against the 30 days prior to that stretch.
+
+:::tip Tip
+When the previous period recorded no data, the counter is shown without a percentage or arrow, because there is no baseline on which to calculate the variation.
+:::
+
+## Access and Permissions
+
+Access to Insights is granted in roles with the **Organization** scope, within the **Insights** permission group. The grouped permission **Admin Insights** enables the whole module and gathers five permissions that you can also grant separately:
+
+- **View Apps Dashboards**
+- **View Customers Dashboards**
+- **View Digital Factory Dashboards**
+- **View Payments Dashboards**
+- **View Originations Dashboards**
+
+The behavior you will observe is the following:
+
+1. The **Insights** icon in the side menu appears only if the member has at least one of the five permissions. If they have none, the module is not shown.
+2. When entering from the icon, the member lands on the first dashboard they are allowed to see, in the order **Apps**, **Customers**, **Digital factory**, **Payments**, **Originations**.
+3. Each dashboard requires its own permission, so a member can see some and not others.
+
+The **Default user** and **Default admin** default roles already include **Admin Insights**. In contrast, roles with the Channels, Content, or Customers scope do not grant access to Insights: a member who only has site, space, or realm roles does not see the module.
+
+To enable only some dashboards, create a [custom role](/en/platform/core/roles.html#custom-roles) with the **Organization** scope and check only the permissions you need.

--- a/docs/en/platform/insights/README.md
+++ b/docs/en/platform/insights/README.md
@@ -61,7 +61,7 @@ Modyo Insights offers different data presentation formats depending on the type 
 - **Time-series charts**: Line and bar visualizations to analyze trends and evolution over time
 - **Lists**: Name and value panels, such as **Recent Campaigns** and **Recent Forms** in the Customers dashboard. They are not tables: they show up to five rows and cannot be sorted or filtered
 - **Heat maps**: Visual representation of activity patterns, such as **Activity by User** in the Digital Factory dashboard
-- **Pie and funnel charts**: Visualizations of proportion over the total, such as **Engagement** in the Customers dashboard or the **Conversion Funnel** in the Origination one
+- **Pie and funnel charts**: Visualizations of proportion over the total, such as **Engagement** in the Customers dashboard or the **Conversion Funnel** in the Origination dashboard
 
 ## Analysis Capabilities
 

--- a/docs/es/platform/insights/README.md
+++ b/docs/es/platform/insights/README.md
@@ -8,12 +8,15 @@ Modyo Insights es el centro de inteligencia de negocio de la plataforma, donde c
 
 ### ¿Qué es Modyo Insights?
 
-**Modyo Insights** centraliza y procesa la información proveniente de todos los módulos de Modyo para ofrecerte:
+**Modyo Insights** centraliza y procesa la información proveniente de los módulos de Modyo y la presenta en cinco dashboards fijos. Cada uno reúne los contadores, gráficos y filtros de un módulo:
 
-- **Dashboards unificados**: Visualización consolidada de métricas de Channels, Content, Customers, Payments y Origination en un solo lugar
-- **Análisis cruzado**: Correlación de datos entre diferentes módulos para identificar patrones y oportunidades
-- **Métricas integradas**: KPIs que combinan información de contenido publicado, comportamiento de usuarios, transacciones y actividad del equipo
-- **Reportes holísticos**: Visión 360° del rendimiento de tu ecosistema digital
+- [Apps](/es/platform/insights/apps.html): tráfico y navegación de tus aplicaciones web
+- [Customers](/es/platform/insights/customers.html): actividad de los usuarios, campañas y formularios de un reino
+- [Digital Factory](/es/platform/insights/digital-factory.html): actividad del equipo sobre contenidos, widgets y páginas
+- [Payments](/es/platform/insights/payments.html): órdenes, medios de pago e ingresos de un reino
+- [Origination](/es/platform/insights/origination.html): respuestas de originación, embudo de conversión y abandono
+
+Cada dashboard es una pantalla independiente, con sus propios filtros y su propio período. Insights no correlaciona datos entre módulos, no genera reportes descargables y no permite crear ni personalizar dashboards. Además, cada miembro ve solo los dashboards que su rol le permite.
 
 ### Fuentes de datos
 
@@ -56,16 +59,55 @@ Modyo Insights ofrece diferentes formatos de presentación de datos según el ti
 
 - **Indicadores clave (KPIs)**: Métricas principales y contadores que muestran el estado actual de forma resumida
 - **Gráficos temporales**: Visualizaciones de líneas y barras para analizar tendencias y evolución en el tiempo
-- **Tablas de datos**: Información detallada con capacidad de ordenamiento y filtrado para análisis específicos
-- **Mapas de calor**: Representación visual de patrones de actividad y concentración de eventos
-- **Gráficos comparativos**: Visualizaciones que permiten contrastar métricas entre diferentes períodos o segmentos
+- **Listados**: Paneles de nombre y valor, como **Campañas Recientes** y **Formularios Recientes** en el dashboard de Customers. No son tablas: muestran hasta cinco filas y no se ordenan ni se filtran
+- **Mapas de calor**: Representación visual de patrones de actividad, como **Actividad por Usuario** en el dashboard de Digital Factory
+- **Gráficos de torta y de embudo**: Visualizaciones de proporción sobre el total, como **Engagement** en el dashboard de Customers o el **Embudo de conversión** en el de Origination
 
 ### Capacidades de análisis
 
 Los datos pueden ser analizados y segmentados mediante:
 
-- **Filtros temporales**: Rangos de fechas predefinidos o personalizados para análisis histórico
-- **Segmentación contextual**: Filtros específicos según el tipo de datos visualizados
-- **Comparativas**: Análisis período contra período para medir evolución y crecimiento
-- **Drill-down**: Navegación desde métricas generales hasta detalles específicos
-- **Vistas personalizadas**: Configuración de dashboards según tus necesidades de negocio
+- **Filtros temporales**: El selector de rango de fechas, común a los cinco dashboards
+- **Segmentación contextual**: Los filtros propios de cada dashboard, como sitio, espacio, reino, segmento, originación, estado de la orden o medio de pago
+- **Comparativas**: El porcentaje de variación de cada contador respecto del período anterior
+- **Enlace al detalle**: En los paneles **Campañas Recientes** y **Formularios Recientes** del dashboard de Customers, cada fila lleva a la ficha de esa campaña o a las respuestas de ese formulario
+
+### Rango de fechas y comparación de períodos
+
+Los cinco dashboards comparten el mismo selector de rango de fechas en la barra de filtros, con un conjunto cerrado de opciones:
+
+- **Últimos 7 días**
+- **Últimos 30 días**
+- **Un mes a la fecha**: desde el primer día del mes en curso hasta hoy
+- **Últimos 3 meses**
+- **Últimos 6 meses**
+- **Últimos 12 meses**
+- **Rango Personalizado**: eliges la fecha de inicio y la de término, y confirmas con **Seleccionar**
+
+Al abrir un dashboard, el rango preseleccionado es **Últimos 7 días** en Apps y **Últimos 3 meses** en Customers, Digital Factory, Payments y Origination.
+
+Los contadores que muestran un porcentaje y una flecha comparan el rango seleccionado contra un período de la misma duración inmediatamente anterior. Si eliges **Últimos 30 días**, la comparación es contra los 30 días previos a ese tramo.
+
+:::tip Tip
+Cuando el período anterior no registró ningún dato, el contador se muestra sin porcentaje ni flecha, porque no hay base sobre la cual calcular la variación.
+:::
+
+### Acceso y permisos
+
+El acceso a Insights se otorga en roles con scope **Organización**, dentro del grupo de permisos **Insights**. El permiso agrupado **Administrar Insights** habilita el módulo completo y reúne cinco permisos que también puedes otorgar por separado:
+
+- **Ver Dashboards de Aplicaciones**
+- **Ver Dashboards de Clientes**
+- **Ver Dashboards de Fábrica Digital**
+- **Ver Dashboards de Pagos**
+- **Ver Dashboards de Originaciones**
+
+El comportamiento que vas a observar es el siguiente:
+
+1. El ícono de **Insights** del menú lateral aparece solo si el miembro tiene al menos uno de los cinco permisos. Si no tiene ninguno, el módulo no se muestra.
+2. Al entrar desde el ícono, el miembro aterriza en el primer dashboard que tenga permitido, en el orden **Aplicaciones**, **Clientes**, **Fábrica digital**, **Pagos**, **Originaciones**.
+3. Cada dashboard exige su propio permiso, así que un miembro puede ver unos y no otros.
+
+Los roles predeterminados **Default user** y **Default admin** ya incluyen **Administrar Insights**. En cambio, los roles con scope Channels, Content o Customers no otorgan acceso a Insights: un miembro que solo tenga roles de sitio, espacio o reino no ve el módulo.
+
+Para habilitar únicamente algunos dashboards, crea un [rol a medida](/es/platform/core/roles.html#roles-a-medida) con scope **Organización** y marca solo los permisos que necesitas.


### PR DESCRIPTION
## Cambios propuestos

El índice de Modyo Insights prometía capacidades que el producto no tiene, no explicaba que el acceso al módulo y a cada dashboard depende de permisos concretos, y dejaba sin definir el selector de rango de fechas y el período de comparación, que son transversales a los cinco dashboards. Este PR corrige lo primero y documenta lo segundo y lo tercero, en español y en inglés.

### docs/es/platform/insights/README.md y docs/en/platform/insights/README.md

**Qué es Modyo Insights**

- Se reemplazan las viñetas por el listado enlazado de los cinco dashboards (Apps, Customers, Digital Factory, Payments y Origination) con lo que cubre cada uno, siguiendo el patrón de los otros índices de módulo.
- Se eliminan **Análisis cruzado** y **Reportes holísticos**: Insights no correlaciona datos entre módulos ni genera reportes. Se explicita que cada dashboard es una pantalla independiente, que no se pueden crear ni personalizar dashboards, y que cada miembro ve solo los que su rol le permite.

**Tipos de visualizaciones**

- Se corrigen las **Tablas de datos** "con capacidad de ordenamiento y filtrado": los dos únicos paneles tabulares son listas de nombre y valor de hasta cinco filas, sin orden ni filtro. Se renombran a **Listados** con el ejemplo real (**Campañas Recientes** y **Formularios Recientes**, en el dashboard de Customers).
- Se reemplazan los **Gráficos comparativos** inexistentes por los gráficos de torta y de embudo que sí existen (**Engagement** en Customers, **Embudo de conversión** en Origination), y se acota el mapa de calor a su panel real (**Actividad por Usuario**, en Digital Factory).

**Capacidades de análisis**

- Se elimina **Vistas personalizadas**, que no tiene implementación.
- **Drill-down** se reemplaza por **Enlace al detalle**, acotado a la única navegación que existe: las filas de campañas y formularios recientes llevan a la ficha de la campaña o a las respuestas del formulario.
- **Filtros temporales**, **Segmentación contextual** y **Comparativas** se redactan con los filtros reales de cada dashboard.

**Rango de fechas y comparación de períodos** (sección nueva)

- Se enumera el conjunto cerrado de opciones del selector, común a los cinco dashboards: Últimos 7 días, Últimos 30 días, Un mes a la fecha, Últimos 3 meses, Últimos 6 meses, Últimos 12 meses y Rango Personalizado.
- Se indica el rango preseleccionado de cada dashboard: Últimos 7 días en Apps y Últimos 3 meses en Customers, Digital Factory, Payments y Origination.
- Se define qué significan el porcentaje y la flecha de cada contador: la comparación es contra un período de la misma duración inmediatamente anterior al seleccionado. Un callout aclara que cuando el período anterior no tuvo datos, el contador aparece sin porcentaje ni flecha.

**Acceso y permisos** (sección nueva)

- Se documenta que el acceso se otorga en roles con scope Organización, dentro del grupo de permisos Insights, y se listan el permiso agrupado Administrar Insights y los cinco permisos por dashboard que reúne.
- Se describe el comportamiento observable: el ícono del menú lateral aparece solo si el miembro tiene al menos uno de los cinco permisos, y el enlace lo lleva al primer dashboard permitido en el orden Aplicaciones, Clientes, Fábrica digital, Pagos, Originaciones.
- Se aclara que Default user y Default admin ya traen Administrar Insights, y que los roles con scope Channels, Content o Customers no dan acceso al módulo.
- Se enlaza a Roles a medida en la página de equipos y roles en vez de duplicar ahí el catálogo de permisos, para no romper el estándar de esa página.

### Notas

- Todas las etiquetas se tomaron literales de los locales del panel, en español y en inglés.
- No hay páginas nuevas: las cinco subpáginas de Insights ya están registradas en el sidebar en ambos idiomas, así que no se toca la configuración de VuePress.

Cierra los gaps INSIGHTS-REPORTES-16, INSIGHTS-REPORTES-23 e INSIGHTS-REPORTES-24.

## Para el revisor

1. Rótulo del filtro de fechas. En el panel, solo el dashboard de Originaciones traduce el título del filtro (Originations.js:335 usa `I18n.t('admin.insights.filters.since')` = "Rango de fechas" / "Date range"). Los otros cuatro lo reciben hardcodeado en inglés desde ChartsHelper.js:49 (`title: 'Date range'`) y RenderFilters.js lo pasa sin traducir. Por eso el texto habla de "el selector de rango de fechas" en vez de poner un rótulo en negrita que sería falso en cuatro de cinco pantallas. Si se arregla el hardcode en el producto, se puede volver a **Rango de fechas** en negrita sin tocar nada más. Las opciones del selector sí están traducidas (UIFilterDateRange.js:44) y esas sí van en negrita.

2. Contradicción heredada en las subpáginas. docs/es/platform/insights/apps.md:20 sigue listando un filtro "Tipo de dispositivo" y una sección "Fuentes de Tráfico" que Apps.js:84 no arma (solo date-range y sitio). No lo toqué porque son páginas de otras tandas; el índice ahora describe los filtros reales, así que el lector puede notar el desajuste hasta que esas tandas corrijan las subpáginas.

3. Sección "Fuentes de datos". Quedó intacta, aunque enumera insumos que no siempre tienen un panel visible (por ejemplo "Patrones de uso por dispositivo" o "Uso de assets y recursos"). Es una lista conceptual de orígenes, no una promesa de visualización, y la tanda no la pedía; queda como candidata para una tanda posterior.

4. Alcance de core/roles.md. Siguiendo la nota de la ficha, no se abre un catálogo de permisos ahí: la página no enumera permisos concretos de ningún módulo y hacerlo solo para Insights sería inconsistente. El desglose vive en el README de Insights y se enlaza a [Roles a medida], que ya trae de un PR vecino la nota de que algunos permisos incluyen a otros (docs/es/platform/core/roles.md:126). Si más adelante se decide abrir un catálogo, esta sección es el insumo natural.

5. Rol Full admin. No se menciona en la sección de permisos porque config/roles/account_owner.yml no declara grouped_permissions y roles.md:84 ya dice que tiene todos los permisos existentes; repetirlo aquí habría sido ruido.

6. Detalle de API omitido a propósito. La ficha pedía documentar que los endpoints de Insights exigen el permiso en contexto de cuenta (insights_permissions.rb:23-54). Se documentó su efecto observable (el permiso se otorga en roles con scope Organización) y no el interno de la API, que no tiene página pública en modyo-docs.

Closes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)
