### PR TITLE
Documentar el switch de cuenta para imágenes SVG y la validación de tipo de contenido en las subidas de archivos

### DIFF
--- a/docs/en/platform/content/asset-manager.md
+++ b/docs/en/platform/content/asset-manager.md
@@ -26,7 +26,7 @@ Allowed file types are:
 - **Files**: 7z, ai, apk, css, csv, doc, docx, fon, ico, iso, jar, js, msi, ods, odt, otf, pdf, ppt, pptx, rar, rss, rtf, scss, tar, tex, ttf, txt, vcf, wdp, xhtml, xls, xlsm, xlsx, xml, zip, one, ecf, pub, xps, json, svg, woff, woff2, ics
 
 :::warning Attention
-The `svg` format depends on an account setting. The **Allow use of SVG** box, under **Settings** > **Security**, comes disabled, and while it stays that way any attempt to upload or update an SVG file is rejected with the message _Can't upload or update SVG files due to configured security policies_. Before enabling it, review [SVG images](/en/platform/core/security.html#svg-images), because it has security implications.
+The `svg` format depends on an account setting. The **Allow use of SVG** box, under **Settings** > **Security**, is disabled by default, and while it stays that way any attempt to upload or update an SVG file is rejected with the message _Can't upload or update SVG files due to configured security policies_. Before enabling it, review [SVG images](/en/platform/core/security.html#svg-images), because it has security implications.
 :::
 
 Modyo also checks the file name: it cannot contain more than one dot, so a name like `styles.min.css` is rejected with the message _shouldn't include dots_. In addition, when saving, every character that is not an unaccented letter, a number, or a hyphen is replaced with an underscore, so `Presentación final.pdf` is stored as `Presentaci_n_final.pdf`.

--- a/docs/en/platform/content/asset-manager.md
+++ b/docs/en/platform/content/asset-manager.md
@@ -20,12 +20,20 @@ Different types of media can be uploaded to this space, considering the followin
 - **Files**: 10 MB
 
 Allowed file types are:
-- **Images**: apng, avif, bmp, gif, ico, jpeg, jpg, png, tif, tiff, webp
+- **Images**: apng, avif, bmp, gif, ico, jpeg, jpg, png, svg, tif, tiff, webp
 - **Videos**: av, avi, f4v, flv, mkv, mov, mp4, mpeg, webm, wmv
 - **Audios**: 3gp, aac, alac, dsd, flac, mp3, pcm, wav, m4a, ogg, wma
 - **Files**: 7z, ai, apk, css, csv, doc, docx, fon, ico, iso, jar, js, msi, ods, odt, otf, pdf, ppt, pptx, rar, rss, rtf, scss, tar, tex, ttf, txt, vcf, wdp, xhtml, xls, xlsm, xlsx, xml, zip, one, ecf, pub, xps, json, svg, woff, woff2, ics
 
+:::warning Attention
+The `svg` format depends on an account setting. The **Allow use of SVG** box, under **Settings** > **Security**, comes disabled, and while it stays that way any attempt to upload or update an SVG file is rejected with the message _Can't upload or update SVG files due to configured security policies_. Before enabling it, review [SVG images](/en/platform/core/security.html#svg-images), because it has security implications.
+:::
 
+Modyo also checks the file name: it cannot contain more than one dot, so a name like `styles.min.css` is rejected with the message _shouldn't include dots_. In addition, when saving, every character that is not an unaccented letter, a number, or a hyphen is replaced with an underscore, so `Presentación final.pdf` is stored as `Presentaci_n_final.pdf`.
+
+:::warning Attention
+Since Modyo 10.2, in addition to the extension and the size, Modyo checks that the file's actual content type matches its extension. If they do not match, the upload fails and the panel shows the file name next to the message _content type does not match the file's extension_. The check applies to the four media types, both in the panel and through the admin API, so a PNG renamed to `.jpg` or a CSV renamed to `.xlsx` can no longer be uploaded. If you run into this error, rename the file with its real extension or export it again in the format you need.
+:::
 
 ## About the Interface
 

--- a/docs/en/platform/core/security.md
+++ b/docs/en/platform/core/security.md
@@ -135,7 +135,7 @@ If you have activated the option to force authentication, the next time the user
 
 ## SVG images
 
