### PR TITLE
Corregir el catálogo de roles predeterminados y documentar su edición, el acceso a las aplicaciones y el cambio de contraseña de un miembro

### DIFF
--- a/docs/en/platform/core/roles.md
+++ b/docs/en/platform/core/roles.md
@@ -114,7 +114,7 @@ The most important user will have the Default Admin or Administrator role. This 
 
 #### Edit and delete the default roles
 
-**Full admin** is the only read-only role on the platform: you cannot rename it, change its permissions, or delete it. The other 14 default roles behave like any custom role and you manage them from **Settings** > **Roles**:
+**Full admin** is the only default role the platform marks as non-editable: you cannot rename it, change its permissions, or delete it. This does not limit its permissions, which are still all of them. The other 14 default roles behave like any custom role and you manage them from **Settings** > **Roles**:
 
 - To change its name or its permissions, click on the role name in the list.
 - To delete it, in the **Actions** column of its row choose **Delete** and confirm.

--- a/docs/en/platform/core/roles.md
+++ b/docs/en/platform/core/roles.md
@@ -37,6 +37,10 @@ Within the user edit screen, platform administrators have access to the followin
 - Groups: Shows a list of all the groups to which the user belongs.
 - Devices: Shows a list of all devices where the user has an active session. It displays data such as browser, operating system, last login, and IP address. Here, in addition, you can remotely log out for each device.
 
+:::warning Attention
+When you set or change another team member's password from **Edit**, the platform marks that password as pending change and immediately revokes all their active sessions: the member is logged out on every device and, on their next login, must set a new password before they can browse the panel. The same happens when you create a team member with a password. Let them know beforehand.
+:::
+
 :::warning Usernames created in earlier versions
 Users created before the character validation existed may have usernames that are no longer allowed (for example, containing spaces). While the username does not meet the validation, any update to that user will fail — including administrative actions such as removing their authenticator (2FA), which may show a success message without actually taking effect. Before performing actions on one of these users, correct their username first.
 :::
@@ -69,7 +73,9 @@ Once a group is created, you can view it in the Groups panel. In addition, when 
 
 You can apply roles in the different modules to customize the experience of your work team. Each role applies in a specific way to a particular module. For example, you can select the administrators of a space or the members who can interact with the CLI somewhere.
 
-Modyo has 10 default roles with different functions for each context, allowing you to distribute and control access to the different sections of each context of the platform.
+Modyo has 15 default roles with different functions for each context, allowing you to distribute and control access to the different sections of each context of the platform.
+
+Each role has the name you see in the panel and a technical name, the _key_, shown in parentheses in the lists below. The _key_ is the value returned by the roles API and the one you use when assigning roles through the API.
 
 ### Default Roles
 
@@ -79,31 +85,43 @@ The default roles that exist, depending on the context, are:
 
 #### Account-level roles
 
-- **Default user**: Has all existing permissions, except for editing the configuration of each context. Must be invited to each context to access its functionalities.
-- **Default admin**: Has all existing permissions, but must be invited to each context to access its functions. At the Modyo Platform account level, this role can only view global variables and activity.
-- **Full admin**: Has all existing permissions and can access all contexts without needing to be invited to them.
+- **Default user** (`account_user`): Has all existing permissions, except for editing the configuration of each context. Must be invited to each context to access its functionalities.
+- **Default admin** (`account_admin`): Has all existing permissions, but must be invited to each context to access its functions. At the Modyo Platform account level, this role can only view global variables and activity.
+- **Full admin** (`account_owner`): Has all existing permissions and can access all contexts without needing to be invited to them.
 
 #### Site-level roles
 
