### PR TITLE
Documentar el método de autenticación y PKCE de OpenID Connect y el contrato del servidor SCIM

### DIFF
--- a/docs/en/platform/core/integrations/identity-providers.md
+++ b/docs/en/platform/core/integrations/identity-providers.md
@@ -119,6 +119,27 @@ The API for obtaining delegated access tokens via `/auth/openidc/access_token` i
 
 <img src="/assets/img/platform/keycloak-new-idp.png" alt="Modyo's new identity provider page." width="500px" style="margin-top: 40px; border: 1px solid #EEE;" />
 
+### Authentication Method and PKCE
+
+**Authentication Method** is a required field that defines how Modyo delivers the client credentials to your provider. It has three possible values:
+
+| Option | Description |
+|:--|:--|
+| **Client secret sent as basic authentication header** | The **Secret** travels in the `Authorization` header, using basic authentication. This is the default value. |
+| **Client secret sent as form parameter** | The **Secret** travels in the request body, as one more parameter. |
+| **Disabled, client secret is not sent** | Modyo does not send the **Secret** to the provider and the field is no longer required. Use it when the provider registered the application as a public client. |
+
+The method you choose applies to every call Modyo makes to the provider with the client credentials: the authorization code exchange, the refresh token renewal, and the token revocation.
+
+If your provider requires proof key for code exchange, turn on **Enable proof key for code exchange (PKCE)**. When you do, **Proof key for code exchange method** becomes required and accepts two values:
+
+- **S256**: Modyo sends the challenge as the SHA-256 hash of the verifier. This is the default value.
+- **plain**: Modyo sends the verifier without transforming it. Use it only if your provider does not support S256.
+
+:::tip Tip
+If the provider registered the application as a public client, combine **Disabled, client secret is not sent** with PKCE enabled on **S256**.
+:::
+
 ### Optional integration settings
 
 When performing a specific integration, Modyo allows you to enable certain settings to control the following session features:
@@ -127,11 +148,13 @@ When performing a specific integration, Modyo allows you to enable certain setti
 |:--------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Enable logout**                                      | Enable logging out of the provider when logging out of Modyo. This allows the session to be effectively closed, forcing the user to identify themselves again with the Identity Provider and disabling the SSO experience.                                                                                                         |
 | **Enable refresh token**                                         | Enable token refreshment managed by Modyo. The access tokens will be automatically renewed by the platform if the user maintains activity on the site and has a valid refresh token.                                                                                                                   |