-The **Enable use of SVG images** section defines whether your account accepts SVG files. It comes disabled, and only team members with the **Admin Security** permission can change it.
+The **Enable use of SVG images** section defines whether your account accepts SVG files. It is disabled by default, and only team members with the **Admin Security** permission can change it.
 
 To allow SVG file uploads, follow these steps:
 

--- a/docs/en/platform/core/security.md
+++ b/docs/en/platform/core/security.md
@@ -133,6 +133,23 @@ If the authenticator is lost or stolen, it will not be possible to access the ac
 If you have activated the option to force authentication, the next time the user tries to log in, they will need to initialize the authenticator first. Once the authenticator is active, the user can proceed with the login process.
 :::
 
+## SVG images
+
+The **Enable use of SVG images** section defines whether your account accepts SVG files. It comes disabled, and only team members with the **Admin Security** permission can change it.
+
+To allow SVG file uploads, follow these steps:
+
+1. In the side menu, expand **Settings** and click **Security**.
+2. Scroll down to the **Enable use of SVG images** section.
+3. Check the **Allow use of SVG** box.
+4. Click **Save**.
+
+While the box is unchecked, any attempt to upload or update an SVG file in [Media](/en/platform/content/asset-manager.html) is rejected with the message _Can't upload or update SVG files due to configured security policies_. The rejection applies both in the panel and through the admin API, and it also reaches the SVG files that already exist in the account: while the box stays unchecked, you cannot save changes to their title, alternative text, description, or tags either.
+
+:::warning Attention
+The panel itself warns you that "The use of SVG images can leave you vulnerable to XSS attacks and may be insecure". An SVG is an XML document that can carry scripts and external references inside, and the browser interprets it with the same privileges as the page that displays it. Enable it only if your teams need this format and you control the origin of the files they upload.
+:::
+
 ## Best practices
 
 ### Important concepts

--- a/docs/es/platform/content/asset-manager.md
+++ b/docs/es/platform/content/asset-manager.md
@@ -20,12 +20,20 @@ Puedes cargar diversos tipos de media a este espacio, considerando las siguiente
 - **Archivos**: 10 MB
 
 Los tipos de archivos permitidos son:
-- **Imágenes**: apng, avif, bmp, gif, ico, jpeg, jpg, png, tif, tiff, webp
+- **Imágenes**: apng, avif, bmp, gif, ico, jpeg, jpg, png, svg, tif, tiff, webp
 - **Videos**: av, avi, f4v, flv, mkv, mov, mp4, mpeg, webm, wmv
 - **Audios**: 3gp, aac, alac, dsd, flac, mp3, pcm, wav, m4a, ogg, wma
 - **Archivos**: 7z, ai, apk, css, csv, doc, docx, fon, ico, iso, jar, js, msi, ods, odt, otf, pdf, ppt, pptx, rar, rss, rtf, scss, tar, tex, ttf, txt, vcf, wdp, xhtml, xls, xlsm, xlsx, xml, zip, one, ecf, pub, xps, json, svg, woff, woff2, ics
 
