### PR TITLE
Insights Digital Factory: corregir el alcance de los filtros Aplicación y Espacio y los recursos que mide el dashboard

### DIFF
--- a/docs/en/platform/insights/digital-factory.md
+++ b/docs/en/platform/insights/digital-factory.md
@@ -8,43 +8,57 @@ The Digital Factory dashboard displays metrics about team productivity and conte
 
 ### Key metrics
 
-Five counters showing team activity:
-- **Created**: New entries, pages, and widgets
-- **Edited**: Saved modifications
-- **Sent for Review**: Elements in approval process
-- **Approved**: Content ready to publish
-- **Published**: Elements in production
+Five counters summarizing team activity across the four resource types the dashboard measures: entries, pages, widgets, and templates.
+
+- **Created**: new elements of any of those four types
+- **Edited**: saved modifications
+- **Sent to Review**: elements that entered the approval flow
+- **Approved**: elements approved and ready to publish
+- **Published**: elements that went to production
 
 Each counter includes a trend indicator comparing with the previous period.
 
+:::tip Tip
+The counters don't tell resource types apart: **Created** goes up whether the team created an entry, a page, a widget, or a template. To see where the work is concentrated, look at the **Activity by Resource** chart.
+:::
+
 ### Available filters
 
-- Date range
-- Sites
-- Spaces
+- The date range selector
+- **App**, listing the account's active apps
+- **Space**, listing the account's spaces
+
+Both dropdowns start on **All**.
 
 :::warning Warning
-When filtering by site, space elements are not included in the count, and vice versa.
+**App** and **Space** add up, they don't intersect. When you pick an app, the dashboard keeps counting entry activity from every space in the account; when you pick a space, it keeps counting page, widget, and template activity from every app. And if you pick an app and a space at the same time, you get the sum of both, never the intersection.
 :::
 
 ### Created vs published resources
 
 Line chart comparing the volume of content created against published over time, allowing identification of potential bottlenecks in the editorial flow.
 
-### Activity by user
+### Activity by User
 
-Table showing team member activity with columns for:
-- Elements created
-- Elements modified
-- Sent for review
-- Approved
-- Published
+Heat map crossing administrators with the five workflow states: **Created**, **Edited**, **Sent to Review**, **Approved**, and **Published**. Each cell gets more intense the more events that administrator has in that state.
 
-### Activity by content
+The panel shows at most the 20 administrators with the most activity in the period, and each row is labeled only with the administrator's first name.
 
-Horizontal bar chart comparing activity by element type:
-- Entries
-- Pages
-- Widgets
-- Templates
-- Navigation
+:::tip Tip
+If two people on your team share a first name, you'll see two rows with the same label. And if more than 20 administrators record activity in the period, the least active ones fall outside the map: narrow the date range to see them.
+:::
+
+### Activity by Resource
+
+Bar chart comparing the total events of the four resource types the dashboard measures:
+
+- **Entries**: the entries in your spaces
+- **Layouts**: the pages of your apps
+- **Widgets**: your widget definitions
+- **Templates**: your apps' templates
+
+Each bar adds up the five workflow states for that resource type, so the chart tells you where the team's work is concentrated, not what stage it's in.
+
+:::warning Warning
+App navigation is not measured in this dashboard, and neither are assets or anything else outside those four types: their changes show up neither in the bars nor in the top counters.
+:::

--- a/docs/es/platform/insights/digital-factory.md
+++ b/docs/es/platform/insights/digital-factory.md
@@ -8,23 +8,30 @@ El dashboard de Digital Factory muestra métricas sobre la productividad del equ
 
 ### Métricas Principales
 
