### PR TITLE
Documenta en la API de Customers el nuevo contrato de assignee, la respuesta 429 de OTP y los adjuntos de respuestas

### DIFF
--- a/docs/en/platform/customers/api.md
+++ b/docs/en/platform/customers/api.md
@@ -56,6 +56,154 @@ If you enable the [**Show delegation information**](/en/platform/core/integratio
 If you do not have the **Show delegation information** option enabled, null (void) will be displayed.
 :::
 
+### Update user information
+
+With `PUT ACCOUNT_URL/api/customers/realms/{realm_uid}/me` the session user updates their own data. Besides the profile attributes, the body accepts `custom_fields` as an array of `key` and `value` pairs.
+
+:::warning Attention
+Custom fields that do not have **Visible to front end users** and **Editable by front end users** checked in the [realm settings](/en/platform/customers/settings.html#custom-fields) are silently discarded: the response is `200`, the rest of the attributes are saved and those fields keep their previous value, with no error to signal it.
+:::
+
+## Origination submissions
+
+### Get a submission
+
+`GET ACCOUNT_URL/api/customers/realms/{realm_uid}/submissions/{uuid}`
+
+Returns the [origination submission](/en/platform/customers/origination.html#submission-management) identified by `uuid`, as long as it belongs to the session user. If the identifier does not exist or the submission belongs to another user, the endpoint returns `404`.
+
+The body carries the following attributes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `id`, `uuid` | Submission identifiers. |
+| `status` | `not_started`, `pending`, `completed` or `canceled`. |
+| `progress` | Percentage of completed tasks, as text. For example, `25%`. |
+| `due` | Ready-to-display text with the deadline and its status. |
+| `due_deadline_at` | Raw deadline date and time. It is `null` when the origination has no deadline configured or when the submission has not started, is completed or is canceled. |
+| `due_label` | Label that replaces the date when there is no deadline, such as `Not started` or `--`. It is `null` when `due_deadline_at` carries a value. |
+| `due_status_label` | Deadline status label in parentheses, such as `(On track)`, `(Due soon)` or `(Overdue)`. It is `null` when the submission is not pending. |
+| `due_extension_days` | Extension days granted to the deadline, or `null` if the origination has no deadline configured. |
+| `created_at`, `updated_at`, `started_at` | Creation, last update and start dates of the submission. |
+| `origination_name`, `origination_uuid` | Name and identifier of the origination. |
+| `cancellation_reason` | Cancellation reason entered when the submission was canceled, or `null`. |
+| `user` | Owner of the submission, with `id`, `uuid`, `name`, `first_name` and `last_name`. |
+| `assignee` | Assigned admin or group, or `null` if the submission is not assigned. |
+| `tasks` | Array with the responses to the origination tasks. |
+
+:::tip Tip
+`due`, `due_label` and `due_status_label` are texts meant to be displayed as they arrive. To make decisions in your code use `status` and `due_deadline_at`.
+:::
+
+#### The assignee object
+
+Up to version 10.1, `assignee` was a flat object with the assigned admin data: `id`, `uuid`, `name`, `first_name` and `last_name`. From 10.2 a submission can be assigned to a whole group or to an admin picked inside a group, as described in [Assign submission](/en/platform/customers/origination.html#assign-submission), so `assignee` adds the `type` attribute and the rest of its content changes according to that value:
+
+| `type` | Attributes |
+|--------|------------|
+| `group` | `id` and `name` of the assigned group, and `label` with the group name. It does not carry `uuid`, `first_name` or `last_name`. |
+| `user_in_group` | `id`, `uuid`, `name`, `first_name` and `last_name` of the admin, `group_id` and `group_name` of the group they were picked from, and `label` with the format `Admin name (Group name)`. |
+| `user` | `id`, `uuid`, `name`, `first_name` and `last_name` of the admin, and `label` with their name. |
+
+```json
+{
+  "assignee": {
+    "type": "group",
+    "id": 14,
+    "name": "Account managers",
+    "label": "Account managers"
+  }
+}
+```
+
+:::warning Attention
+If your application reads `assignee.uuid` without checking `type`, it breaks when the submission is assigned to a group: that variant does not include `uuid` and its `id` belongs to the group, not to an admin. Always check `assignee.type` before reading the rest of the attributes, and use `assignee.label` when you only need to display the assignee.
+:::
+
+#### The task responses
+
+Each element of `tasks` carries `task`, with the `uid`, `name`, `type` and `step_name` of the task; `status`, with `not_started`, `pending` or `completed`; `user_id`, and the assignee data of that task in `assignee_id`, `assignee_group_id`, `assignee_context_group_id` and `assignee_label`. Input tasks add `fields` with the user answers, and pending review tasks add `content`. Task responses whose task no longer exists in the origination are not included in the array.
+
+:::warning Attention
+Pending review tasks stopped returning the boolean `completed` key in 10.2. To know whether the review is finished, compare `status` with `completed`.
+:::
+
+## OTP code verification
+
+`POST ACCOUNT_URL/api/customers/realms/{realm_uid}/verify_otp_code`
+
+Verifies the one-time code of [Soft login](/en/platform/customers/settings.html#soft-login). It is the only Customers API endpoint that does not require an active session. The body carries `identifier`, with the username, and `code`, with the received code.
+
+| Code | Meaning |
+|------|---------|
+| `200` | The code is valid. The body arrives as an empty object. |
+| `409` | The code is not valid or already expired. |
+| `429` | The maximum of five failed attempts was exceeded. New in 10.2. |
+
+Both `409` and `429` carry the `errors` array with a ready-to-display text:
+
+```json
+{
+  "errors": ["You have exceeded the maximum number of attempts."]
+}
+```
+
+:::warning Attention
+After five failed attempts the endpoint responds `429` even when the code sent is the correct one, because the validation stops at the attempt count before comparing the code. Treat `429` as a case apart from `409`: the user cannot keep retrying and the only way out is to request a new code, which resets the counter.
+:::
+
+The code stops being valid once the time set in **OTP validity duration (in minutes)** of the realm goes by, five minutes by default. Check [Soft login](/en/platform/customers/settings.html#soft-login) for the details of that setting.
+
+## Submission attachments
+
+File questions of an origination receive their attachments through these two endpoints. Both require an active session, always work on the files of the session user, and do not appear in the interactive reference at `ACCOUNT_URL/api/customers/docs`.
+
+### Upload a file
+
+`POST ACCOUNT_URL/api/customers/realms/{realm_uid}/private_upload/answer`
+
+Send a `multipart/form-data` request with these parameters:
+
+- `file`: the file to upload. It is required.
+- `question_id`: identifier of the file question the attachment belongs to. It is optional.
+
+With `200`, the body describes the stored file:
+
+```json
+{
+  "id": 431,
+  "uuid": "586e591c-1f07-4f6d-b886-a66fea953afe",
+  "name": "receipt.pdf",
+  "size": 60548,
+  "url": "/uploads/586e591c-1f07-4f6d-b886-a66fea953afe/original/receipt.pdf"
+}
+```
+
+The file is stored as private and associated with the session user. Use the numeric `id` as the value of the answer to the file question, and the `uuid` to delete the attachment.
+
+| Code | Meaning |
+|------|---------|
+| `401` | There is no active session. |
+| `404` | The `question_id` sent does not match any file question. |
+| `422` | The file did not pass the validations. |
+
+The `422` body carries the `errors` array with one text per rejection reason, prefixed with the file name. A file is rejected when it is missing, when its extension is not allowed on the platform, when its content does not match the declared extension, or when it exceeds the maximum size allowed on your account.
+
+### Delete a file
+
+`DELETE ACCOUNT_URL/api/customers/realms/{realm_uid}/private_upload/answer/{uuid}`
+
+Deletes the attachment identified by `uuid`. With `200` the body arrives empty.
+
+| Code | Meaning |
+|------|---------|
+| `401` | There is no active session. |
+| `404` | There is no attachment with that `uuid` among the files of the session user. |
+
+:::warning Attention
+The deletion is immediate and cannot be undone. If the attachment was already associated with the answer to a question, that answer is left without a file.
+:::
+
 ## Zendesk API
 
 With these endpoints you will be able to obtain the tokens needed for an integration with Modyo and Zendesk.

--- a/docs/es/platform/customers/api.md
+++ b/docs/es/platform/customers/api.md
@@ -56,6 +56,154 @@ Si habilitas la opción de [**Mostrar información de delegación**](/es/platfor
 En caso de no tener habilitada la opción **Mostrar información de delegación**, se mostrará null (vacío).
 :::
 
+### Actualizar la información del usuario
+
+Con `PUT ACCOUNT_URL/api/customers/realms/{realm_uid}/me` el usuario de la sesión actualiza sus propios datos. Además de los atributos del perfil, el cuerpo acepta `custom_fields` como un arreglo de pares `key` y `value`.
+
+:::warning Atención
+Los custom fields que no tengan marcadas **Visible para usuarios de los sitios** y **Editable por usuarios de los sitios** en la [configuración del reino](/es/platform/customers/settings.html#custom-fields) se descartan en silencio: la respuesta es `200`, el resto de los atributos se guarda y esos campos conservan su valor anterior, sin ningún error que lo indique.
+:::
+
+## Respuestas de originación
+
+### Consultar una respuesta
+
+`GET ACCOUNT_URL/api/customers/realms/{realm_uid}/submissions/{uuid}`
+
+Devuelve la [respuesta de originación](/es/platform/customers/origination.html#gestion-de-respuestas) identificada por `uuid`, siempre que pertenezca al usuario de la sesión. Si el identificador no existe o la respuesta es de otro usuario, el endpoint devuelve `404`.
+
+El cuerpo trae los siguientes atributos:
+
+| Atributo | Descripción |
+|----------|-------------|
+| `id`, `uuid` | Identificadores de la respuesta. |
+| `status` | `not_started`, `pending`, `completed` o `canceled`. |
+| `progress` | Porcentaje de tareas completadas, como texto. Por ejemplo, `25%`. |
+| `due` | Texto ya armado con la fecha límite y su estado, listo para mostrar. |
+| `due_deadline_at` | Fecha y hora límite sin formatear. Es `null` cuando la originación no tiene plazo configurado o cuando la respuesta no ha comenzado, está completada o está cancelada. |
+| `due_label` | Etiqueta que reemplaza a la fecha cuando no hay fecha límite, como `No iniciado` o `--`. Es `null` cuando `due_deadline_at` trae un valor. |
+| `due_status_label` | Etiqueta del estado del plazo entre paréntesis, como `(A tiempo)`, `(Vence pronto)` o `(Vencido)`. Es `null` cuando la respuesta no está pendiente. |
+| `due_extension_days` | Días de extensión otorgados al plazo, o `null` si la originación no tiene plazo configurado. |
+| `created_at`, `updated_at`, `started_at` | Fechas de creación, de última actualización y de inicio de la respuesta. |
+| `origination_name`, `origination_uuid` | Nombre e identificador de la originación. |
+| `cancellation_reason` | Razón de cancelación ingresada al cancelar la respuesta, o `null`. |
+| `user` | Usuario dueño de la respuesta, con `id`, `uuid`, `name`, `first_name` y `last_name`. |
+| `assignee` | Administrador o grupo asignado, o `null` si la respuesta no está asignada. |
+| `tasks` | Arreglo con las respuestas a las tareas de la originación. |
+
+:::tip Tip
+`due`, `due_label` y `due_status_label` son textos pensados para mostrarse tal cual. Para tomar decisiones en tu código usa `status` y `due_deadline_at`.
+:::
+
+#### El objeto assignee
+
+Hasta la versión 10.1, `assignee` era un objeto plano con los datos del administrador asignado: `id`, `uuid`, `name`, `first_name` y `last_name`. Desde 10.2 una respuesta puede quedar asignada a un grupo completo o a un administrador elegido dentro de un grupo, como se describe en [Asignar respuesta](/es/platform/customers/origination.html#asignar-respuesta), así que `assignee` incorpora el atributo `type` y el resto de su contenido cambia según ese valor:
+
+| `type` | Atributos |
+|--------|-----------|
+| `group` | `id` y `name` del grupo asignado, y `label` con el nombre del grupo. No trae `uuid`, `first_name` ni `last_name`. |
+| `user_in_group` | `id`, `uuid`, `name`, `first_name` y `last_name` del administrador, `group_id` y `group_name` del grupo desde el que fue elegido, y `label` con el formato `Nombre del administrador (Nombre del grupo)`. |
+| `user` | `id`, `uuid`, `name`, `first_name` y `last_name` del administrador, y `label` con su nombre. |
+
+```json
+{
+  "assignee": {
+    "type": "group",
+    "id": 14,
+    "name": "Ejecutivos",
+    "label": "Ejecutivos"
+  }
+}
+```
+
+:::warning Atención
+Si tu aplicación lee `assignee.uuid` sin revisar `type`, deja de funcionar cuando la respuesta está asignada a un grupo: esa variante no incluye `uuid` y su `id` corresponde al grupo, no a un administrador. Revisa siempre `assignee.type` antes de leer el resto de los atributos y usa `assignee.label` cuando solo necesites mostrar el asignado.
+:::
+
+#### Las respuestas a las tareas
+
+Cada elemento de `tasks` trae `task`, con el `uid`, `name`, `type` y `step_name` de la tarea; `status`, con `not_started`, `pending` o `completed`; `user_id`, y los datos del asignado de esa tarea en `assignee_id`, `assignee_group_id`, `assignee_context_group_id` y `assignee_label`. Las tareas de input agregan `fields` con las respuestas del usuario y las de revisión pendiente agregan `content`. Las respuestas a tareas cuya tarea ya no existe en la originación no se incluyen en el arreglo.
+
+:::warning Atención
+Las tareas de revisión pendiente dejaron de entregar la clave booleana `completed` en 10.2. Para saber si la revisión terminó, compara `status` con `completed`.
+:::
+
+## Verificación de código OTP
+
+`POST ACCOUNT_URL/api/customers/realms/{realm_uid}/verify_otp_code`
+
+Verifica el código de un solo uso del [Soft login](/es/platform/customers/settings.html#soft-login). Es el único endpoint de la API de Customers que no requiere una sesión iniciada. El cuerpo lleva `identifier`, con el nombre de usuario, y `code`, con el código recibido.
+
+| Código | Significado |
+|--------|-------------|
+| `200` | El código es válido. El cuerpo llega como un objeto vacío. |
+| `409` | El código no es válido o ya expiró. |
+| `429` | Se superó el máximo de cinco intentos fallidos. Nuevo en 10.2. |
+
+Tanto el `409` como el `429` traen el arreglo `errors` con un texto listo para mostrar:
+
+```json
+{
+  "errors": ["Has excedido el número máximo de intentos."]
+}
+```
+
+:::warning Atención
+Después de cinco intentos fallidos, el endpoint responde `429` incluso cuando el código enviado es el correcto, porque la validación corta en el conteo de intentos antes de comparar el código. Trata el `429` como un caso distinto del `409`: el usuario no puede seguir reintentando y la única salida es pedir un código nuevo, que reinicia el contador.
+:::
+
+El código deja de ser válido cuando pasa el tiempo definido en **Validez de duración de OTP (en minutos)** del reino, cinco minutos por defecto. Revisa [Soft login](/es/platform/customers/settings.html#soft-login) para el detalle de esa configuración.
+
+## Adjuntos de las respuestas
+
+Las preguntas de tipo archivo de una originación reciben sus adjuntos por estos dos endpoints. Ambos requieren una sesión iniciada, trabajan siempre sobre los archivos del usuario de la sesión y no aparecen en la referencia interactiva de `ACCOUNT_URL/api/customers/docs`.
+
+### Subir un archivo
+
+`POST ACCOUNT_URL/api/customers/realms/{realm_uid}/private_upload/answer`
+
+Envía una petición `multipart/form-data` con estos parámetros:
+
+- `file`: el archivo a subir. Es obligatorio.
+- `question_id`: identificador de la pregunta de tipo archivo a la que corresponde el adjunto. Es opcional.
+
+Con `200`, el cuerpo describe el archivo guardado:
+
+```json
+{
+  "id": 431,
+  "uuid": "586e591c-1f07-4f6d-b886-a66fea953afe",
+  "name": "comprobante.pdf",
+  "size": 60548,
+  "url": "/uploads/586e591c-1f07-4f6d-b886-a66fea953afe/original/comprobante.pdf"
+}
+```
+
+El archivo queda guardado como privado y asociado al usuario de la sesión. Usa el `id` numérico como valor de la respuesta a la pregunta de tipo archivo y el `uuid` para eliminar el adjunto.
+
+| Código | Significado |
+|--------|-------------|
+| `401` | No hay una sesión iniciada. |
+| `404` | El `question_id` enviado no corresponde a ninguna pregunta de tipo archivo. |
+| `422` | El archivo no pasó las validaciones. |
+
+El cuerpo del `422` trae el arreglo `errors` con un texto por cada motivo de rechazo, prefijado con el nombre del archivo. Un archivo se rechaza cuando falta, cuando su extensión no está permitida en la plataforma, cuando su contenido no corresponde a la extensión declarada o cuando supera el tamaño máximo permitido en tu cuenta.
+
+### Eliminar un archivo
+
+`DELETE ACCOUNT_URL/api/customers/realms/{realm_uid}/private_upload/answer/{uuid}`
+
+Elimina el adjunto identificado por `uuid`. Con `200` el cuerpo llega vacío.
+
+| Código | Significado |
+|--------|-------------|
+| `401` | No hay una sesión iniciada. |
+| `404` | No existe un adjunto con ese `uuid` entre los archivos del usuario de la sesión. |
+
+:::warning Atención
+La eliminación es inmediata y no se puede deshacer. Si el adjunto ya estaba asociado a la respuesta de una pregunta, esa respuesta queda sin archivo.
+:::
+
 ## API de Zendesk
 
 Con estos endpoints podrás obtener los tokens necesarios para una integración con Modyo y Zendesk.


### PR DESCRIPTION
## Cambios propuestos

Documenta en la referencia de las APIs de Customers tres superficies que hoy no estan cubiertas o quedaron desactualizadas con 10.2: el contrato de respuesta del endpoint de respuestas de originacion, la nueva respuesta 429 de la verificacion de codigo OTP y los endpoints de adjuntos de respuestas.

### docs/es/platform/customers/api.md

Se agregan cuatro bloques nuevos, todos antes de la seccion de la API de Zendesk:

- **Actualizar la informacion del usuario**: nueva subseccion dentro de la API de Customers que documenta `PUT /me` y advierte que los custom fields sin **Visible para usuarios de los sitios** y **Editable por usuarios de los sitios** se descartan en silencio, con respuesta `200` y sin ningun error que lo indique. Enlaza a la configuracion del reino en vez de repetirla.
- **Respuestas de originacion**: documenta `GET /submissions/{uuid}`, con la tabla de todos los atributos que devuelve hoy, incluidos `due_deadline_at`, `due_label`, `due_status_label`, `due_extension_days`, `updated_at` y `cancellation_reason`, y una nota de que los tres campos de texto del plazo son para mostrar y no para comparar en codigo.
  - Subseccion **El objeto assignee**: explica que hasta 10.1 era un objeto plano y que desde 10.2 trae `type` con las variantes `group`, `user_in_group` y `user`, con la tabla de atributos de cada una y un ejemplo JSON. Incluye la advertencia central: la variante de grupo no trae `uuid` y su `id` es el del grupo, asi que leer `assignee.uuid` sin revisar `type` rompe el front al actualizar.
  - Subseccion **Las respuestas a las tareas**: describe el contenido de cada elemento de `tasks` y advierte que las tareas de revision pendiente dejaron de entregar la clave booleana `completed` en 10.2, indicando que el reemplazo es comparar `status` con `completed`.
- **Verificacion de codigo OTP**: documenta `POST /verify_otp_code` con sus tres respuestas, incluida la `429` nueva en 10.2 con su cuerpo de errores, y la trampa que ningun codigo de estado deja ver: tras cinco intentos fallidos el endpoint responde `429` aunque el codigo enviado sea el correcto, porque la validacion corta en el conteo de intentos antes de comparar. Ademas enlaza a Soft login para la vigencia del codigo.
- **Adjuntos de las respuestas**: documenta por primera vez `POST /private_upload/answer` y `DELETE /private_upload/answer/{uuid}`, con sus parametros, el cuerpo de la respuesta correcta, los codigos de error (`401`, `404` por `question_id` inexistente o adjunto ajeno, `422` por validaciones del archivo) y la aclaracion de que el `id` numerico es el valor de la respuesta a la pregunta de tipo archivo mientras el `uuid` sirve para eliminarla. Se advierte que borrar un adjunto ya asociado deja la respuesta sin archivo.

### docs/en/platform/customers/api.md

Espejo equivalente en ingles de los cuatro bloques, con los labels de panel tomados del locale en ingles.

Cierra los gaps API-PUBLICA-19, API-PUBLICA-18 y API-PUBLICA-20.

## Para el revisor

1. master vs 10.2-stable: `git diff releases/10.2-stable..origin/master` esta vacio para submission_list_serializer.rb, task_response_serializer.rb, pending_review_task_response_serializer.rb, user_info_controller.rb, private_upload_actions.rb, otp_authenticable.rb, assets/answer.rb, docs/api/customers/user_info.rb y config/routes.rb. No hubo que ajustar nada por diferencias entre ramas.

2. Correccion a la ficha API-PUBLICA-19: decia que `assignee` "ahora es un objeto con `type` y `label`". El serializer entrega bastante mas por variante (group: type/id/name/label; user_in_group: type/id/uuid/name/first_name/last_name/group_id/group_name/label; user: type/id/uuid/name/first_name/last_name/label). Documente la forma real. El nucleo del gap se confirma: la variante group no trae `uuid` y su `id` es el del grupo, no el de un AdminUser.

3. Correccion a la ficha API-PUBLICA-20: decia que `question_id` sirve "para heredar la lista de extensiones permitidas de la pregunta". En el codigo `load_allowed_extensions` pasa `allowed_extensions_list` a `Assets::Answer`, pero ese atributo es un `attr_accessor` que no consume ninguna validacion (grep en todo origin/master: solo aparece en private_upload_actions.rb:30 y answer.rb:28). La extension efectivamente validada es la whitelist de plataforma mas el chequeo de coincidencia con el content type. Por eso documente `question_id` solo como parametro opcional que puede producir `404`, sin afirmar que restringe extensiones. Vale la pena abrir una issue en modyo por ese cabo suelto.

4. Fuera del alcance de este PR, pendiente en el repo de codigo: corregir el schema `assignee` del Swagger en app/controllers/docs/api/customers/user_info.rb:288-313, agregar el `response 429` en :335-377, declarar `status` en el schema :TaskResponse (:445) y registrar `Api::Customers::PrivateUploadController` en SWAGGERED_CLASSES de docs_controller.rb:32-37.

5. No agregue la nota de version 10.2 que piden las fichas API-PUBLICA-19 y API-PUBLICA-18. docs/es/platform/release-notes.md solo llega hasta la seccion 10.1 (10.1.17), abrir la seccion 10.2 requiere numero de release y fecha que no tengo, y la tanda solo lista customers/api.md como pagina. Queda pendiente para la tanda que se haga cargo de release-notes.

6. Idioma de los mensajes de error: `Api::Customers::BaseController` no incluye `LocaleResolver` (solo lo hacen `Api::AdminController` y `CoreController`), asi que no pude verificar en que idioma llegan los textos de `errors`, `due_label` y `due_status_label`. Por eso los presento como "texto listo para mostrar" en cada idioma, sin afirmar de que depende la traduccion.

7. Labels de custom fields: use los del locale (`Visible para usuarios de los sitios` / `Editable por usuarios de los sitios`; `Visible to front end users` / `Editable by front end users`). Difieren de lo que dice hoy docs/es/platform/customers/settings.md:449-450 ("Visible para los usuarios de los sitios") y docs/en/.../settings.md:448-449 ("Visible to users of the sites" / "Editable by site users"). No toque esa pagina porque no esta en la tanda, pero queda esa inconsistencia entre paginas.

8. Anclas de enlaces internos usadas: /es/platform/customers/settings.html#custom-fields, #soft-login; /es/platform/customers/origination.html#gestion-de-respuestas, #asignar-respuesta; y sus equivalentes en ingles #submission-management y #assign-submission. Todas verificadas contra los encabezados existentes de esas paginas en master.

9. Sin cambios en docs/.vuepress/config.js: la pagina ya esta registrada en los dos idiomas (lineas 166 y 462). Sin llaves dobles fuera de bloques cercados; los `{realm_uid}` y `{uuid}` van siempre dentro de codigo inline, igual que en el contenido que ya tiene la pagina.

Closes #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)
