### PR TITLE
Actualizar los filtros de submission de Liquid Markup al comportamiento de 10.2

### DIFF
--- a/docs/en/platform/channels/liquid-markup/filters.md
+++ b/docs/en/platform/channels/liquid-markup/filters.md
@@ -773,7 +773,8 @@ Returns the Submissions with the selected status. *e.g.*
 
 In Modyo 10.2 a submission can be in one of four statuses: **Not started**, **Pending**, **Completed**, and **Canceled**. The filter recognizes only three values, and they don't map directly onto those statuses:
 
-- `'pending'` returns the **Pending** submissions and `'completed'`, the **Completed** ones.
+- `'pending'` returns the **Pending** submissions.
+- `'completed'` returns the **Completed** ones.
 - `'all'` doesn't return all of them: it delivers the **Pending** ones plus the **Completed** ones, and leaves out the **Not started** and the **Canceled** ones.
 - `'not_started'` and `'canceled'` aren't supported. The filter doesn't fail and leaves no trace on the page: it returns an empty collection, so any listing that uses them shows up blank.
 

--- a/docs/en/platform/channels/liquid-markup/filters.md
+++ b/docs/en/platform/channels/liquid-markup/filters.md
@@ -769,7 +769,28 @@ Returns the Submissions with the selected status. *e.g.*
 
 **Parameters:**
 - submissions (ArraySubmission) - array with user submissions
-- status (String) - Originations status. Supported values are 'pending', 'completed' and 'all'
+- status (String) - Submission status. Supported values are 'pending', 'completed' and 'all'
+
+In Modyo 10.2 a submission can be in one of four statuses: **Not started**, **Pending**, **Completed**, and **Canceled**. The filter recognizes only three values, and they don't map directly onto those statuses:
+
+- `'pending'` returns the **Pending** submissions and `'completed'`, the **Completed** ones.
+- `'all'` doesn't return all of them: it delivers the **Pending** ones plus the **Completed** ones, and leaves out the **Not started** and the **Canceled** ones.
+- `'not_started'` and `'canceled'` aren't supported. The filter doesn't fail and leaves no trace on the page: it returns an empty collection, so any listing that uses them shows up blank.
+
+:::warning Attention
+A submission is born **Not started** and only moves to **Pending** when the first response to one of its tasks is saved, so newly created ones don't show up in listings built with this filter. On top of that, `user.submissions` is already scoped to the **Pending** and **Completed** submissions, so no combination of `by_status` can reach the **Not started** or **Canceled** ones in that collection.
+:::
+
+To list the statuses the filter doesn't cover, loop over an unscoped collection, such as `user.invited_submissions`, without going through `by_status`, and compare [`submission.status`](/en/platform/channels/liquid-markup/objects.html#submission) inside the loop:
+
+```liquid
+{% assign invited = user.invited_submissions | by_origination: 'my-origination' %}
+{% for invited_submission in invited %}
+  {% if invited_submission.status == 'not_started' %}
+    <a href="{{ invited_submission.resume_url }}">{{ invited_submission.origination.name }}</a>
+  {% endif %}
+{% endfor %}
+```
 
 ### Completed
 
@@ -783,17 +804,35 @@ Checks whether an element (step/task wrapper) is completed for a given submissio
 
 Returns: Boolean (true/false)
 
+As of Modyo 10.2 the filter resolves the status against the user present in the render context, not against the submission owner: a step counts as completed only if that user has a completed response for every task they can see. In a flow with invited users, the same template delivers different results depending on who is looking, and a step that showed up as completed in 10.1 may now show up as incomplete.
+
+:::warning Attention
+The filter needs the `user` object in the template context. If it isn't there, evaluation aborts as soon as the submission has at least one completed task, and the published HTML shows the `<!-- Liquid Error -->` comment instead of the block, with no warning for whoever is browsing. Guard the block with <span v-pre>`{% if user %}`</span> and make sure the template receives the user.
+:::
+
 ### URL (Step URL for Submission)
 
 Generates a navigable URL for a step within a submission (first visible task). Only returns a value if submission is pending and either the step is completed or origination step ordering permits navigation.
 
 *e.g.* <span v-pre>`{{ step | url: submission }}`</span>
 