-Cinco contadores que muestran la actividad del equipo:
-- **Creados**: Nuevas entradas, páginas y widgets
-- **Editados**: Modificaciones guardadas
-- **Enviados a revisión**: Elementos en proceso de aprobación
-- **Aprobados**: Contenido listo para publicar
-- **Publicados**: Elementos en producción
+Cinco contadores que resumen la actividad del equipo sobre los cuatro tipos de recurso que mide el dashboard: entradas, páginas, widgets y plantillas.
+
+- **Creados**: elementos nuevos de cualquiera de esos cuatro tipos
+- **Editados**: modificaciones guardadas
+- **Enviados a Revisión**: elementos que entraron al flujo de aprobación
+- **Aprobados**: elementos aprobados y listos para publicar
+- **Publicados**: elementos que pasaron a producción
 
 Cada contador incluye un indicador de tendencia comparando con el período anterior.
 
+:::tip Tip
+Los contadores no distinguen el tipo de recurso: **Creados** sube igual si el equipo creó una entrada, una página, un widget o una plantilla. Para saber dónde se concentró el trabajo, mira el gráfico **Actividad por Contenido**.
+:::
+
 ### Filtros disponibles
 
-- Rango de fechas
-- Sitios
-- Espacios
+- El selector de rango de fechas
+- **Aplicación**, con las aplicaciones activas de la cuenta
+- **Espacio**, con los espacios de la cuenta
+
+Ambos desplegables parten en **Todos**.
 
 :::warning Atención
-Al filtrar por sitio, los elementos de espacios no se incluyen en el conteo, y viceversa.
+**Aplicación** y **Espacio** se suman, no se cruzan. Al elegir una aplicación, el dashboard sigue contando la actividad de entradas de todos los espacios de la cuenta; al elegir un espacio, sigue contando la actividad de páginas, widgets y plantillas de todas las aplicaciones. Y si eliges una aplicación y un espacio a la vez, obtienes la suma de ambos, nunca la intersección.
 :::
 
 ### Recursos creados vs publicados
@@ -33,18 +40,25 @@ Gráfico de líneas que compara el volumen de contenido creado contra el publica
 
 ### Actividad por Usuario
 
-Tabla que muestra la actividad de los miembros del equipo con columnas para:
-- Elementos creados
-- Elementos modificados
-- Enviados a revisión
-- Aprobados
-- Publicados
+Mapa de calor que cruza a los administradores con los cinco estados del flujo: **Creados**, **Editados**, **Enviados a Revisión**, **Aprobados** y **Publicados**. Cada celda se pinta más intensa mientras más eventos acumule ese administrador en ese estado.
+
+El panel muestra como máximo los 20 administradores con más actividad en el período, y cada fila se identifica solo con el nombre de pila del administrador.
+
+:::tip Tip
+Si dos personas del equipo comparten nombre de pila, verás dos filas con la misma etiqueta. Y si más de 20 administradores registran actividad en el período, los de menor actividad quedan fuera del mapa: acota el rango de fechas para verlos.
+:::
 
 ### Actividad por Contenido
 
-Gráfico de barras horizontales comparando la actividad por tipo de elemento:
-- Entradas
-- Páginas
-- Widgets
-- Templates
-- Navegación
+Gráfico de barras que compara el total de eventos de los cuatro tipos de recurso que mide el dashboard:
+
+- **Entradas**: las entradas de tus espacios
+- **Layouts**: las páginas de tus aplicaciones
+- **Widgets**: las definiciones de widget
+- **Plantillas**: las plantillas de tus aplicaciones
+
+Cada barra suma los cinco estados del flujo para ese tipo de recurso, así que el gráfico te dice dónde se concentra el trabajo del equipo, no en qué etapa está.
+
+:::warning Atención
+La navegación de tus aplicaciones no se mide en este dashboard, ni tampoco los assets ni ningún otro elemento fuera de esos cuatro tipos: sus cambios no aparecen ni en las barras ni en los contadores superiores.
+:::


### PR DESCRIPTION
## Cambios propuestos

Corrige dos afirmaciones incorrectas del dashboard de Digital Factory en Insights, en español y en inglés.

**docs/es/platform/insights/digital-factory.md**