-- **Site viewer**: You can view entries, see differences between versions, and leave comments. You can also access the synchronization view and see pending changes to synchronize. However, this role is not authorized to perform any action that implies a change in the platform.
-- **Site developer**: Can only edit resources. Cannot publish, delete, rollback, or edit the configuration.
-- **Site developer CLI**: Has the same permissions as Site developer; in addition, can interact with modyo-cli.
-- **Site reviewer**: Has all the permissions of the site admin role, except for permissions to edit the site settings.
-- **Site admin**: Has all the permissions at the level of a site, but cannot create new sites.
+- **Site Viewer** (`site_viewer`): You can view entries, see differences between versions, and leave comments. You can also access the synchronization view and see pending changes to synchronize. However, this role is not authorized to perform any action that implies a change in the platform.
+- **Site Developer** (`site_developer`): Can only edit resources. Cannot publish, delete, rollback, or edit the configuration.
+- **Site Developer CLI** (`site_developer_cli`): Has the same permissions as Site Developer; in addition, can interact with modyo-cli.
+- **Site Reviewer** (`site_reviewer`): Has all the permissions of the Site Admin role, except for permissions to edit the site settings.
+- **Site Admin** (`site_admin`): Has all the permissions at the level of a site, but cannot create new sites.
 
 #### Space-level roles
 
-- **Space viewer**: This role allows you to view the contents of a space, see differences between versions, and leave comments. Access is limited to viewing and participating through comments; you cannot make modifications to the content or take actions that affect the configuration.
-- **Space writer**: This role can only edit content in a space. You do not have permissions to publish, delete, perform rollback, or edit the configuration.
-- **Space editor**: Has all the permissions of a space admin, except for permissions to edit the space configuration. Has no permissions over assets and cannot create types.
-- **Space admin**: This role has all the permissions at the space level, but it cannot create new spaces. Can create and delete assets.
+- **Space Viewer** (`space_viewer`): This role allows you to view the contents of a space, see differences between versions, and leave comments. Access is limited to viewing and participating through comments; you cannot make modifications to the content or take actions that affect the configuration.
+- **Space Writer** (`space_writer`): This role can only edit content in a space. You do not have permissions to publish, delete, perform rollback, or edit the configuration.
+- **Space Editor** (`space_editor`): Has all the permissions of a Space Admin, except for permissions to edit the space configuration. Has no permissions over assets and cannot create types.
+- **Space Admin** (`space_admin`): This role has all the permissions at the space level, but it cannot create new spaces. Can create and delete assets.
 
 The most important user will have the Default Admin or Administrator role. This role has all the features enabled to manage the platform and sites.
 
 #### Roles by realm
 
-- **Realm User**: This role can add users, create, modify, and submit campaigns, forms, and segments for review.
-- **Realm Admin**: Can access all the configurations and sections of the realm. In addition, can add and remove users and team members, as well as delete the realm.
+- **Realm User** (`realm_user`): This role can add users, create, modify, and submit campaigns, forms, and segments for review.
+- **Realm Admin** (`realm_admin`): Can access all the configurations and sections of the realm. In addition, can add and remove users and team members, as well as delete the realm.
+- **Realm Viewer** (`realm_viewer`): A read-only role over Customers. It carries the **View User**, **View Segments**, **View Events**, **View Payment Orders**, **View Campaign Templates**, **View Forms**, and **View Campaign Deliveries** permissions. It cannot create or modify anything inside the realm.
+
+#### Edit and delete the default roles
+
+**Full admin** is the only read-only role on the platform: you cannot rename it, change its permissions, or delete it. The other 14 default roles behave like any custom role and you manage them from **Settings** > **Roles**:
+
+- To change its name or its permissions, click on the role name in the list.
+- To delete it, in the **Actions** column of its row choose **Delete** and confirm.
+
+:::warning Attention
+A role can only be deleted if it is not assigned to anyone. If any team member or group has it assigned in any context, the platform blocks the deletion and shows an error. Reassign those members and groups first, and only then delete the role.
+:::
 
 ### Custom roles
 Custom roles allow you to create profiles with unique access and permissions, combining existing roles or configuring them according to the specific needs of your organization.
@@ -128,7 +146,21 @@ Some permissions include others: when you check one, the platform also checks th
 To keep the changes, press the **Save** button.
 
 ### Access to applications
