### PR TITLE
Documentar la autenticación contra la API pública de Customers y corregir los claims del content delivery token

### DIFF
--- a/docs/en/platform/content/public-api-reference.md
+++ b/docs/en/platform/content/public-api-reference.md
@@ -687,28 +687,28 @@ The content access token is a public token in [JWT](https://tools.ietf.org/html/
 
 The content delivery token contains the following attributes:
 
-- **iss**: Base URL of the customers API
-- **aud**: Base URL of the Content API
-- **sub**: Name of the space
-- **exp**: Token expiration time
-- **access_type**: delivery,
-- **segments**: Array of segments
+- **iss**: URL with which Modyo identifies the issuer of the token. It is informative and carries a `/profile/` segment that does not match any real route, so do not use it as the address to call.
+- **aud**: Base URL of the Content API.
+- **sub**: UUID of the account, not the name of the space. The Content API compares this value with the UUID of the account serving the request and only enables private content when they match.
+- **exp**: Expiration moment of the token, calculated with the lifetime configured in the account. Check [Content Delivery Token (JWT - JSON Web Token)](/en/platform/core/security.html#content-delivery-token-jwt-json-web-token) to change it.
+- **access_type**: Always `delivery`.
+- **segments**: Array with the UUIDs of the segments the user belongs to.
 
 For example:
 
 ```javascript
 {
-  "iss": "http://my-account.modyo.me/api/customers",
-  "aud": "http://my-account.modyo.me/api/content",
-  "sub": "account_uuid",
+  "iss": "https://my_account.modyo.com/api/customers/realms/my_realm/profile/delivery_token",
+  "aud": "https://my_account.modyo.com/api/content",
+  "sub": "0f3d1b6c-5a2e-4c81-9b7f-2d84a6e05c19",
   "exp": 1516242622,
   "access_type": "delivery",
-  "segments": ["segment1", "segment2"]
+  "segments": ["7a41c9d2-3e58-4b60-8f13-95c2d7ae61b0", "c86b0f45-19da-4e27-b3a8-6f04d5217e9c"]
 }
 ```
 
 :::warning Attention
-To access the token acquisition URL, you must ensure you have an active session with a user in the account or at least in a site of the same; otherwise, you will receive a `404 - Not found` error.
+To request the token you need the credential of a user with an active session in the realm. Without it the endpoint responds `401` with <code v-pre>{"error":{"user_session":"user not found"}}</code>, not `404`. The `404` is a different matter: it shows up when the `realm_uid` in the URL does not match any active realm of the account. The interactive reference at `ACCOUNT_URL/api/customers/docs` only declares the `404` for this endpoint, so do not rely on it on this point. The credentials accepted by the Customers API are in [Authentication](/en/platform/customers/api.html#authentication).
 :::
 
 :::warning Attention

--- a/docs/en/platform/customers/api.md
+++ b/docs/en/platform/customers/api.md
@@ -7,6 +7,80 @@ search: true
 Modyo Customers contains a variety of APIs with which you can obtain information about Realms, notifications, and users.
 
 
+## Authentication
+
+Every endpoint under `ACCOUNT_URL/api/customers/realms/{realm_uid}/` answers on behalf of an end user of the realm, so each call needs a credential for that user. The only exception is [OTP code verification](#otp-code-verification).
+
+The realm accepts two credentials:
+
+- **OAuth2 access token**, in the `Authorization: Bearer` header. It takes precedence: when the request carries a recognized access token, the session cookie is not evaluated.
+- **Session cookie** of the user in the realm. It is used when the request does not carry a recognized access token. It is the natural option when your application runs inside a Modyo site, because the browser sends it on its own.
+
+Both resolve to the same user and grant access to the same endpoints. Choose the access token when your application lives outside the account domains, for example a mobile application or a front end on another domain.
+
+### Get an access token
+
+Each realm exposes its own OAuth2 server:
+
+| Endpoint | What it is for |
+|----------|----------------|
+| `ACCOUNT_URL/realms/{realm_uid}/oauth/authorize` | Authorizes the user and returns the code. |
+| `ACCOUNT_URL/realms/{realm_uid}/oauth/token` | Exchanges the code for the access token. |
+| `ACCOUNT_URL/realms/{realm_uid}/oauth/revoke` | Invalidates an already issued token. |
+
+The only supported flow is `authorization_code`. The realm does not issue tokens with `client_credentials`, `password` or `implicit`, and it does not deliver refresh tokens either.
+
+To start you need an OAuth client of the realm, created as described in [OAuth client](/en/platform/customers/settings.html#oauth-client). Clicking the client name shows its **UID** and its **Secret**, which are the `client_id` and the `client_secret` of the flow, together with the ready-made authorization URL in **Client Web** and the realm endpoints ready to copy in **Client Mobile**.
+
+1. Send the user to `ACCOUNT_URL/realms/{realm_uid}/oauth/authorize` with the `response_type=code`, `client_id` and `redirect_uri` parameters and, if you need them, `scope` and `state`.
+2. If the user does not have a session in the realm yet, Modyo sends them to the login screen and resumes the authorization when they finish. There is no consent screen: as soon as there is a session, Modyo redirects to your **Redirect URI** with the `code` parameter.
+3. Exchange the code at the token endpoint. The code lives ten minutes and works only once.
+4. Use the `access_token` from the response in the `Authorization` header of your calls.
+
+The code exchange looks like this:
+
+```shell
+curl -X POST "ACCOUNT_URL/realms/{realm_uid}/oauth/token" \
+  -d "grant_type=authorization_code" \
+  -d "code=THE_CODE" \
+  -d "client_id=THE_CLIENT_UID" \
+  -d "client_secret=THE_CLIENT_SECRET" \
+  -d "redirect_uri=YOUR_REDIRECT_URI"
+```
+
+And an already authenticated call, like this:
+
+```shell
+curl -X GET "ACCOUNT_URL/api/customers/realms/{realm_uid}/me" \
+  -H "Authorization: Bearer THE_ACCESS_TOKEN"
+```
+
+The realm recognizes `public` as the default scope and `admin` as the only optional scope. The `scope` you request must be among those values and, if the OAuth client defines **Scopes**, within its own as well; otherwise the authorization fails before delivering the code.
+
+Public clients, such as a mobile application or a front end without a backend, can use PKCE: if you send `code_challenge` and `code_challenge_method` in the authorization step, you must send the matching `code_verifier` when exchanging the code.
+
+:::warning Attention
+The OAuth client belongs to the realm where you created it and can only authorize users of that same realm. If your account has several realms, you need one client for each one.
+:::
+
+:::warning Attention
+The access token does not carry an expiration of its own, but that does not make it eternal: it is tied to the session of the user who authorized the flow. When that session expires because of the realm session expiration policy, when the user logs out, or when their sessions are revoked from the panel, the token stops working. While it keeps being used, the session renews itself before expiring, so a token in continuous use does not fall on its own.
+:::
+
+### Authentication errors
+
+Every Customers API endpoint shares these error bodies:
+
+| Code | Body | When it happens |
+|------|------|-----------------|
+| `401` | <code v-pre>{"error":{"user_session":"user not found"}}</code> | The request carries no usable credentials, the access token does not match a user of the realm, or the user is inactive. |
+| `401` | <code v-pre>{"error":{"grant_expired":"session expired"}}</code> | The credential identifies a user, but the session behind it expired or was revoked. |
+| `404` | <code v-pre>{}</code> | The `realm_uid` in the URL does not match any active realm of the account. |
+
+:::tip Tip
+Telling the two `401` apart saves you debugging time. `user_session` means that no usable credential ever arrived, so check the `Authorization` header or the cookie. `grant_expired` means that the credential was correct and what ran out was the session, so what you need is to authenticate the user again instead of retrying.
+:::
+
 ## Customer APIs
 
 Access the Customers API to manage realms and users through the URL `ACCOUNT_URL/api/customers/docs`. Examples of endpoints:

--- a/docs/en/platform/customers/settings.md
+++ b/docs/en/platform/customers/settings.md
@@ -306,6 +306,8 @@ Use an authentication client to send your integration access tokens to your reso
 - Confidential: There are two types of OAuth clients, confidential or public. Select the confidential option if your application can securely authenticate with the authentication server. Public clients are usually applications that run on mobile devices or browsers.
 - Scopes: If your OAuth2 authentication service uses multiple spaces or environments to separate users, and you want to use a specific one in this integration, define it in this field.
 
+Clicking the client name shows its **UID** and its **Secret**, plus two blocks ready to copy: **Client Web**, with the ready-made authorization URL, and **Client Mobile**, with the authorization, token, revocation and logout endpoints of the realm. With those values your application completes the realm `authorization_code` flow and gets the access token it uses to call the public Customers API on behalf of the user. The step by step is in [Authentication](/en/platform/customers/api.html#authentication).
+
 ### Amazon Rekognition
 
 The Amazon Rekognition integration, of the **Identity Verification** category, enables biometric verification in the realm's originations: identity document capture, face comparison, and liveness detection.

--- a/docs/es/platform/content/public-api-reference.md
+++ b/docs/es/platform/content/public-api-reference.md
@@ -685,28 +685,28 @@ El token de acceso al contenido es un token público en formato [JWT](https://to
 
 El token de acceso a contenido (content delivery token) contiene los siguientes atributos:
 
-- **iss**: URL base de la API de customers
-- **aud**: URL base de la API de contenido
-- **sub**: Nombre del space
-- **exp**: Tiempo de expiración del token
-- **access_type**: delivery,
-- **segmentos**: Array de segmentos
+- **iss**: URL con la que Modyo identifica al emisor del token. Es informativa y trae un segmento `/profile/` que no corresponde a ninguna ruta real, así que no la uses como la dirección a la que llamar.
+- **aud**: URL base de la API de contenido.
+- **sub**: UUID de la cuenta, no el nombre del space. La API de contenido compara este valor con el UUID de la cuenta que atiende la petición y sólo habilita el contenido privado cuando coinciden.
+- **exp**: Momento de expiración del token, calculado con el tiempo de vida configurado en la cuenta. Revisa [Token de Entrega de Contenido (JWT - JSON Web Token)](/es/platform/core/security.html#token-de-entrega-de-contenido-jwt-json-web-token) para cambiarlo.
+- **access_type**: Siempre `delivery`.
+- **segments**: Arreglo con los UUID de los segmentos a los que pertenece el usuario.
 
 Por ejemplo:
 
 ```javascript
 {
-  "iss": "http://my-account.modyo.me/api/customers",
-  "aud": "http://my-account.modyo.me/api/content",
-  "sub": "account_uuid",
+  "iss": "https://my_account.modyo.com/api/customers/realms/my_realm/profile/delivery_token",
+  "aud": "https://my_account.modyo.com/api/content",
+  "sub": "0f3d1b6c-5a2e-4c81-9b7f-2d84a6e05c19",
   "exp": 1516242622,
   "access_type": "delivery",
-  "segments": ["segment1", "segment2"]
+  "segments": ["7a41c9d2-3e58-4b60-8f13-95c2d7ae61b0", "c86b0f45-19da-4e27-b3a8-6f04d5217e9c"]
 }
 ```
 
 :::warning Atención
-Para poder acceder a la URL de obtención del token, debes asegurarte de tener una sesión iniciada con un usuario en la cuenta o al menos en un sitio de la misma, de lo contrario recibirás un error `404 - Not found`.
+Para pedir el token necesitas la credencial de un usuario con sesión iniciada en el reino. Sin ella el endpoint responde `401` con <code v-pre>{"error":{"user_session":"user not found"}}</code>, no `404`. El `404` es otra cosa: aparece cuando el `realm_uid` de la URL no corresponde a ningún reino activo de la cuenta. La referencia interactiva de `ACCOUNT_URL/api/customers/docs` sólo declara el `404` para este endpoint, así que no te guíes por ella en este punto. Las credenciales que acepta la API de Customers están en [Autenticación](/es/platform/customers/api.html#autenticacion).
 :::
 
 :::warning Atención

--- a/docs/es/platform/customers/api.md
+++ b/docs/es/platform/customers/api.md
@@ -7,6 +7,80 @@ search: true
 Modyo Customers contiene una variedad de APIs con las que podrás obtener la información de Reinos, las notificaciones y sus usuarios.
 
 
+## Autenticación
+
+Todos los endpoints bajo `ACCOUNT_URL/api/customers/realms/{realm_uid}/` responden en nombre de un usuario final del reino, así que cada llamada necesita una credencial de ese usuario. La única excepción es [Verificación de código OTP](#verificacion-de-codigo-otp).
+
+El reino acepta dos credenciales:
+
+- **Access token de OAuth2**, en la cabecera `Authorization: Bearer`. Tiene precedencia: cuando la petición trae un access token reconocido, la cookie de sesión no se evalúa.
+- **Cookie de sesión** del usuario en el reino. Se usa cuando la petición no trae un access token reconocido. Es la opción natural cuando tu aplicación corre dentro de un sitio de Modyo, porque el navegador la envía sola.
+
+Las dos resuelven al mismo usuario y dan acceso a los mismos endpoints. Elige el access token cuando tu aplicación vive fuera de los dominios de la cuenta, por ejemplo una aplicación móvil o un front en otro dominio.
+
+### Obtener un access token
+
+Cada reino expone su propio servidor OAuth2:
+
+| Endpoint | Para qué sirve |
+|----------|----------------|
+| `ACCOUNT_URL/realms/{realm_uid}/oauth/authorize` | Autoriza al usuario y entrega el código. |
+| `ACCOUNT_URL/realms/{realm_uid}/oauth/token` | Canjea el código por el access token. |
+| `ACCOUNT_URL/realms/{realm_uid}/oauth/revoke` | Invalida un token ya emitido. |
+
+El único flujo soportado es `authorization_code`. El reino no emite tokens con `client_credentials`, `password` ni `implicit`, y tampoco entrega refresh tokens.
+
+Para empezar necesitas un cliente OAuth del reino, creado como se describe en [Cliente OAuth](/es/platform/customers/settings.html#cliente-oauth). Al hacer click en el nombre del cliente, el panel muestra su **UID** y su **Secreto**, que son el `client_id` y el `client_secret` del flujo, junto con la URL de autorización ya armada en **Cliente web** y los endpoints del reino listos para copiar en **Cliente móvil**.
+
+1. Lleva al usuario a `ACCOUNT_URL/realms/{realm_uid}/oauth/authorize` con los parámetros `response_type=code`, `client_id`, `redirect_uri` y, si los necesitas, `scope` y `state`.
+2. Si el usuario todavía no tiene sesión en el reino, Modyo lo manda al inicio de sesión y retoma la autorización cuando termina. No hay pantalla de consentimiento: apenas hay sesión, Modyo redirige a tu **URI de redirección** con el parámetro `code`.
+3. Canjea el código en el endpoint de token. El código vive diez minutos y sirve una sola vez.
+4. Usa el `access_token` de la respuesta en la cabecera `Authorization` de tus llamadas.
+
+El canje del código se ve así:
+
+```shell
+curl -X POST "ACCOUNT_URL/realms/{realm_uid}/oauth/token" \
+  -d "grant_type=authorization_code" \
+  -d "code=EL_CODIGO" \
+  -d "client_id=EL_UID_DEL_CLIENTE" \
+  -d "client_secret=EL_SECRETO_DEL_CLIENTE" \
+  -d "redirect_uri=TU_URI_DE_REDIRECCION"
+```
+
+Y una llamada ya autenticada, así:
+
+```shell
+curl -X GET "ACCOUNT_URL/api/customers/realms/{realm_uid}/me" \
+  -H "Authorization: Bearer EL_ACCESS_TOKEN"
+```
+
+El reino reconoce `public` como scope por defecto y `admin` como único scope opcional. El `scope` que pidas tiene que estar entre esos valores y, si el cliente OAuth define **Scopes**, también dentro de los suyos; si no, la autorización falla antes de entregar el código.
+
+Los clientes públicos, como una aplicación móvil o un front sin backend, pueden usar PKCE: si envías `code_challenge` y `code_challenge_method` en el paso de autorización, tienes que enviar el `code_verifier` correspondiente al canjear el código.
+
+:::warning Atención
+El cliente OAuth pertenece al reino donde lo creaste y sólo puede autorizar usuarios de ese mismo reino. Si tu cuenta tiene varios reinos, necesitas un cliente por cada uno.
+:::
+
+:::warning Atención
+El access token no lleva vencimiento propio, pero eso no lo hace eterno: queda amarrado a la sesión del usuario que autorizó el flujo. Cuando esa sesión caduca por la política de expiración de sesiones del reino, cuando el usuario cierra sesión o cuando sus sesiones se revocan desde el panel, el token deja de servir. Mientras se sigue usando, la sesión se renueva sola antes de vencer, así que un token en uso continuo no se cae por sí solo.
+:::
+
+### Errores de autenticación
+
+Todos los endpoints de la API de Customers comparten estos cuerpos de error:
+
+| Código | Cuerpo | Cuándo ocurre |
+|--------|--------|---------------|
+| `401` | <code v-pre>{"error":{"user_session":"user not found"}}</code> | La petición no trae credenciales utilizables, el access token no corresponde a un usuario del reino o el usuario está inactivo. |
+| `401` | <code v-pre>{"error":{"grant_expired":"session expired"}}</code> | La credencial identifica a un usuario, pero la sesión que la respalda venció o fue revocada. |
+| `404` | <code v-pre>{}</code> | El `realm_uid` de la URL no corresponde a ningún reino activo de la cuenta. |
+
+:::tip Tip
+Separar los dos `401` te ahorra tiempo de depuración. `user_session` significa que nunca llegó una credencial utilizable, así que revisa la cabecera `Authorization` o la cookie. `grant_expired` significa que la credencial era correcta y lo que se acabó fue la sesión, así que corresponde volver a autenticar al usuario en vez de reintentar.
+:::
+
 ## API de Customers
 
 Accede a la API de Customers para gestionar reinos y usuarios a través de la URL `ACCOUNT_URL/api/customers/docs`. Ejemplos de endpoints:

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -306,6 +306,8 @@ Utiliza un cliente de autenticación para enviar los tokens de acceso de tu inte
 - Confidencial: Existen dos tipos de clientes OAuth, confidencial o públicos. Selecciona la opción confidencial si tu aplicación puede autenticarse de manera segura con el servidor de autenticación. Los clientes públicos suelen ser aplicaciones que se ejecutan en dispositivos móviles o navegadores.
 - Scopes: Si tu servicio de autenticación OAuth2 usa múltiples espacios o ambientes para separar a los usuarios y quieres usar uno en específico en esta integración, defínelo en este campo.
 
+Al hacer click en el nombre del cliente, el panel muestra su **UID** y su **Secreto**, y además dos bloques listos para copiar: **Cliente web**, con la URL de autorización ya armada, y **Cliente móvil**, con los endpoints de autorización, token, revocación y cierre de sesión del reino. Con esos valores tu aplicación completa el flujo `authorization_code` del reino y obtiene el access token con el que llama a la API pública de Customers en nombre del usuario. El paso a paso está en [Autenticación](/es/platform/customers/api.html#autenticacion).
+
 ### Amazon Rekognition
 
 La integración de Amazon Rekognition, de la categoría **Verificación de Identidad**, habilita la verificación biométrica en las originaciones del reino: captura de documento de identidad, comparación facial y detección de vida (liveness).


### PR DESCRIPTION
## Cambios propuestos

Documenta cómo obtener credenciales para la API pública de Customers y corrige tres afirmaciones erróneas sobre el content delivery token.

### `docs/es/platform/customers/api.md` y `docs/en/platform/customers/api.md`

Se agrega la sección **Autenticación** al principio de la página, que hasta ahora no decía cómo autenticar ni una sola de sus llamadas. Cubre:

- Las dos credenciales que acepta el reino, el access token de OAuth2 en la cabecera `Authorization: Bearer` y la cookie de sesión del usuario final, con su precedencia: la cookie sólo se evalúa cuando la petición no trae un access token reconocido.
- El servidor OAuth2 por reino, con sus endpoints `/realms/{realm_uid}/oauth/authorize`, `/oauth/token` y `/oauth/revoke`, y el flujo `authorization_code` como único soportado, sin refresh tokens.
- El paso a paso para obtener el token partiendo del cliente OAuth del reino, incluyendo dónde encontrar el **UID** y el **Secreto** y los ejemplos de `curl` para canjear el código y para llamar autenticado.
- Los scopes que reconoce el reino, `public` por defecto y `admin` como único opcional, y el uso opcional de PKCE para clientes públicos.
- Una advertencia sobre la vida del access token: no tiene vencimiento propio, pero queda amarrado a la sesión del usuario que autorizó el flujo, así que deja de servir cuando esa sesión caduca, el usuario cierra sesión o sus sesiones se revocan desde el panel.
- Una subsección **Errores de autenticación** con los dos cuerpos de `401` que devuelve la API, `user_session` cuando nunca llegó una credencial utilizable y `grant_expired` cuando la sesión detrás de la credencial se acabó, más el `404` por `realm_uid`.

### `docs/es/platform/customers/settings.md` y `docs/en/platform/customers/settings.md`

La sección **Cliente OAuth** describía los seis campos del formulario sin decir para qué sirve el cliente resultante. Se agrega un párrafo que explica qué muestra el panel al abrir el cliente, **UID**, **Secreto**, **Cliente web** y **Cliente móvil**, y enlaza al paso a paso de la nueva sección de autenticación.

### `docs/es/platform/content/public-api-reference.md` y `docs/en/platform/content/public-api-reference.md`

Se corrige la sección **Contenido privado**:

- **sub** dejaba entender que era el nombre del space. Es el UUID de la cuenta, y es el único valor que la API de contenido revisa para habilitar el contenido privado. El propio ejemplo de la página ya se contradecía con el bullet.
- **iss** se describía como la URL base de la API de customers. Es la URL completa con la que Modyo identifica al emisor, incluye un segmento `/profile/` que no corresponde a ninguna ruta real y no debe usarse como dirección a la que llamar.
- El callout decía que sin sesión recibes un `404 - Not found`. El endpoint responde `401`; el `404` sólo aparece cuando el `realm_uid` no corresponde a ningún reino activo de la cuenta. El callout nuevo además advierte que la referencia interactiva de la API de Customers sólo declara el `404` para este endpoint.
- Se precisa de qué depende **exp**, con enlace a la configuración de la cuenta que lo controla, y se corrige el nombre y el contenido del claim **segments**, que son los UUID de los segmentos del usuario.
- El ejemplo JSON se actualiza para reflejar los valores reales del token.

### Gaps que cierra

- API-PUBLICA-13
- API-PUBLICA-14

## Para el revisor

**Discrepancia que queda viva en el producto**: el Swagger de `ACCOUNT_URL/api/customers/docs` declara solo `404` para `GET /realms/{realm_uid}/delivery_token` (`app/controllers/docs/api/customers/user_info.rb:144-146`) y no declara el `401`. No puedo tocar el repo de la plataforma, así que la documentación avisa explícitamente que la referencia interactiva se queda corta en ese punto. Conviene abrir la corrección del Swagger como tarea aparte en modyo/modyo.

**Cosas que documenté más allá de la letra de las fichas**, todas verificadas en `origin/master`:
- `oauth/revoke`: no está en la ficha, pero el propio panel lo publica en el bloque **Cliente móvil** (`oauth_clients/index.html.erb:28`), así que dejarlo fuera habría sido incoherente con lo que el cliente ve.
- PKCE: no está en la ficha. Lo incluí porque las columnas `code_challenge`/`code_challenge_method` existen en `oauth_access_grants` (`db/schema.rb:1002-1003`), doorkeeper es 5.9.3 y la URL que el panel arma en **Cliente web** ya viaja con `code_challenge_method=plain` (`OauthClients.js:17-25`). Está redactado como opcional, sin prometer `force_pkce`.
- El claim `segments` de la ficha 14: además de los tres errores listados, corregí el nombre de la clave (la doc decía `segmentos`, el JWT trae `segments`) y precisé que son UUID ordenados (`user.rb:389`).
- `docs/*/platform/customers/settings.md` no está en la lista de "Páginas" de la tanda, pero la ficha API-PUBLICA-13 pide expresamente enlazar desde la sección 'Cliente OAuth'. Son dos párrafos, uno por idioma.

**Matices de redacción que tomé a propósito**:
- Escribí "cuando la petición trae un access token **reconocido**" en vez de "un access token": si mandas una cabecera `Authorization` con un token que no existe en la base, `doorkeeper_token` queda en nil y `user_credentials` (`session_discovery.rb:145-150`) sí cae a la cookie. Decir "precedencia estricta" habría sido falso.
- "ningún reino activo de la cuenta" en vez de "reino en estado producción": `Realm::STATUS_PRODUCTION` y `STATUS_REMOVING` son los únicos estados válidos (`realm.rb:89-90,145`) y "producción" no es un estado que el cliente vea en el panel.
- No enlacé la política de expiración de sesiones del reino porque no está documentada en ninguna página de modyo-docs (`realm.expire_after`, `session_manager.rb:152`). Queda como gap para otra tanda.
- La renovación automática de la sesión se describe sin cifras ni nombres de variables, porque el intervalo viene de configuración de infraestructura.

**Directiva de producto**: la tanda no me llevó a paginas de soporte ni al modulo Soporte. Existe una ruta `/admin/customers/:realm_uid/support` en `routes.rb:369` y el listado de rutas de la API de Customers no incluye endpoints de tickets, así que no hubo nada que omitir; ninguna de las seis ediciones los menciona.

**Riesgo bajo de conflicto**: los seis `old_string` están en zonas que ninguna otra tanda de este bloque toca, salvo que otra tanda del mismo lote inserte contenido inmediatamente antes de `## API de Customers` en `customers/api.md` o antes de `### Amazon Rekognition` en `customers/settings.md`.

Closes #1023

🤖 Generated with [Claude Code](https://claude.com/claude-code)