-| **Tolerance in seconds for access token**                        | Number in seconds that will be used as a margin of tolerance to obtain an access token using the refresh token.                                                                                                                                                                                                           |
+| **Time in seconds for the anticipation of the preventive refresh token** | Number in seconds that will be used as a margin of tolerance to obtain an access token using the refresh token. It accepts values between 0 and 100. |
 | **Enable token revocation**                                   | Enables revocation of access tokens via API. For revocation, you can use the provider's endpoint to revoke tokens.                              |
 | **Activate refresh token**                  | Enables the use of OAuth 2.0 refresh tokens. To refresh your access token, you can use the provider's POST endpoint by sending <tt> grant_type: refresh_token, refresh_token: **my-refresh-token**, client_id: **my-client-id** </tt>  |
 | **Show delegation information**                               | Enable more information in the [User Profile API](/en/platform/customers/api) regarding delegated tokens. This is useful when the access token issued by the identity provider is needed to gain access to another service (e.g., an external API).                           |
 | **Enable claims synchronization at login** | Enable synchronization of OpenID Connect claims with custom fields in Modyo. More information in [Claims Synchronization](#claims-synchronization).                                                                                                                                                                      |
+| **Enable User Info** | Lets Modyo query the provider's User Info endpoint to complete the user's data. It comes enabled by default and, while it is active, **Userinfo endpoint** is required; the discovery service fills it in for you. If you turn it off, Modyo only uses the claims that come in the id_token. |
+| **Include id_token_hint on logout** | Adds the `id_token_hint` parameter, with the session's id_token, to the remote logout URL. Many providers use it to identify the session being closed and skip the confirmation screen. It only takes effect if remote logout is enabled. |
 
 
 

--- a/docs/en/platform/core/integrations/scim.md
+++ b/docs/en/platform/core/integrations/scim.md
@@ -83,6 +83,24 @@ Username and email are required fields to generate users. Without them, user pro
 :::
 
 
+### SCIM server contract
+
+Besides Entra ID, you can connect any SCIM 2.0 client to the Modyo server. The base URL is `https://[account_host]/api/admin/scim` and calls are authenticated with the administrative user token, just like in the rest of the [Administration API](/en/platform/core/api.html#bearer-token). The users this server manages are the **Team** ones, not the Customers ones.
+
+| Resource | Methods | Description |
+|:--|:--|:--|
+| `/Users` | `GET`, `POST` | Lists and creates users. The listing supports pagination with `startIndex` and `count`, and the `userName eq` and `externalId eq` filters. |
+| `/Users/:id` | `GET`, `PATCH` | Gets and updates a user. `PATCH` accepts operations on `userName`, `name`, `emails`, and `active`. |
+| `/Groups` | `GET`, `POST` | Lists and creates groups. |
+| `/Groups/:id` | `GET`, `PATCH`, `DELETE` | Gets, updates, and deletes a group. |
+| `/Schemas` | `GET` | Returns the definition of the `urn:ietf:params:scim:schemas:core:2.0:User` and `urn:ietf:params:scim:schemas:core:2.0:Group` schemas with all their attributes. Use it if your client discovers the schema before provisioning. This endpoint is not listed in the Swagger portal, so this table is its reference. |
+
+Every response, including errors, uses the `application/scim+json` content type and not the `application/json` declared by the rest of the Administration API. Make sure your client accepts it.
+
+:::warning Attention
+User deprovisioning is not done with `DELETE`. The `DELETE /api/admin/scim/Users/:id` route exists, but it has no implementation: the request ends in a generic error, with no SCIM response, and the user is not changed. To deprovision, send a `PATCH` to `/Users/:id` with the `active` property set to `false`. For groups, `DELETE` is implemented.
+:::
+
 ### References
 - To build a SCIM API compatible with Entra ID, follow this guide from Microsoft. [Use SCIM to Provision Users and Groups](https://docs.microsoft.com/en-us/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups)
 - For more information on the APIs that Modyo offers, see [Administration API](https://docs.modyo.com/en/platform/core/api).

--- a/docs/es/platform/core/integrations/identity-providers.md
+++ b/docs/es/platform/core/integrations/identity-providers.md
@@ -119,6 +119,27 @@ La API para obtención de access tokens delegados vía  `/auth/openidc/access_to
 
 <img src="/assets/img/platform/keycloak-new-idp.png" alt="Modyo's new identity provider page." width="500px" style="margin-top: 40px; border: 1px solid #EEE;" />
 
+### Método de autenticación y PKCE
+
+**Método de autenticación** es un campo obligatorio que define cómo Modyo entrega las credenciales del cliente a tu proveedor. Tiene tres valores posibles:
+
+| Opción | Descripción |
+|:--|:--|
+| **Client secret enviado como cabecera de autenticación básica** | El **Secreto** viaja en la cabecera `Authorization`, con autenticación básica. Es el valor por defecto. |
+| **Client secret enviado como parámetro de formulario** | El **Secreto** viaja en el cuerpo de la solicitud, como un parámetro más. |
+| **Deshabilitado, client secret no es enviado** | Modyo no envía el **Secreto** al proveedor y el campo deja de ser obligatorio. Úsalo cuando el proveedor registró la aplicación como cliente público. |
+
+El método que elijas se aplica a todas las llamadas que Modyo hace al proveedor con las credenciales del cliente: el intercambio del código de autorización, la renovación con refresh token y la revocación de tokens.
+
+Si tu proveedor exige proof key for code exchange, activa **Habilitar proof key for code exchange (PKCE)**. Al hacerlo, **Método de proof key for code exchange** pasa a ser obligatorio y admite dos valores:
+
+- **S256**: Modyo envía el desafío como hash SHA-256 del verificador. Es el valor por defecto.
+- **plain**: Modyo envía el verificador sin transformar. Úsalo solo si tu proveedor no soporta S256.
+
+:::tip Tip
+Si el proveedor registró la aplicación como cliente público, combina **Deshabilitado, client secret no es enviado** con PKCE habilitado en **S256**.
+:::
+
 ### Configuraciones opcionales de la integración
 
 Al momento de realizar una integración específica, Modyo te permite habilitar ciertas configuraciones para controlar las siguientes características de sesión:
@@ -127,11 +148,13 @@ Al momento de realizar una integración específica, Modyo te permite habilitar 
 |:--------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Habilitar cierre de sesión**                                      | Habilita el cierre de sesión en el provider al cerrar la sesión en Modyo. Esto permite cerrar efectivamente la sesión, obligando al usuario a identificarse nuevamente en el Proveedor de Identidad y deshabilitando la experiencia SSO.                                                                                                         |
 | **Habilitar refresh token**                                         | Habilita el refresco de tokens administrado por Modyo. Los access tokens serán renovados automáticamente por la plataforma si el usuario mantiene actividad en el sitio y cuenta con un refresh token válido.                                                                                                                   |
-| **Tolerancia en segundos para access token**                        | Número en segundos que será usado como margen de tolerancia para obtener un access token utilizando el refresh token.                                                                                                                                                                                                           |
+| **Tiempo en segundos para la anticipación preventiva del refresh token** | Número en segundos que será usado como margen de tolerancia para obtener un access token utilizando el refresh token. Admite valores entre 0 y 100. |
 | **Habilitar revocación de token**                                   | Habilita la revocación de access tokens a través de API. Para la revocación, puedes usar el endpoint del proveedor para revokar tokens.                              |
 | **Activar token de actualización (Refresh Token)**                  | Habilita el uso de tokens de actualización de OAuth 2.0. Para refrescar tu access token, puedes usar el POST endpoint del proveedor enviando como headers <tt>grant_type: refresh_token, refresh_token: **mi-refresh-token**, client_id: **mi-client-id**</tt> |
 | **Mostrar información de delegación**                               | Habilita más información en la [API de perfil de usuario](/es/platform/customers/api#api-de-customers) con respecto a tokens delegados. Esto es útil cuando se necesita el access token que emite el proveedor de identidad para conseguir acceso a algún otro servicio (e.g. una API externa).                           |
 | **Habilitar sincronización de claims al momento de iniciar sesión** | Habilita la sincronización de claims OpenID Connect con custom fields en Modyo. Más información en  [Sincronización de claims](#sincronizacion-de-claims).                                                                                                                                                                      |
+| **Habilitar User Info** | Permite que Modyo consulte el endpoint de User Info del proveedor para completar los datos del usuario. Viene habilitada por defecto y, mientras esté activa, **Endpoint de User Info** es obligatorio; el servicio de descubrimiento lo completa por ti. Si la desactivas, Modyo usa solo los claims que vienen en el id_token. |
+| **Incluir id_token_hint al cerrar sesión** | Agrega el parámetro `id_token_hint`, con el id_token de la sesión, a la URL de cierre de sesión remoto. Muchos proveedores lo usan para identificar la sesión que se cierra y omitir la pantalla de confirmación. Solo tiene efecto si el cierre de sesión remoto está habilitado. |
 
 
 

--- a/docs/es/platform/core/integrations/scim.md
+++ b/docs/es/platform/core/integrations/scim.md
@@ -83,6 +83,24 @@ Nombre del usuario y correo electrónico son campos requeridos para generar usua
 :::
 
 
+### Contrato del servidor SCIM
+
+Además de Entra ID, puedes conectar cualquier cliente SCIM 2.0 contra el servidor de Modyo. La URL base es `https://[account_host]/api/admin/scim` y las llamadas se autentican con el token del usuario administrativo, igual que en el resto de la [API de administración](/es/platform/core/api.html#bearer-token). Los usuarios que administra este servidor son los de **Equipo**, no los de Customers.
+
+| Recurso | Métodos | Descripción |
+|:--|:--|:--|
+| `/Users` | `GET`, `POST` | Lista y crea usuarios. El listado admite paginación con `startIndex` y `count`, y los filtros `userName eq` y `externalId eq`. |
+| `/Users/:id` | `GET`, `PATCH` | Consulta y actualiza un usuario. El `PATCH` acepta operaciones sobre `userName`, `name`, `emails` y `active`. |
+| `/Groups` | `GET`, `POST` | Lista y crea grupos. |
+| `/Groups/:id` | `GET`, `PATCH`, `DELETE` | Consulta, actualiza y elimina un grupo. |
+| `/Schemas` | `GET` | Devuelve la definición de los esquemas `urn:ietf:params:scim:schemas:core:2.0:User` y `urn:ietf:params:scim:schemas:core:2.0:Group` con todos sus atributos. Úsalo si tu cliente descubre el esquema antes de aprovisionar. Este endpoint no aparece en el portal Swagger, así que esta tabla es su referencia. |
+
+Todas las respuestas, incluidas las de error, usan el content type `application/scim+json` y no el `application/json` que declara el resto de la API de administración. Asegúrate de que tu cliente lo acepte.
+
+:::warning Atención
+La baja de usuarios no se hace con `DELETE`. La ruta `DELETE /api/admin/scim/Users/:id` existe, pero no tiene implementación: la solicitud termina en un error genérico, sin respuesta SCIM, y el usuario no cambia. Para desaprovisionar, envía un `PATCH` a `/Users/:id` con la propiedad `active` en `false`. En grupos, `DELETE` sí está implementado.
+:::
+
 ### Referencias
 - Para construir un API de SCIM compatible con Entra ID, sigue esta guía de Microsoft. [Use SCIM to Provision Users and Groups](https://docs.microsoft.com/en-us/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups)
 - Para más información de las APIs que Modyo ofrece, ve [API de administración](https://docs.modyo.com/es/platform/core/api).


### PR DESCRIPTION
## Cambios propuestos

Documenta las opciones avanzadas de la integración OpenID Connect y el contrato del servidor SCIM de Modyo, en español y en inglés. Todo se verificó contra `origin/master`, que no tiene diferencias con `releases/10.2-stable` en los archivos involucrados.

### `platform/core/integrations/identity-providers.md`

Nueva sección **Método de autenticación y PKCE**, entre la configuración de la integración y las configuraciones opcionales:

- **Método de autenticación**, campo obligatorio con sus tres valores reales del panel (cabecera de autenticación básica, parámetro de formulario, deshabilitado), qué implica cada uno para el envío del **Secreto** y en qué llamadas se aplica el método elegido.
- **Habilitar proof key for code exchange (PKCE)** y **Método de proof key for code exchange**, con la diferencia entre `S256` y `plain`, cuál es el valor por defecto y cuándo el método pasa a ser obligatorio.
- Un tip para el caso más frecuente en integraciones corporativas: cliente público sin secreto más PKCE en `S256`.

En la tabla de configuraciones opcionales:

- Dos filas nuevas: **Habilitar User Info** con su **Endpoint de User Info** (incluye qué pasa si la desactivas: Modyo usa solo los claims del id_token) e **Incluir id_token_hint al cerrar sesión**.
- La fila del margen de segundos para el refresh token ahora declara que solo admite valores entre 0 y 100, y usa el nombre con el que el campo aparece realmente en el panel.

Cierra CONFIGURACIONES-12.

### `platform/core/integrations/scim.md`

Nueva sección **Contrato del servidor SCIM**, junto a la guía de Entra ID, para cualquier IdP que no sea Entra ID:

- Tabla de recursos con `/Users`, `/Groups` y `/Schemas`, sus métodos soportados, los filtros y la paginación del listado. `/Schemas` no estaba documentado en ninguna parte ni aparece en el portal Swagger.
- El content type de todas las respuestas, incluidos los errores, es `application/scim+json` y no el `application/json` que declara el resto de la API de administración.
- Una advertencia: `DELETE /api/admin/scim/Users/:id` está ruteado pero no implementado, así que la baja de usuarios se hace con `PATCH` y `active` en `false`. En grupos el `DELETE` sí funciona.
- Se aclara que los usuarios que administra este servidor son los de **Equipo** y no los de Customers.

Cierra API-ADMIN-16.

## Para el revisor

Tres cosas para revisar antes de mergear. (1) Renombré la fila del clock skew de "Tolerancia en segundos para access token" a "Tiempo en segundos para la anticipación preventiva del refresh token" porque ese es el label real que renderiza el panel; el nombre viejo no existe en el producto y quien lo buscara no lo encontraba. Es un cambio de nombre visible en una fila que ya estaba publicada. (2) En esa misma tabla quedan otros labels desactualizados que no toqué por estar fuera del alcance de la tanda: "Habilitar cierre de sesión" hoy es "Habilitar cierre de sesión remoto", "Habilitar refresh token" hoy es "Activar refresh token" y la fila "Activar token de actualización (Refresh Token)" duplica el mismo campo. Por eso en la fila nueva de id_token_hint escribí "si el cierre de sesión remoto está habilitado" en vez de citar el label en negrita: citarlo habría chocado con la fila vieja. Conviene una tanda de limpieza de esa tabla. (3) El formulario del panel acepta hasta 1000 en el campo de segundos por una validación de front-end, pero el modelo rechaza cualquier valor sobre 100; documenté el 0-100 porque es el que manda al guardar. Además, el campo **Secreto** aparece marcado como requerido en el formulario aunque el método sea "Deshabilitado, client secret no es enviado"; la validación del servidor sí lo exime, que es lo que documenté. Sobre el DELETE de SCIM: la ruta existe sin acción, así que la respuesta la produce el manejo de errores genérico de Rails y no el manejador SCIM; por eso describí el efecto ("un error genérico, sin respuesta SCIM") sin comprometerme con un código de estado.

Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)