-Modyo has roles that allow access to all applications without any restrictions; therefore, Modyo allows you to restrict access to certain applications by configuring the roles of team members. In this way, it is possible to grant a user full access (Owner) only to the Channels application, while restricting their access to other applications.
+
+Beyond the role, each team member has a switch per application that decides which modules they see in the panel. There are four applications you can enable or disable: **Content**, **Channels**, **Customers**, and **Insights**.
+
+The **Applications access** block appears in two places:
+
+- In the **Access** tab of a team member, above the role selector.
+- When creating or editing a group, above the **Group Role** field.
+
+Access is additive between the member's own settings and their groups: if any of the groups they belong to has an application enabled, the member sees it, even if that checkbox is off in their individual settings. To take an application away from them you have to turn it off in their settings and also in every group that grants it.
+
+Disabling an application does not remove the member's role: the role stays assigned, but the platform subtracts that application's permissions, so they stop seeing that section of the panel even if their role would grant it.
+
+:::tip Tip
+Some checkboxes are ticked automatically and left disabled depending on the selected account role. In the **Access** tab of a member, the account owner has all four applications fixed and the **Default admin** role fixes **Content**, **Channels**, and **Customers**. In the group form, **Default admin** fixes all four.
+:::
 
 ### Assign one role per account
 

--- a/docs/es/platform/core/roles.md
+++ b/docs/es/platform/core/roles.md
@@ -114,7 +114,7 @@ El usuario más importante tendrá el rol de Default Admin o Administrador. Este
 
 #### Editar y eliminar los roles predeterminados
 
-**Full admin** es el único rol de solo lectura de la plataforma: no puedes cambiarle el nombre, ni sus permisos, ni eliminarlo. Los otros 14 roles predeterminados se comportan como cualquier rol a medida y los administras desde **Configuración** > **Roles**:
+**Full admin** es el único rol predeterminado que la plataforma marca como no editable: no puedes cambiarle el nombre, ni sus permisos, ni eliminarlo. Esto no limita sus permisos, que siguen siendo todos los de la plataforma. Los otros 14 roles predeterminados se comportan como cualquier rol a medida y los administras desde **Configuración** > **Roles**:
 
 - Para cambiar su nombre o sus permisos, haz click sobre el nombre del rol en el listado.
 - Para eliminarlo, en la columna **Acciones** de su fila elige **Borrar** y confirma.

--- a/docs/es/platform/core/roles.md
+++ b/docs/es/platform/core/roles.md
@@ -37,6 +37,10 @@ Dentro de la pantalla de edición de usuario, los administradores de la platafor
 - Grupos: Muestra una lista de todos los grupos a los que pertenece el usuario.
 - Dispositivos: Muestra un listado de todos los dispositivos en los que el usuario tiene una sesión activa.  Despliega datos como navegador, sistema operativo, último inicio de sesión y dirección IP. Aquí, además, puedes cerrar la sesión de forma remota para cada dispositivo.
 
+:::warning Atención
+Cuando defines o cambias la contraseña de otro miembro del equipo desde **Editar**, la plataforma marca esa contraseña como pendiente de cambio y revoca de inmediato todas sus sesiones activas: el miembro queda desconectado en todos sus dispositivos y, en su siguiente inicio de sesión, tiene que definir una contraseña nueva antes de poder navegar el panel. Lo mismo ocurre al crear un miembro del equipo con una contraseña. Avísale antes de hacerlo.
+:::
+
 :::warning Nombres de usuario creados en versiones anteriores
 Los usuarios creados antes de que existiera la validación de caracteres pueden tener nombres de usuario hoy no permitidos (por ejemplo, con espacios). Mientras el nombre de usuario no cumpla la validación, cualquier actualización de ese usuario fallará — incluidas acciones administrativas como eliminar su autenticador (2FA), que puede mostrar un mensaje de éxito sin aplicarse realmente. Antes de realizar acciones sobre uno de estos usuarios, corrige primero su nombre de usuario.
 :::
@@ -69,7 +73,9 @@ Una vez creado un grupo, lo puedes ver en el panel de Grupos. Además, al editar
 
 Puedes aplicar roles en los distintos módulos para personalizar la experiencia de tu equipo de trabajo. Cada rol se aplica de manera específica a un módulo en particular. Por ejemplo, puedes seleccionar a los administradores de un espacio o a los miembros que pueden interactuar con el CLI en algún sitio.
 
