### PR TITLE
Documentar la bandeja Mis tareas del panel de administración

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -100,6 +100,7 @@ module.exports = {
                           collapsable: true,
                           children: [
                               ["/en/platform/core/", "Introduction"],
+                              "/en/platform/core/my-tasks",
                               "/en/platform/core/configuration",
                               {
                                   title: "Integrations",
@@ -396,6 +397,7 @@ module.exports = {
                         collapsable: true,
                         children: [
                             ["/es/platform/core/", "Introducción"],
+                            "/es/platform/core/my-tasks",
                             "/es/platform/core/configuration",
                             {
                                 title: "Integraciones",

--- a/docs/en/platform/core/my-tasks.md
+++ b/docs/en/platform/core/my-tasks.md
@@ -1,0 +1,67 @@
+---
+search: true
+---
+
+# My tasks
+
+**My tasks** is each administrator's personal work inbox. It is a top-level item in the Modyo Platform side menu that gathers on a single screen everything waiting for your action, so you don't have to go space by space and realm by realm looking for your pending work.
+
+The inbox is personal: each administrator only sees the tasks assigned to them or to one of the groups they belong to.
+
+## Task types
+
+The inbox brings together two different sources of work:
+
+- **Workflow review**: Content and Channels elements waiting for your approval within [Team Review](/en/platform/core/#team-review), such as entries, pages, navigation, templates, and widgets.
+- **Validation review**: validation and pending review tasks from the [originations](/en/platform/customers/origination.html) assigned to you or to a group you belong to.
+
+## About the Interface
+
+To open the inbox, click the **My tasks** icon in the Modyo Platform side menu.
+
+The list has these filters:
+
+- **Task type**: shows only **Workflow review** tasks or only **Validation review** tasks.
+- **Status**: **Pending**, which is the default value, **Completed**, or **All**.
+- **Search**: filters by the task title and by the context name.
+
+Each row in the list shows:
+
+- **Status**: **Pending** or **Completed**.
+- **Title**: the name of the element under review or, for validations, the name of the origination and the name of the task.
+- **Type**: **Workflow review** or **Validation review**.
+- **Context**: where the element lives, with its type and its name, for example `Space: my_space`, `App: my_site`, or `Origination: my_origination`.
+- **Details**: for workflow reviews, the author who sent the element to review; for validation reviews, the number of items left to validate.
+- **Assigned at**: when the task arrived in your inbox. You can sort the list by this column.
+
+Click the **Title** of a row to go straight to the point of work: the entry or page under review, or the specific task inside the origination submission, with no intermediate steps.
+
+:::tip Tip
+Filters only appear if you have ever received a task. When you have nothing pending, the screen shows the message **All your elements and assignments are reviewed.**
+:::
+
+## How tasks reach your inbox
+
+You don't have to do anything to feed the inbox: tasks are created on their own.
+
+- When the flow of an origination submission reaches an agent task and its assignee is resolved, a **Validation review** task is created for each administrator that must be notified. If the assignee is a group, the task reaches all of its members. The notification email is sent in parallel, so the inbox and the email always show the same thing.
+- When a Content or Channels element enters review and you are among its reviewers, a **Workflow review** task is created. If you are added as a reviewer of an element that was already under review, the task also appears; if you are removed from the reviewer list, it disappears from your inbox.
+
+:::tip Tip
+**Pending review** tasks that have the **Disable manual completion** option enabled do not create an entry in the inbox, because they are not completed from the admin. Check [Tasks answered by agents](/en/platform/customers/origination.html#tasks-answered-by-agents).
+:::
+
+## How a task is closed
+
+Tasks are not marked by hand: they move to **Completed** when the work they represent finishes.
+
+- A **Validation review** task is completed when the response to the associated task is completed or when you approve or reject the validation.
+- A **Workflow review** task is completed when the element is approved, when it is archived, or when it goes back to the editable state after a rejection.
+
+If the work is reopened, for example when a rejected validation is assigned again, the task is reactivated and appears as **Pending** again with its new assignment date.
+
+To review what you already closed, change the **Status** filter to **Completed** or to **All**.
+
+## Who sees the inbox
+
+The **My tasks** item only appears in the side menu if you can receive one of the two task types: if you have permissions to edit or review elements in some space or site, or to access the origination submissions of some realm, with **List Assigned Submissions** or **List All Submissions**. Check [Roles](/en/platform/core/roles.html#roles) for the detail of the grouped permissions.

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -109,7 +109,7 @@ The task is refreshed every 5 seconds so that the end user knows if the task has
 
 When configuring the task, you can define an **Assignee**: an administrator or a group of administrators responsible for the validations. When selecting a group, you can assign the whole group or a specific user within it. If you do not define an assignee, validations are assigned by default to the submission assignee.
 
-Assigned administrators receive an email when a validation is pending and can also review it from the **My tasks** view in the main menu, filtering by the **Validation review** task type. The user receives an internal notification when their task is approved or rejected.
+Assigned administrators receive an email when a validation is pending and can also review it from the [**My tasks**](/en/platform/core/my-tasks.html) view in the main menu, filtering by the **Validation review** task type. The user receives an internal notification when their task is approved or rejected.
 
 In a specific submission, you can reassign the validation from the **Validations** tab, once the user has completed the tasks to validate.
 
@@ -460,7 +460,7 @@ Each task in the flow has the **Assigned to** option, which defines who answers 
 - **User**: The task is answered by the end user on the origination page.
 - **Agent**: The task is answered by an administrator from the admin. **Validation** and **Pending review** tasks are always agent tasks; **Input** and **Code snippet** tasks can be configured in either mode.
 
-When the flow reaches an agent task, the assigned administrators receive an email with a direct link to the task and also see it in the **My tasks** view. The effective assignee is resolved in this order: the assignee of the task response, the assignee configured on the task and, failing that, the assignee of the submission; you can reassign a specific task from the submission view, which notifies the new assignee.
+When the flow reaches an agent task, the assigned administrators receive an email with a direct link to the task and also see it in the [**My tasks**](/en/platform/core/my-tasks.html) view. The effective assignee is resolved in this order: the assignee of the task response, the assignee configured on the task and, failing that, the assignee of the submission; you can reassign a specific task from the submission view, which notifies the new assignee.
 
 From the submission view, the agent opens the task and answers the form with the same experience as the site: live conditional logic, file uploads, repeatable groups, and code snippets. While the task awaits the agent's action, the user sees on the origination page the text configured in **Waiting message shown to the user**.
 

--- a/docs/es/platform/core/my-tasks.md
+++ b/docs/es/platform/core/my-tasks.md
@@ -1,0 +1,67 @@
+---
+search: true
+---
+
+# Mis tareas
+
+**Mis tareas** es la bandeja de trabajo personal de cada administrador. Es un ítem de primer nivel del menú lateral de Modyo Platform que reúne en una sola pantalla todo lo que espera tu acción, para que no tengas que recorrer espacio por espacio y reino por reino buscando tus pendientes.
+
+La bandeja es personal: cada administrador ve únicamente las tareas asignadas a él o a alguno de los grupos a los que pertenece.
+
+## Tipos de tarea
+
+La bandeja reúne dos orígenes de trabajo distintos:
+
+- **Revisión del flujo de trabajo**: elementos de Content y Channels que esperan tu aprobación dentro de [Revisión en Equipo](/es/platform/core/#revision-en-equipo), como entradas, páginas, navegación, plantillas y widgets.
+- **Revisión de validación**: tareas de validación y de revisión pendiente de las [originaciones](/es/platform/customers/origination.html) asignadas a ti o a un grupo al que perteneces.
+
+## Sobre la Interfaz
+
+Para abrir la bandeja, haz clic en el ícono **Mis tareas** del menú lateral de Modyo Platform.
+
+El listado tiene estos filtros:
+
+- **Tipo de tarea**: muestra solo las tareas de **Revisión del flujo de trabajo** o solo las de **Revisión de validación**.
+- **Estado**: **Pendiente**, que es el valor por defecto, **Completada** o **Todos**.
+- **Buscar**: filtra por el título de la tarea y por el nombre del contexto.
+
+Cada fila del listado muestra:
+
+- **Estado**: **Pendiente** o **Completada**.
+- **Título**: el nombre del elemento en revisión o, en las validaciones, el nombre de la originación y el de la tarea.
+- **Tipo**: **Revisión del flujo de trabajo** o **Revisión de validación**.
+- **Contexto**: dónde vive el elemento, con su tipo y su nombre, por ejemplo `Espacio: my_space`, `Aplicación: my_site` u `Originación: my_origination`.
+- **Detalles**: en las revisiones del flujo de trabajo, el autor que envió el elemento a revisión; en las revisiones de validación, la cantidad de ítems que quedan por validar.
+- **Asignado en**: cuándo llegó la tarea a tu bandeja. Puedes ordenar el listado por esta columna.
+
+Haz clic en el **Título** de una fila para ir directo al punto de trabajo: la entrada o la página en revisión, o la tarea específica dentro de la respuesta de originación, sin pasos intermedios.
+
+:::tip Tip
+Los filtros aparecen solo si alguna vez recibiste una tarea. Cuando no tienes nada pendiente, la pantalla muestra el mensaje **Todos tus elementos y asignaciones están revisados.**
+:::
+
+## Cómo llegan las tareas a tu bandeja
+
+No tienes que hacer nada para alimentar la bandeja: las tareas se crean solas.
+
+- Cuando el flujo de una respuesta de originación llega a una tarea de agente y se resuelve su asignado, se crea una tarea de **Revisión de validación** para cada administrador al que corresponde notificar. Si el asignado es un grupo, la tarea llega a todos sus integrantes. En paralelo se envía el correo de aviso, así que la bandeja y el correo muestran siempre lo mismo.
+- Cuando un elemento de Content o Channels entra en revisión y figuras entre sus revisores, se crea una tarea de **Revisión del flujo de trabajo**. Si te agregan como revisor de un elemento que ya estaba en revisión, la tarea también aparece; si te quitan de la lista de revisores, desaparece de tu bandeja.
+
+:::tip Tip
+Las tareas de **Revisión pendiente** que tienen activada la opción **Desactivar el completado manual** no generan una entrada en la bandeja, porque no se completan desde el panel. Revisa [Tareas respondidas por agentes](/es/platform/customers/origination.html#tareas-respondidas-por-agentes).
+:::
+
+## Cómo se cierra una tarea
+
+Las tareas no se marcan a mano: pasan a **Completada** cuando termina el trabajo que representan.
+
+- Una tarea de **Revisión de validación** se completa cuando se completa la respuesta a la tarea asociada o cuando apruebas o rechazas la validación.
+- Una tarea de **Revisión del flujo de trabajo** se completa cuando el elemento queda aprobado, cuando se archiva o cuando vuelve al estado editable tras un rechazo.
+
+Si el trabajo se reabre, por ejemplo cuando una validación rechazada se vuelve a asignar, la tarea se reactiva y aparece otra vez como **Pendiente** con su nueva fecha de asignación.
+
+Para revisar lo que ya cerraste, cambia el filtro **Estado** a **Completada** o a **Todos**.
+
+## Quién ve la bandeja
+
+El ítem **Mis tareas** aparece en el menú lateral solo si puedes recibir alguno de los dos tipos de tarea: si tienes permisos para editar o revisar elementos en algún espacio o sitio, o para acceder a las respuestas de originación de algún reino, con **Listar Respuestas Asignadas** o **Listar Todas las Respuestas**. Revisa [Roles](/es/platform/core/roles.html#roles) para el detalle de los permisos agrupados.

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -109,7 +109,7 @@ Se hace un refresco de la tarea cada 5 segundos para que el usuario final sepa s
 
 Al configurar la tarea, puedes definir un **Asignado**: un administrador o un grupo de administradores responsable de las validaciones. Al seleccionar un grupo, puedes asignar a todo el grupo o a un usuario específico dentro de él. Si no defines un asignado, las validaciones se asignan de forma predeterminada al asignado de la respuesta.
 
-Los administradores asignados reciben un correo cuando una validación queda pendiente y también pueden revisarla desde la vista **Mis tareas** del menú principal, filtrando por el tipo de tarea **Revisión de validación**. El usuario recibe una notificación interna cuando su tarea es aprobada o rechazada.
+Los administradores asignados reciben un correo cuando una validación queda pendiente y también pueden revisarla desde la vista [**Mis tareas**](/es/platform/core/my-tasks.html) del menú principal, filtrando por el tipo de tarea **Revisión de validación**. El usuario recibe una notificación interna cuando su tarea es aprobada o rechazada.
 
 En una respuesta específica, puedes reasignar la validación desde la pestaña **Validaciones**, una vez que el usuario haya completado las tareas a validar.
 
@@ -461,7 +461,7 @@ Cada tarea del flujo tiene la opción **Asignado a**, que define quién la respo
 - **Usuario**: La tarea la responde el usuario final en la página de originación.
 - **Agente**: La tarea la responde un administrador desde el admin. Las tareas de **Validación** y **Revisión pendiente** son siempre de agente; las tareas **Input** y **Snippet de código** pueden configurarse en cualquiera de los dos modos.
 
-Cuando el flujo llega a una tarea de agente, los administradores asignados reciben un correo con el enlace directo a la tarea y también la ven en la vista **Mis tareas**. El asignado efectivo se resuelve en este orden: el asignado de la respuesta a la tarea, el asignado configurado en la tarea y, en su defecto, el asignado general de la respuesta; puedes reasignar una tarea específica desde la vista de la respuesta, lo que notifica al nuevo asignado.
+Cuando el flujo llega a una tarea de agente, los administradores asignados reciben un correo con el enlace directo a la tarea y también la ven en la vista [**Mis tareas**](/es/platform/core/my-tasks.html). El asignado efectivo se resuelve en este orden: el asignado de la respuesta a la tarea, el asignado configurado en la tarea y, en su defecto, el asignado general de la respuesta; puedes reasignar una tarea específica desde la vista de la respuesta, lo que notifica al nuevo asignado.
 
 Desde la vista de la respuesta, el agente abre la tarea y responde el formulario con la misma experiencia del sitio: lógica condicional en vivo, carga de archivos, grupos repetibles y snippets de código. Mientras la tarea espera la acción del agente, el usuario ve en la página de originación el texto configurado en **Mensaje de espera que ve el usuario**.
 


### PR DESCRIPTION
## Cambios propuestos

Documenta **Mis tareas**, el ítem de primer nivel del menú lateral del panel que reúne todo lo que espera acción del administrador conectado. Es la pantalla por la que entra a trabajar un revisor o un agente de originación cada día y hoy no aparece en ninguna página de la documentación.

### `docs/es/platform/core/my-tasks.md` y `docs/en/platform/core/my-tasks.md` (páginas nuevas)

Ficha propia en Plataforma, junto a Revisión en Equipo, porque la pantalla es transversal: la mitad de su contenido viene de Content y Channels y la otra mitad de Customers. Documenta:

- Qué es la bandeja y que es personal: cada administrador ve solo lo asignado a él o a sus grupos.
- Los dos tipos de tarea: **Revisión del flujo de trabajo** (elementos de Content y Channels que esperan su aprobación dentro de Revisión en Equipo) y **Revisión de validación** (tareas de validación y de revisión pendiente de originaciones).
- La interfaz: los filtros **Tipo de tarea**, **Estado** (**Pendiente** por defecto, **Completada** o **Todos**) y **Buscar**, y las columnas **Estado**, **Título**, **Tipo**, **Contexto**, **Detalles** y **Asignado en**, con el detalle de qué muestra cada una según el tipo de tarea y el mensaje de la pantalla vacía.
- Que el **Título** de cada fila enlaza directo al punto de trabajo: la entrada o la página en revisión, o la tarea específica dentro de la respuesta de originación.
- Cómo se alimenta sola la bandeja al asignarse una validación o al entrar un elemento en revisión, incluida la excepción de las tareas de **Revisión pendiente** con **Desactivar el completado manual**.
- Cómo se cierra una tarea sin intervención manual: al completarse la respuesta a la tarea asociada, al aprobar o rechazar la validación, o al quedar el elemento aprobado, archivado o de vuelta en editable tras un rechazo; y que se reactiva como **Pendiente** si el trabajo se reabre.
- Qué permisos hacen visible el ítem en el menú.

### `docs/es/platform/customers/origination.md` y `docs/en/platform/customers/origination.md`

Las dos menciones existentes a **Mis tareas** (en la sección de Validación y en Tareas respondidas por agentes) ahora enlazan a la ficha nueva, para que el agente encuentre la explicación completa de la bandeja desde donde ya se le nombra.

### `docs/.vuepress/config.js`

Registra la página nueva en el grupo Plataforma del sidebar en los dos locales, justo después de Introducción, para que no quede huérfana.

Cierra los gaps **ORIGINATION-28** y **API-ADMIN-X3** (los filtros de la pantalla; la API interna `/api/admin/admin_user_tasks` que la alimenta no se documenta por ser interna del panel).

## Para el revisor

- **Contador por tipo**: la ficha pedía documentar que "el contador de pendientes se muestra por tipo". El endpoint existe en master (`AdminUserTasksController#count`, con `total`, `workflow_review` y `validation_review`), pero no está consumido en ninguna parte del front (`git grep admin_user_tasks -- app/javascript` solo devuelve la URL del listado). Al no ser observable para el cliente, no lo documenté; en su lugar documenté lo que sí se ve: el filtro **Estado** con **Pendiente** por defecto y la columna **Detalles** con los ítems que quedan por validar.\n- **Captura existente pero desactualizada**: hay una imagen huérfana en `/Users/max/Dev/modyo-docs/docs/.vuepress/public/assets/img/platform/core/my-tasks.png` que no se usa en ninguna página. Corresponde a una versión anterior de la pantalla (filtros Assigned to / Type / Author / Context, columna Last Update) y no coincide con la UI de master (Tipo de tarea / Estado / Buscar, columnas Detalles y Asignado en). No la incluí para no documentar algo que no existe; conviene regenerarla en una tanda de assets.\n- **Sin divergencia 10.2-stable → master**: el diff entre `releases/10.2-stable` y `origin/master` está vacío en los ocho archivos verificados, así que no hubo que reescribir nada respecto de lo que decía la ficha.\n- **Originaciones fuera del tipo workflow_review**: aunque `Origination::Origination` incluye el plugin de workflow, `Workflow#team_review?` devuelve `false` cuando la aplicación es un `Realm`, por lo que nunca entra en estado `reviewing` y no genera tareas. Redacté **Revisión del flujo de trabajo** acotado a Content y Channels.\n- **Permisos**: el ítem del menú se muestra con una condición compuesta de permisos finos (`workflows_approve`, `originations_submissions`, `entries_edit`, `layout_pages_edit`, `menus_edit`, `templates_edit`, `widget_definitions_edit`). Solo cité con label exacto los dos permisos agrupados que verifiqué en `grouped_permissions.yml` y en los locales (**Listar Respuestas Asignadas** / **Listar Todas las Respuestas**); el resto lo describí de forma funcional para no inventar labels.\n- **Fuera de esta tanda**: `origination.md` (línea 478 en es, 478 en en) cita los permisos como **Ver Todas las Respuestas** / **Ver Respuestas Asignadas**, pero en master los labels agrupados son **Listar Todas las Respuestas** / **Listar Respuestas Asignadas** (renombrados por `db/migrate/20260803222944_rename_submissions_grouped_permissions_and_add_show_tiers.rb`). No lo toqué porque no lo pide esta tanda, pero conviene corregirlo.\n- **Directiva de producto**: esta tanda no roza páginas de soporte ni el módulo Soporte (los tipos de tarea son solo `workflow_review` y `validation_review`), así que no hubo nada que omitir por ese motivo.

Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