+Just like `completed`, it resolves the completed step and the first visible task against the user in the render context, with the same consequences in flows with invited users and the same behavior when `user` is missing from the context.
+
+:::warning Attention
+A newly created submission is **Not started**, not **Pending**, so the filter returns no value in the most common case of a template meant to resume a submission. The submission moves to **Pending** when the first response to one of its tasks is saved; until then, take the user to the start of the flow with [`submission.resume_url`](/en/platform/channels/liquid-markup/objects.html#submission), which doesn't depend on the status.
+:::
+
 ### Resume Link
 
 Returns an HTML anchor tag to resume a pending step for a submission, or the step name if no URL is available.
 
 *e.g.* <span v-pre>`{{ step | resume_link: submission }}`</span>
+
+The link is built by `url`, so it inherits all of its conditions: when `url` returns no value, `resume_link` prints the step name as plain text.
+
+:::warning Attention
+On a **Not started** submission the filter prints the step name as plain text and the page shows no error: the template looks complete, but the user has no way in. The same happens when `url` returns no link for that step with the context user. Check the submission status before rendering the listing and offer [`submission.resume_url`](/en/platform/channels/liquid-markup/objects.html#submission) while it isn't **Pending** yet.
+:::
 
 ### Submissions Selector
 

--- a/docs/es/platform/channels/liquid-markup/filters.md
+++ b/docs/es/platform/channels/liquid-markup/filters.md
@@ -776,7 +776,8 @@ Devuelve los Submissions con el estado seleccionado. *ej.*
 
 En Modyo 10.2 una respuesta puede estar en cuatro estados: **No Iniciada**, **Pendiente**, **Completada** y **Cancelada**. El filtro reconoce solo tres valores y no hay correspondencia directa con esos estados:
 
-- `'pending'` devuelve las respuestas **Pendiente** y `'completed'`, las **Completada**.
+- `'pending'` devuelve las respuestas **Pendiente**.
+- `'completed'` devuelve las respuestas **Completada**.
 - `'all'` no devuelve todas: entrega las **Pendiente** más las **Completada**, y deja fuera las **No Iniciada** y las **Cancelada**.
 - `'not_started'` y `'canceled'` no están soportados. El filtro no falla ni deja rastro en la página: devuelve una colección vacía, así que el listado que los use se ve en blanco.
 

--- a/docs/es/platform/channels/liquid-markup/filters.md
+++ b/docs/es/platform/channels/liquid-markup/filters.md
@@ -772,7 +772,28 @@ Devuelve los Submissions con el estado seleccionado. *ej.*
 
 **Parámetros:**
 - submissions (ArraySubmission) - array con submissions del usuario
-- status (String) - Estado de los Originations. Los valores soportados son 'pending', 'completed' y 'all'
+- status (String) - Estado de la respuesta. Los valores soportados son 'pending', 'completed' y 'all'
+
+En Modyo 10.2 una respuesta puede estar en cuatro estados: **No Iniciada**, **Pendiente**, **Completada** y **Cancelada**. El filtro reconoce solo tres valores y no hay correspondencia directa con esos estados:
+
+- `'pending'` devuelve las respuestas **Pendiente** y `'completed'`, las **Completada**.
+- `'all'` no devuelve todas: entrega las **Pendiente** más las **Completada**, y deja fuera las **No Iniciada** y las **Cancelada**.
+- `'not_started'` y `'canceled'` no están soportados. El filtro no falla ni deja rastro en la página: devuelve una colección vacía, así que el listado que los use se ve en blanco.
+
+:::warning Atención
+Una respuesta nace **No Iniciada** y pasa a **Pendiente** recién cuando se guarda la primera respuesta a una de sus tareas, así que las recién creadas no aparecen en los listados construidos con este filtro. Además, `user.submissions` ya viene acotado a las respuestas **Pendiente** y **Completada**, de modo que ninguna combinación de `by_status` alcanza a las **No Iniciada** ni a las **Cancelada** de esa colección.
+:::
+
+Para listar los estados que el filtro no cubre, recorre una colección sin acotar, como `user.invited_submissions`, sin pasar por `by_status`, y compara [`submission.status`](/es/platform/channels/liquid-markup/objects.html#submission) dentro del ciclo:
+
+```liquid
+{% assign invited = user.invited_submissions | by_origination: 'my-origination' %}
+{% for invited_submission in invited %}
+  {% if invited_submission.status == 'not_started' %}
+    <a href="{{ invited_submission.resume_url }}">{{ invited_submission.origination.name }}</a>
+  {% endif %}
+{% endfor %}
+```
 
 ### Completed
 
@@ -786,17 +807,35 @@ Verifica si un elemento (wrapper de step/task) está completado para un submissi
 
 Retorna: Boolean (true/false)
 
+Desde Modyo 10.2 el filtro resuelve el estado contra el usuario presente en el contexto de render y no contra el titular de la respuesta: un step cuenta como completado solo si ese usuario tiene una respuesta completada en cada una de las tareas que ve. En un flujo con usuarios invitados, la misma plantilla entrega resultados distintos según quién la mire, y un step que en 10.1 aparecía completado puede aparecer incompleto.
+
+:::warning Atención
+El filtro necesita el objeto `user` en el contexto de la plantilla. Si no está, la evaluación aborta apenas la respuesta tiene al menos una tarea completada, y en el HTML publicado queda el comentario `<!-- Liquid Error -->` en lugar del bloque, sin ningún aviso para quien navega. Protege el bloque con <span v-pre>`{% if user %}`</span> y asegúrate de que la plantilla reciba el usuario.
+:::
+
 ### URL (URL del Step para Submission)
 
 Genera una URL navegable para un step dentro de un submission (primer task visible). Solo retorna valor si el submission está pendiente y el step está completado o el orden de steps permite navegación.
 
 *ej.* <span v-pre>`{{ step | url: submission }}`</span>
 
+Igual que `completed`, resuelve el step completado y la primera task visible contra el usuario del contexto de render, con las mismas consecuencias en flujos con usuarios invitados y el mismo comportamiento si falta `user` en el contexto.
+
+:::warning Atención
+Una respuesta recién creada está **No Iniciada**, no **Pendiente**, así que el filtro no devuelve valor justo en el caso más frecuente de una plantilla para retomar una respuesta. La respuesta pasa a **Pendiente** cuando se guarda la primera respuesta a una de sus tareas; hasta entonces, lleva al usuario al inicio del flujo con [`submission.resume_url`](/es/platform/channels/liquid-markup/objects.html#submission), que no depende del estado.
+:::
+
 ### Resume Link
 
 Retorna un tag HTML de enlace para retomar un step pendiente dentro de un submission, o el nombre del step si no hay URL disponible.
 
 *ej.* <span v-pre>`{{ step | resume_link: submission }}`</span>
+
+El enlace lo arma `url`, así que hereda todas sus condiciones: cuando `url` no devuelve valor, `resume_link` imprime el nombre del step como texto plano.
+
+:::warning Atención
+Sobre una respuesta **No Iniciada** el filtro imprime el nombre del step como texto plano y la página no muestra ningún error: la plantilla se ve completa, pero el usuario no tiene por dónde entrar. Lo mismo pasa cuando `url` no entrega enlace para ese step con el usuario del contexto. Revisa el estado de la respuesta antes de renderizar el listado y ofrece [`submission.resume_url`](/es/platform/channels/liquid-markup/objects.html#submission) mientras no esté **Pendiente**.
+:::
 
 ### Submissions Selector
 


### PR DESCRIPTION
## Cambios propuestos

Actualiza los filtros de submission de Liquid Markup al comportamiento real de Modyo 10.2, en español y en inglés.

### docs/es/platform/channels/liquid-markup/filters.md y docs/en/platform/channels/liquid-markup/filters.md

**By Status** (LIQUID-FILTROS-03)
- Se corrige la descripción del parámetro `status`: es el estado de la respuesta, no el de la originación.
- Se documentan los cuatro estados de una respuesta en 10.2 (**No Iniciada**, **Pendiente**, **Completada** y **Cancelada**) frente a los tres valores que acepta el filtro, con los labels exactos del panel.
- Se explican las dos trampas: `'all'` no devuelve todas, sino las pendientes más las completadas; y `'not_started'` o `'canceled'` devuelven una colección vacía sin error ni rastro en la página, así que el listado simplemente se ve en blanco.
- Se agrega un callout con el efecto que más duele: una respuesta nace **No Iniciada** y solo pasa a **Pendiente** al guardarse la primera respuesta a una tarea, y como `user.submissions` ya viene acotado a pendientes y completadas, ninguna combinación de `by_status` alcanza a las recién creadas ni a las canceladas.
- Se agrega un ejemplo Liquid para listar esos estados recorriendo una colección sin acotar, como `user.invited_submissions`, y comparando `submission.status` dentro del ciclo.

**Completed, URL y Resume Link** (LIQUID-FILTROS-04, que unifica LIQUID-FILTROS-20)
- Se documenta que los tres filtros resuelven el estado del step contra el usuario del contexto de render y no contra el titular de la respuesta: un step cuenta como completado solo si ese usuario tiene una respuesta completada en cada tarea que ve, por lo que en flujos con usuarios invitados la misma plantilla entrega resultados distintos según quién la mire.
- Se agrega un callout en **Completed** sobre la necesidad de tener `user` en el contexto: si falta, la evaluación aborta apenas la respuesta tiene una tarea completada y en el HTML publicado queda el comentario de error de Liquid en lugar del bloque, sin aviso para quien navega. Se recomienda proteger el bloque y asegurar el usuario en el contexto.
- Se agrega un callout en **URL** sobre el nuevo estado inicial: una respuesta recién creada está **No Iniciada**, no **Pendiente**, así que el filtro no devuelve valor justo en el caso más frecuente de una plantilla para retomar una respuesta. Se apunta a `submission.resume_url`, que no depende del estado.
- Se agrega un callout en **Resume Link** con la consecuencia visible: sobre una respuesta **No Iniciada** imprime el nombre del step como texto plano, sin enlace y sin error, de modo que la plantilla se ve completa pero el usuario no tiene por dónde entrar.

### Notas

- Todo el contenido se verificó contra el código de la plataforma en master: lista blanca del filtro, mapeo de `'all'`, enum de cuatro estados, estado inicial `not_started` y los scopes de las colecciones de submissions del objeto user.
- Los labels de estado se citan con el texto exacto de los locales del panel de administración en cada idioma.
- Cierra los gaps LIQUID-FILTROS-03, LIQUID-FILTROS-04 y LIQUID-FILTROS-20.

## Para el revisor

- Verificado contra origin/master: el codigo de by_status, completed, url y resume_link es identico en releases/10.2-stable y en master, igual que el enum de cuatro estados, el estado inicial not_started y los scopes de user_drop. Ninguna ficha quedo invalidada y no hubo que ajustar nada por deriva de master.
- Ajuste de alcance respecto de la ficha 04: la caida por falta de `user` se documenta como condicionada a que la respuesta ya tenga al menos una tarea completada, no como incondicional, porque el acceso sin guarda vive dentro del bloque scope.any? de task.rb y el resto de la cadena es nil-safe. Es lo que dice el bloque "Corregido en la verificacion".
- El ejemplo usa `user.invited_submissions`, que todavia no figura en la tabla de objetos de user de objects.md (esa coleccion la cubre otra tanda). Por eso se menciona sin enlace: si esa tanda entra despues, conviene enlazarla desde aqui. Los dos enlaces que si se agregan apuntan a objects.html#submission, que existe hoy en los dos idiomas y contiene submission.status y submission.resume_url.
- Las fichas pedian ademas registrar el cambio de enum y el cambio de aridad en las notas de version de 10.2. Esa pagina no esta en el alcance de esta tanda (solo filters.md), asi que queda pendiente para la tanda de release notes.
- Terminologia: el estilo de la casa pide "respuesta" para submission en Origination, pero la pagina existente dice "submission" en todos sus titulos y parrafos. El texto nuevo en espanol usa "respuesta" y no se reescribieron las lineas viejas, para no tocar lo que la tanda no pide; queda una mezcla que conviene resolver en una pasada de terminologia sobre toda la seccion Submission.
- Se mantuvo "step" y "task" en el texto nuevo en espanol porque asi estan en el resto de la pagina (### By UID: "Devuelve el Step con el UID seleccionado").
- La directiva de producto sobre paginas y modulo de Soporte no aplico: nada del contenido llevo a tickets, casos ni comentarios, y no se menciona.
- Sin internos de infraestructura: el comentario de error de Liquid se documenta como efecto observable en el HTML publicado (la pagina ya lo usa asi en dos callouts previos), sin nombrar el initializer ni el monkeypatch.

Closes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)