-Modyo tiene 10 roles predeterminados con diferentes funciones para cada contexto, lo que te permite distribuir y controlar el acceso a las distintas secciones de cada contexto de la plataforma.
+Modyo tiene 15 roles predeterminados con diferentes funciones para cada contexto, lo que te permite distribuir y controlar el acceso a las distintas secciones de cada contexto de la plataforma.
+
+Cada rol tiene el nombre que ves en el panel y un nombre técnico, la _key_, que aparece entre paréntesis en las listas de abajo. La _key_ es el valor que devuelve la API de roles y el que usas cuando asignas roles por API.
 
 ### Roles predeterminados
 
@@ -79,31 +85,43 @@ Los roles predeterminados que existen, según contexto, son:
 
 #### Roles por cuenta
 
-- **Default user**: Tiene todos los permisos existentes,  excepto la edición de la configuración de cada contexto. Debe ser invitado a cada contexto para poder acceder a sus funcionalidades.
-- **Default admin**: Tiene todos los permisos existentes, pero debe ser invitado a cada contexto para poder acceder a sus funciones. A nivel de cuenta de Modyo Platform, solo puede ver variables globales y actividad.
-- **Full admin**: Tiene todos los permisos existentes y puede acceder a todos los contextos sin necesidad de ser invitado a ellos.
+- **Default user** (`account_user`): Tiene todos los permisos existentes, excepto la edición de la configuración de cada contexto. Debe ser invitado a cada contexto para poder acceder a sus funcionalidades.
+- **Default admin** (`account_admin`): Tiene todos los permisos existentes, pero debe ser invitado a cada contexto para poder acceder a sus funciones. A nivel de cuenta de Modyo Platform, solo puede ver variables globales y actividad.
+- **Full admin** (`account_owner`): Tiene todos los permisos existentes y puede acceder a todos los contextos sin necesidad de ser invitado a ellos.
 
 #### Roles por sitio
 
-- **Site viewer**: Puede ver entradas, ver diferencias entre versiones y puede dejar comentarios. También puede acceder a la vista de sincronización y ver los cambios pendientes de sincronizar. Sin embargo, este rol no tiene autorización para realizar ninguna acción que implique un cambio en la plataforma.
-- **Site developer**: Solamente puede editar recursos. No puede publicar, eliminar, hacer rollback o editar la configuración.
-- **Site developer CLI**: Tiene los mismos permisos que Site developer; en adición, puede interactuar con modyo-cli.
-- **Site reviewer**:  Tiene todos los permisos del rol de site admin, excepto los permisos para editar la configuración del sitio.
-- **Site admin**: Tiene todos los permisos a nivel de un sitio, pero no puede crear nuevos sitios.
+- **Site Viewer** (`site_viewer`): Puede ver entradas, ver diferencias entre versiones y puede dejar comentarios. También puede acceder a la vista de sincronización y ver los cambios pendientes de sincronizar. Sin embargo, este rol no tiene autorización para realizar ninguna acción que implique un cambio en la plataforma.
+- **Site Developer** (`site_developer`): Solamente puede editar recursos. No puede publicar, eliminar, hacer rollback o editar la configuración.
+- **Site Developer CLI** (`site_developer_cli`): Tiene los mismos permisos que Site Developer; en adición, puede interactuar con modyo-cli.
+- **Site Reviewer** (`site_reviewer`): Tiene todos los permisos del rol de Site Admin, excepto los permisos para editar la configuración del sitio.
+- **Site Admin** (`site_admin`): Tiene todos los permisos a nivel de un sitio, pero no puede crear nuevos sitios.
 
 #### Roles por espacio
 