+:::warning Atención
+El formato `svg` depende de una configuración de tu cuenta. La casilla **Permitir el uso de SVG**, en **Configuración** > **Seguridad**, viene desactivada, y mientras siga así cualquier intento de subir o de actualizar un archivo SVG se rechaza con el mensaje _No se pueden cargar ni actualizar archivos SVG debido a las políticas de seguridad configuradas_. Antes de activarla, revisa [Imágenes SVG](/es/platform/core/security.html#imagenes-svg), porque tiene implicancias de seguridad.
+:::
 
+Modyo también revisa el nombre del archivo: no puede contener más de un punto, así que un nombre como `estilos.min.css` se rechaza con el mensaje _no debe incluir puntos_. Al guardar, además, cualquier carácter que no sea una letra sin acento, un número o un guion se reemplaza por un guion bajo, por lo que `Presentación final.pdf` queda almacenado como `Presentaci_n_final.pdf`.
+
+:::warning Atención
+Desde Modyo 10.2, además de la extensión y del tamaño, se comprueba que el tipo de contenido real del archivo corresponda a su extensión. Si no coinciden, la subida falla y el panel muestra el nombre del archivo junto al mensaje _el tipo de contenido no coincide con la extensión del archivo_. La comprobación se aplica a los cuatro tipos de media, tanto en el panel como en la API de administración, así que un PNG renombrado a `.jpg` o un CSV renombrado a `.xlsx` dejan de subirse. Si te encuentras con este error, renombra el archivo con su extensión real o vuelve a exportarlo en el formato que necesitas.
+:::
 
 ## Acerca de la Interfaz
 

--- a/docs/es/platform/core/security.md
+++ b/docs/es/platform/core/security.md
@@ -133,6 +133,23 @@ En caso de extravío o robo del autenticador, no será posible entrar a la cuent
 Si has activado la opción de forzar autenticación, la próxima vez que el usuario intente iniciar sesión, será necesario que primero inicialice el autenticador. Una vez que el autenticador esté activo, el usuario puede proceder con el proceso de inicio de sesión.
 :::
 
+## Imágenes SVG
+
+La sección **Habilitar el uso de imágenes SVG** define si tu cuenta acepta archivos SVG. Viene desactivada, y solo pueden cambiarla los miembros del equipo con el permiso **Administrar Seguridad**.
+
+Para permitir la carga de archivos SVG, sigue estos pasos:
+
+1. En el menú lateral, expande **Configuración** y haz click en **Seguridad**.
+2. Baja hasta la sección **Habilitar el uso de imágenes SVG**.
+3. Marca la casilla **Permitir el uso de SVG**.
+4. Haz click en **Guardar**.
+
+Mientras la casilla está desmarcada, cualquier intento de subir o de actualizar un archivo SVG en [Media](/es/platform/content/asset-manager.html) se rechaza con el mensaje _No se pueden cargar ni actualizar archivos SVG debido a las políticas de seguridad configuradas_. El rechazo aplica tanto en el panel como en la API de administración, y alcanza también a los SVG que ya existan en la cuenta: mientras la casilla siga desmarcada tampoco puedes guardar cambios en su título, texto alternativo, descripción o etiquetas.
+
+:::warning Atención
+El propio panel advierte que "El uso de imágenes SVG te puede dejar vulnerable a los ataques XSS y puede resultar inseguro". Un SVG es un documento XML que puede llevar scripts y referencias externas dentro, y el navegador lo interpreta con los mismos privilegios que la página que lo muestra. Actívalo solo si tus equipos necesitan este formato y controlas el origen de los archivos que suben.
+:::
+
 ## Mejores Prácticas
 
 ### Conceptos importantes


### PR DESCRIPTION
## Cambios propuestos

Documenta las dos causas por las que una subida de archivos puede fallar sin explicación en Modyo 10.2: el switch de cuenta que condiciona los SVG y la nueva validación que exige que el tipo de contenido del archivo coincida con su extensión.

### `docs/es/platform/core/security.md` y `docs/en/platform/core/security.md`

Se agrega la sección **Imágenes SVG**, la séptima y última de la pantalla de Seguridad de la cuenta, que hasta ahora era la única sin documentar. Va después de Autenticación de Dos Pasos 2FA, respetando el orden en que el panel las muestra, e incluye:

- Qué controla la casilla **Permitir el uso de SVG**, dentro de **Habilitar el uso de imágenes SVG**, y que viene desactivada.
- Quién puede cambiarla: los miembros del equipo con el permiso **Administrar Seguridad**.
- Los pasos para activarla desde **Configuración** > **Seguridad**.
- Qué pasa mientras está desmarcada: se rechaza subir y también actualizar archivos SVG, en el panel y en la API de administración, con el mensaje _No se pueden cargar ni actualizar archivos SVG debido a las políticas de seguridad configuradas_. Se aclara que el bloqueo alcanza incluso a los SVG que ya existen en la cuenta, cuyos metadatos tampoco se pueden guardar.
- Un `:::warning` con la advertencia real del producto sobre XSS y el criterio para decidir si conviene activarlo.

### `docs/es/platform/content/asset-manager.md` y `docs/en/platform/content/asset-manager.md`

Se corrigen las restricciones de subida, que hoy inducen al error porque listan `svg` como formato permitido sin condiciones:

- `svg` se suma a la lista de **Imágenes**, porque un archivo SVG entra como asset de tipo Imagen, y un `:::warning` explica que el formato depende de la casilla de cuenta, con enlace a la sección nueva de Seguridad.
- Se documenta que desde Modyo 10.2 se comprueba que el tipo de contenido real del archivo corresponda a su extensión, con el mensaje de error exacto, el alcance (los cuatro tipos de media, en el panel y en la API de administración) y ejemplos concretos: un PNG renombrado a `.jpg` o un CSV renombrado a `.xlsx` dejan de subirse.
- Se añaden las dos reglas de nombre de archivo que tampoco estaban escritas: no se acepta más de un punto (_no debe incluir puntos_) y el resto de los caracteres no permitidos se reemplaza por guion bajo al guardar.

### Gaps que cierra

- **CONFIGURACIONES-16**: el flag de cuenta "Habilitar el uso de imágenes SVG" no estaba documentado y el Asset Manager ofrecía SVG sin condiciones. Cierra también **CONTENT-12** y **ROLES-SEGURIDAD-18**, que la ficha unifica porque se resuelven con estas mismas dos ediciones.
- **CONTENT-11**: los assets cuyo tipo de contenido no coincide con su extensión se rechazan desde 10.2, sin aviso en la documentación.

Todo el contenido se verificó contra `origin/master`, incluidos los textos de los mensajes de error y los labels de la interfaz, que se citan tal como aparecen en los archivos de traducción de la plataforma.

## Para el revisor

No hubo divergencia entre releases/10.2-stable y origin/master: el diff de content_type_match_extension_validator.rb, assets/asset.rb, picture/file/video/audio.rb, los locales de error y SVGSettingsSection.js sale vacío, así que lo documentado es lo de master.

Decisiones que van más allá de la letra de la ficha:
- Agregué `svg` a la lista de **Imágenes** / **Images**. La ficha solo pedía condicionar el SVG que ya aparecía en **Archivos**, pero `DEFAULT_EXTENSIONS['image']` lo incluye y `pictureUtils.js` mapea `image/svg+xml` a la clase `picture`, así que en el panel un SVG queda como asset de tipo Imagen. Dejar la lista sin `svg` seguiría siendo incorrecto. Si la revisora prefiere no ampliar listas, se puede revertir esa edición sin tocar el resto.
- El error de tipo de contenido se agrega sobre `:data_file_name` y `data_file_name` no tiene traducción de atributo en ningún locale, por lo que `full_message` lo antepone humanizado ("Data file name el tipo de contenido..."). Por eso el texto dice que "el panel muestra el nombre del archivo junto al mensaje" y cita solo el fragmento traducido, en vez de prometer una cadena literal completa.

Cosas que decidí no documentar:
- La depuración del SVG al subirlo (`Paperclip::SvgHush`): depende de que el binario esté presente en la instalación (`skip_for_svg` lo salta si no existe), así que prometerla sería inexacto además de entrar en internos de infraestructura.
- Los tamaños máximos y la lista blanca de extensiones son configurables por instalación; la página ya publica los valores por defecto y no toqué esa parte.
- `MIME::Types.type_for` puede no conocer algunas extensiones de la lista blanca (`ecf`, `fon`, `wdp`, `xps`, `one`, `dsd`, `pcm`, `av`), en cuyo caso el conjunto esperado queda vacío y la subida se rechazaría siempre. No lo afirmo en la documentación porque no lo pude ejecutar; queda como posible seguimiento si aparecen reportes.

Directiva de producto: esta tanda no toca páginas de soporte, el módulo Soporte, tickets ni objetos Liquid de casos o comentarios, así que no hubo nada que omitir por ese motivo.

No hay páginas nuevas, así que no se toca `docs/.vuepress/config.js`. Ninguna de las seis ediciones se apoya en el resultado de otra: las dos que caen sobre el mismo archivo actúan en líneas distintas (la lista de Imágenes y el bloque previo al encabezado siguiente) y pueden aplicarse en el orden en que van.

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)