- **Filtros disponibles**: el callout decía que al filtrar por sitio los elementos de espacios quedaban fuera del conteo, y el código hace exactamente lo contrario. Ahora se explica que **Aplicación** y **Espacio** se suman y nunca se cruzan: al elegir una aplicación se siguen contando las entradas de todos los espacios, al elegir un espacio se siguen contando páginas, widgets y plantillas de todas las aplicaciones, y al elegir ambos se obtiene la unión. Además los filtros pasan a nombrarse con sus labels reales del panel, **Aplicación** y **Espacio**, y se indica que ambos desplegables parten en **Todos**. Cierra INSIGHTS-REPORTES-07.
- **Métricas Principales**: se precisa que los cinco contadores suman los eventos de los cuatro tipos de recurso que mide el dashboard, así que **Creados** también incluye páginas y plantillas, no solo entradas y widgets. Se corrige la capitalización de **Enviados a Revisión**. Cierra parte de INSIGHTS-REPORTES-08.
- **Actividad por Usuario**: dejaba de describirse como una tabla con columnas. Es un mapa de calor de administradores contra los cinco estados del flujo, con tope de 20 administradores y filas etiquetadas solo con el nombre de pila. Cierra parte de INSIGHTS-REPORTES-08.
- **Actividad por Contenido**: se elimina **Navegación**, que no se mide, y quedan los cuatro tipos que sí compara el gráfico con el label real de cada serie: **Entradas**, **Layouts** (las páginas de tus aplicaciones), **Widgets** y **Plantillas**. Se agrega un callout aclarando que la navegación y los assets no entran ni en las barras ni en los contadores. Cierra parte de INSIGHTS-REPORTES-08.

**docs/en/platform/insights/digital-factory.md**

Espejo de todos los cambios anteriores. Además, los encabezados de los dos paneles pasan a coincidir con los labels reales en inglés: **Activity by User** y **Activity by Resource**, y el contador **Sent for Review** se corrige a **Sent to Review**. Ninguna página enlaza anclajes de esta página, así que el cambio de encabezados no rompe links.

## Para el revisor

Los filtros del dashboard se llaman **Aplicación** y **Espacio** en el panel (admin.commons.site y admin.content.contexts.space), no "Sitios" y "Espacios" como decía la página. Alineé el listado y el callout con esos labels, así que esta página queda usando "aplicación" donde docs/es/platform/insights/README.md todavía habla de "sitio, espacio, reino" en Segmentación contextual y donde apps.md y customers.md siguen diciendo "Sitio específico" y "Sitios específicos". No lo toqué porque está fuera de la tanda, pero conviene homologarlo en una tanda posterior.

La serie de páginas del gráfico **Actividad por Contenido** se etiqueta literalmente **Layouts**: el controlador reutiliza admin.customization.layout.label, la misma clave que titula el grupo de layouts del editor de plantillas, aunque lo que cuenta son páginas. Documenté el label real con la aclaración de que corresponde a las páginas, en vez de escribir "Páginas" como decía la ficha, porque el label no existe con ese texto en el locale. Es un desalineamiento del producto que vale la pena reportar aparte.

En inglés cambié dos encabezados para que coincidan con los labels reales del panel: "Activity by user" pasa a "Activity by User" y "Activity by content" pasa a "Activity by Resource". Verifiqué con grep que ninguna página enlaza anclajes de digital-factory.html, así que no rompo links. En español los encabezados ya coincidían con el label y quedaron intactos.

En español subí la capitalización de **Enviados a Revisión** y en inglés corregí "Sent for Review" a "Sent to Review", que es el texto del locale.

No documenté dos matices internos: que el relleno por defecto del filtro de aplicación usa solo los sitios base (sin ancestro) mientras el desplegable lista todos los sitios activos, y que StyledBarChart recibe layout 'row', que no es un valor válido de nivo. Por eso quité "horizontales" de la descripción del gráfico en vez de afirmar una orientación.

La directiva sobre páginas de soporte y el módulo Soporte no aplica en esta tanda: el dashboard mide solo entradas, páginas, widgets y plantillas de sitio, así que no hubo nada que omitir.

Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)