-- **Space viewer**: Este rol permite ver el contenido de un espacio, ver diferencias entre versiones y dejar comentarios. Su acceso está limitado a la visualización y participación mediante comentarios, no puede realizar modificaciones en el contenido o realizar acciones que afecten la configuración.
-- **Space writer**: Este rol solo puede editar el contenido en un espacio. No tiene permisos para publicar, eliminar, realizar rollback o editar la configuración.
-- **Space editor**: Tiene todos los permisos de un space admin, excepto permisos para editar la configuración del espacio. No tiene permisos sobre los assets y no puede crear tipos.
-- **Space admin**: Este rol tiene todos los permisos a nivel de un espacio, pero no puede crear nuevos espacios. Puede crear y eliminar assets.
+- **Space Viewer** (`space_viewer`): Este rol permite ver el contenido de un espacio, ver diferencias entre versiones y dejar comentarios. Su acceso está limitado a la visualización y participación mediante comentarios, no puede realizar modificaciones en el contenido o realizar acciones que afecten la configuración.
+- **Space Writer** (`space_writer`): Este rol solo puede editar el contenido en un espacio. No tiene permisos para publicar, eliminar, realizar rollback o editar la configuración.
+- **Space Editor** (`space_editor`): Tiene todos los permisos de un Space Admin, excepto permisos para editar la configuración del espacio. No tiene permisos sobre los assets y no puede crear tipos.
+- **Space Admin** (`space_admin`): Este rol tiene todos los permisos a nivel de un espacio, pero no puede crear nuevos espacios. Puede crear y eliminar assets.
 
 El usuario más importante tendrá el rol de Default Admin o Administrador. Este rol tiene todas las funciones habilitadas para gestionar la plataforma y los sitios.
 
 #### Roles por reino
 
-- **Realm User**: Este rol puede añadir usuarios, crear, modificar y enviar a revisión campañas, formularios y segmentos.
-- **Realm Admin**: Puede acceder a todas las configuraciones y secciones del reino. Además, puede añadir y eliminar usuarios y miembros del equipo, así como eliminar el reino.
+- **Realm User** (`realm_user`): Este rol puede añadir usuarios, crear, modificar y enviar a revisión campañas, formularios y segmentos.
+- **Realm Admin** (`realm_admin`): Puede acceder a todas las configuraciones y secciones del reino. Además, puede añadir y eliminar usuarios y miembros del equipo, así como eliminar el reino.
+- **Realm Viewer** (`realm_viewer`): Es un rol de solo lectura sobre Customers. Trae los permisos **Ver Usuarios**, **Ver Segmentos**, **Ver Eventos**, **Ver Órdenes de Pago**, **Ver Plantillas de Campañas**, **Ver Formularios** y **Ver Entregas de Mensajes**. No puede crear ni modificar nada dentro del reino.
+
+#### Editar y eliminar los roles predeterminados
+
+**Full admin** es el único rol de solo lectura de la plataforma: no puedes cambiarle el nombre, ni sus permisos, ni eliminarlo. Los otros 14 roles predeterminados se comportan como cualquier rol a medida y los administras desde **Configuración** > **Roles**:
+
+- Para cambiar su nombre o sus permisos, haz click sobre el nombre del rol en el listado.
+- Para eliminarlo, en la columna **Acciones** de su fila elige **Borrar** y confirma.
+
+:::warning Atención
+Un rol solo se puede eliminar si no está asignado a nadie. Si algún miembro del equipo o algún grupo lo tiene asignado en cualquier contexto, la plataforma bloquea el borrado y muestra un error. Reasigna primero a esos miembros y grupos, y recién entonces elimina el rol.
+:::
 
 ### Roles a medida
 Los roles a medida te permiten crear perfiles con accesos y permisos únicos, combinando roles existentes o configurándolos según las necesidades específicas de tu organización.
@@ -128,7 +146,21 @@ Algunos permisos incluyen a otros: al marcar uno, la plataforma marca también l
 Para conservar los cambios, presiona el botón **Guardar**.
 
 ### Acceso a las aplicaciones
-Modyo tiene roles que permiten acceder a todas las aplicaciones sin restricción alguna; por ello, Modyo permite restringir el acceso a ciertas aplicaciones configurando los roles de los miembros del equipo. De esta manera, es posible otorgar a un usuario un acceso total (Owner) solo en la aplicación de Channels, mientras restringe su acceso a otras aplicaciones.
+
+Además del rol, cada miembro del equipo tiene un interruptor por aplicación que decide qué módulos ve en el panel. Las aplicaciones que puedes habilitar o deshabilitar son cuatro: **Content**, **Channels**, **Customers** e **Insights**.
+
+El bloque **Acceso a aplicaciones** aparece en dos lugares:
+
+- En la pestaña **Acceso** de un miembro del equipo, sobre el selector de rol.
+- Al crear o editar un grupo, sobre el campo **Rol de grupo**.
+
+El acceso es aditivo entre la ficha del miembro y sus grupos: si cualquiera de los grupos a los que pertenece tiene una aplicación habilitada, el miembro la ve, aunque en su ficha individual esa casilla esté apagada. Para quitarle una aplicación tienes que apagarla en su ficha y también en todos los grupos que se la entregan.
+
+Deshabilitar una aplicación no le quita el rol al miembro: el rol sigue asignado, pero la plataforma le descuenta los permisos de esa aplicación, así que deja de ver esa sección del panel aunque su rol se los diera.
+
+:::tip Tip
+Algunas casillas se marcan solas y quedan deshabilitadas según el rol de cuenta seleccionado. En la pestaña **Acceso** de un miembro, el dueño de la cuenta tiene fijas las cuatro aplicaciones y el rol **Default admin** deja fijas **Content**, **Channels** y **Customers**. En el formulario de un grupo, **Default admin** deja fijas las cuatro.
+:::
 
 ### Asignar un rol por cuenta
 


### PR DESCRIPTION
## Cambios propuestos

Esta tanda corrige y completa la página de Equipos y Grupos, que era la primera referencia que lee un administrador al diseñar su esquema de permisos y que hoy parte con una cifra falsa.

### docs/es/platform/core/roles.md y docs/en/platform/core/roles.md

**Catálogo de roles predeterminados (ROLES-SEGURIDAD-02)**

- Se corrige la cifra: la página declaraba 10 roles predeterminados, listaba 14 y en el producto existen 15.
- Se agrega el rol faltante **Realm Viewer**, de solo lectura sobre Customers, con los siete permisos que trae realmente: Ver Usuarios, Ver Segmentos, Ver Eventos, Ver Órdenes de Pago, Ver Plantillas de Campañas, Ver Formularios y Ver Entregas de Mensajes.
- Cada rol pasa a mostrar su nombre técnico, la key, entre paréntesis. Es el valor que devuelve la API de roles y el que se usa al asignar roles por API.
- Se corrige la capitalización de los nombres de los roles de sitio, espacio y reino para que coincida con lo que muestra el panel: Site Viewer, Site Developer, Site Developer CLI, Site Reviewer, Site Admin, Space Viewer, Space Writer, Space Editor, Space Admin.

**Editar y eliminar los roles predeterminados (ROLES-SEGURIDAD-03)**

- Nueva subsección que explica que Full admin es el único rol de solo lectura de la plataforma y que los otros 14 roles predeterminados se pueden renombrar, editar y eliminar desde Configuración > Roles, con los labels reales del listado.
- Se advierte, con un callout, que un rol solo se puede eliminar si no está asignado a nadie: si algún miembro del equipo o algún grupo lo tiene asignado en cualquier contexto, la plataforma bloquea el borrado y muestra un error. Esto corrige el supuesto de partida del gap, que asumía que el borrado se hacía igual y los miembros perdían el acceso.

**Acceso a las aplicaciones (ROLES-SEGURIDAD-07)**

- Se reescribe la sección, que antes eran dos líneas genéricas con un ejemplo confuso. Ahora enumera las cuatro aplicaciones que se pueden habilitar o deshabilitar (Content, Channels, Customers e Insights) y dice dónde está el control: la pestaña Acceso de un miembro del equipo y también el formulario de creación y edición de un grupo, dato que la sección de Grupos omitía.
- Se explica que el acceso es aditivo entre la ficha del miembro y sus grupos: basta que un grupo tenga la aplicación habilitada para que el miembro la vea, aunque su casilla individual esté apagada.
- Se aclara por qué algunas casillas aparecen marcadas y bloqueadas: al dueño de la cuenta se le fijan las cuatro aplicaciones, y el rol Default admin fija Content, Channels y Customers en la ficha del miembro, y las cuatro en el formulario de grupo.
- Se mantiene el encabezado original para no romper el anclaje de la sección.

**Cambio de contraseña de un miembro del equipo (ROLES-SEGURIDAD-20)**

- Nuevo callout de atención en Editar usuario: cuando un administrador define o cambia la contraseña de otro miembro, esa contraseña queda marcada como pendiente de cambio, se revocan de inmediato todas sus sesiones activas y el miembro queda desconectado en todos sus dispositivos, con obligación de definir una contraseña nueva en su siguiente inicio de sesión antes de poder navegar el panel. Lo mismo ocurre al crear un miembro con contraseña. El comportamiento ya estaba en la referencia de API, pero no en la pantalla donde el administrador hace el cambio.

Cierra los gaps ROLES-SEGURIDAD-02, ROLES-SEGURIDAD-03, ROLES-SEGURIDAD-07 y ROLES-SEGURIDAD-20.

El archivo en inglés recibe la edición equivalente, con los labels tomados del locale en.

## Para el revisor

1. Dos correcciones que las fichas pedían quedan fuera del alcance de esta tanda porque viven en páginas que la tanda no declara (Páginas: docs/es/platform/core/roles.md) y que muy probablemente estén tocadas por los PRs abiertos:
   - docs/es/platform/customers/settings.md:388 sigue diciendo "Puedes elegir entre dos roles:" para Miembros del equipo del reino, cuando el selector ofrece los tres roles de contexto realm (realm_admin, realm_user, realm_viewer). Es la misma causa raíz de ROLES-SEGURIDAD-02 y conviene arreglarlo en la tanda que sea dueña de esa página.
   - docs/es/platform/core/api.md:307-325 (y su espejo en inglés) muestra un ejemplo JSON de /api/admin/roles con `"name": "Writer"` y `"name": "Editor"` y `"read_only": true` para space_writer y space_editor. Los tres datos son falsos hoy: los YAML dicen "Space Writer" y "Space Editor" y `read_only: no`. El ejemplo contradice de frente la subsección que este PR agrega en roles.md.

2. Corrección de fondo a la ficha ROLES-SEGURIDAD-03: la ficha afirmaba que al eliminar un rol "los miembros con ese rol pierden el acceso asociado". En origin/master eso no ocurre: `Role has_many :roleships, dependent: :restrict_with_error` impide el borrado de cualquier rol que esté asignado. Documenté el comportamiento real (borrado bloqueado con error). Si en algún momento se cambia a `dependent: :destroy`, esta advertencia habría que reescribirla.

3. Corrección de fondo a la ficha ROLES-SEGURIDAD-07: la ficha decía que "Full admin/Owner activa las cuatro" casillas. El código evalúa `role === 'Owner' || isAccountOwner`, y ningún rol predeterminado se llama "Owner" (account_owner se llama "Full admin"), de modo que en la práctica quien fuerza las cuatro es el dueño de la cuenta (`@person.id == @account.owner_id`). Un miembro con rol Full admin que no sea el dueño de la cuenta no ve casillas forzadas. Escribí "el dueño de la cuenta" para no prometer algo que no pasa. Es una rama de código con aspecto de residuo de un rename antiguo: si alguna vez se limpia, la frase sigue siendo correcta.

4. Diferencia real entre pantallas que la documentación ahora expone: Default admin fuerza tres aplicaciones en la ficha del miembro (EditPermissions.js:25) y cuatro en el formulario de grupo (groups/actions.js:22-24). Documenté ambas porque son observables, pero parece una inconsistencia del producto más que una decisión. Vale la pena que producto la mire.

5. El label del rol de grupo en el locale español es "Rol de grupo", mientras que el paso 4 de "Crear un grupo" en la misma página dice "**Rol del Grupo**". Usé el label real del locale en el texto nuevo, así que la página queda con las dos formas. No lo unifiqué porque esa línea no la pide la tanda; es un arreglo de una palabra para quien toque esa sección.

6. No se crean páginas nuevas, por lo que no hay edición de docs/.vuepress/config.js.

7. Los 14 anclajes se verificaron con count == 1 sobre los archivos actuales y se aplicaron en seco en orden; el resultado no introduce ni {{ ni {% fuera de bloques de código.

Closes #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)
