### PR TITLE
Documentar el campo Texto de múltiples líneas, los Grupos repetibles y las opciones de campo que faltan en Tipos de contenido

### DIFF
--- a/docs/en/platform/content/types.md
+++ b/docs/en/platform/content/types.md
@@ -85,6 +85,20 @@ The scope of **Unique** is the whole type: the comparison goes through every ent
 **Unique** has no effect on a field that lives inside a **Group**. The checkbox is still displayed when you configure the field, but the validation isn't evaluated and repeated values are saved without an error. If you need to guarantee uniqueness, keep the field outside the group.
 :::
 
+### Multiline text
+
+This field allows you to enter plain text on several lines, with no formatting options. Unlike **Single-line text**, which accepts up to 255 characters, here you can store long texts. It has the following restrictions:
+
+- **Minimum length**: Allows you to require a minimum number of characters for the entered text.
+- **Maximum length**: Allows you to limit the maximum number of characters for the entered text.
+- **Validation by regular expression**: Allows you to add a regular expression to validate that the entered text, when creating or modifying an entry, complies with a certain format.
+
+This field doesn't offer the **Unique** validation: uniqueness is only available in [Single-line text](#single-line-text).
+
+:::warning Attention
+As of version 10.2, the value of this field is delivered HTML-escaped when you print it with Liquid: any tags you wrote are shown as literal text instead of being interpreted as markup. If you need to publish HTML from an entry, use a [Rich text](#rich-text) field. Review the templates that were using this field to inject HTML.
+:::
+
 ### Rich text
 
 This field results in a multi-line WYSIWYG text editor that also allows you to modify the HTML code of the text. This field has the following restrictions:
@@ -116,9 +130,15 @@ If you load this field through the API, send the exact labels of the allowed val
 
 In choice fields (Dropdown, Radio, Checkbox, and Multiple choice), the options are managed in the field's **Allowed values** section: use **Add value** and **Delete value** to manage them, and the selector to mark the **Default value**. Before saving, the interface marks the values as **New** or **Edited** so you can review your changes.
 
+The **Default value** is applied automatically when you create a new entry, and only when the field doesn't already carry a value: it isn't applied when you edit an existing entry and it never replaces what you loaded.
+
+:::warning Attention
+That automatic assignment only reaches the choice fields that are at the first level of the type. If you mark a **Default value** on a choice field that lives inside a **Group**, the value isn't applied to new entries and the interface doesn't warn you. Keep the field outside the group if you need that behavior.
+:::
+
 Each value is an individual element of the content type:
 
-- When **renaming a value**, the entries that had it selected keep their selection with the new name, across all their versions.
+- When **renaming a value**, the entries that had it selected keep their selection with the new name, across all their versions. The new text is propagated to the entries in the background, so the public API may take a moment to return it.
 - When **deleting a value in use**, it is archived: it is no longer offered for new selections, but the entries that already had it selected continue to display it, with no loss of historical data.
 
 :::tip Tip
@@ -156,7 +176,16 @@ Use this field to add a date picker. Limit the selectable dates by applying the 
 
 ### Location
 
-Use this field to select a geographical address, based on the fields in Google Maps. If you do not have a Google API key, you can manually enter the location's name, latitude, longitude, and political divisions. These administrative divisions are not standard and vary by country. In the case of Chile, the divisions are: Region, Province, Commune, and City.
+Use this field to select one or more geographical addresses, based on the fields in Google Maps. A single Location field stores an ordered list of locations: add as many as you need and use **Delete location** to remove one from the list. The order you leave them in is the order delivered by the API and the SDKs.
+
+If you do not have a Google API key, you can manually enter the **Location Street**, the **Latitude**, the **Longitude**, and the political divisions of the location. **Latitude** accepts values between -90 and 90, and **Longitude** between -180 and 180; outside that range the entry isn't saved. These administrative divisions are not standard and vary by country. In the case of Chile, the divisions are: Region, Province, Commune, and City.
+
+In the public API and in the SDKs, the value of the field is an array with one object per location, and each object always carries the same eight keys:
+
+- `location_street`: the address written in the **Location Street** field.
+- `location`: object with the `lat` and `lon` coordinates.
+- `country`: the country of the location.
+- `administrative_area_level_1` through `administrative_area_level_5`: the five levels of administrative division, from largest to smallest. The levels the country doesn't use are delivered with no data.
 
 :::warning Attention
 To ensure that location maps work properly with the Google API key configured in your account, the key must have permissions to access:
@@ -168,11 +197,17 @@ To ensure that location maps work properly with the Google API key configured in
 
 ### File
 
-This field allows you to attach a single file to the entry, using the file manager.
+This field allows you to attach a single file to the entry, using the file manager. It has the following restriction:
+
+- **Allowed Types**: Limits the type of file you can attach. You can pick one or more values among **Images**, **Video**, **Audio**, and **Documents**; if you pick none, any file is accepted. If the attached file is of another type, the entry isn't saved and the field shows "Does not match with allowed types", followed by the types you configured.
+
+The check runs against the type the file manager gave the file when you uploaded it, not against its extension.
 
 ### Asset list
 
-This field allows you to attach multiple files to the entry, using the file manager.
+This field allows you to attach multiple files to the entry, using the file manager. It has the following restriction:
+
+- **Allowed Types**: Limits the type of the files you can attach, with the same options and the same behavior as in [File](#file). A single attached file of another type is enough to prevent the entry from being saved.
 
 ### Content (link to one)
 
@@ -193,6 +228,39 @@ Use the Group field to house another field within it. You can assign a name to t
 Once you have more than one type of field within a group, you can drag and order them as needed.
 
 There is no limit to the number of fields you can include within a group.
+
+In an entry, the group behaves as a repeatable list: the same set of child fields can be filled in several times. To work with the repetitions:
+
+1. Open the entry and find the group.
+2. Click **Add new item** to add a repetition with the same fields.
+3. Fill in the fields of that repetition.
+4. Drag the repetitions to change their order.
+5. To delete a repetition, click its delete icon and confirm.
+
+The order you leave the repetitions in is preserved and is the order delivered by the API and the SDKs.
+
+That is why the value of a Group field is always an array of objects, even when it has a single repetition: each object carries the child fields under the name you gave them.
+
+```json
+{
+  "fields": {
+    "my_group": {
+      "fields": [
+        { "my_field": "First item" },
+        { "my_field": "Second item" }
+      ]
+    }
+  }
+}
+```
+
+From Liquid, loop over the repetitions and read the child fields inside the loop. Each repetition is exposed as a [repeatable_group_field](/en/platform/channels/liquid-markup/objects.html#field) object:
+
+```liquid
+{% for item in entry["my_group"] %}
+  {{ item["my_field"] }}
+{% endfor %}
+```
 
 You can validate the contents of the fields as follows:
 

--- a/docs/es/platform/content/types.md
+++ b/docs/es/platform/content/types.md
@@ -85,6 +85,20 @@ El alcance de **Único** es el tipo completo: la comparación recorre todas las 
 **Único** no tiene efecto sobre un campo que está dentro de un **Grupo**. La casilla se sigue mostrando al configurar el campo, pero la validación no se evalúa y los valores repetidos se guardan sin error. Si necesitas garantizar unicidad, deja el campo fuera del grupo.
 :::
 
+### Texto de múltiples líneas
+
+Este campo te permite ingresar texto plano en varias líneas, sin opciones de formato. A diferencia de **Texto de una línea**, que admite hasta 255 caracteres, aquí puedes guardar textos largos. Cuenta con las siguientes restricciones:
+
+- **Largo mínimo**: Permite exigir un mínimo de caracteres para el texto ingresado.
+- **Largo máximo**: Permite limitar la cantidad máxima de caracteres para el texto ingresado.
+- **Validación por expresión regular**: Te permite añadir una expresión regular para validar que el texto ingresado, al crear o modificar una entrada, cumpla con un formato determinado.
+
+Este campo no ofrece la validación **Único**: la unicidad solo está disponible en [Texto de una línea](#texto-de-una-linea).
+
+:::warning Atención
+Desde la versión 10.2, el valor de este campo se entrega escapado como HTML al imprimirlo con Liquid: las etiquetas que hayas escrito aparecen como texto literal en lugar de interpretarse como marcado. Si necesitas publicar HTML desde una entrada, usa un campo [Texto enriquecido](#texto-enriquecido). Revisa las plantillas que venían usando este campo para inyectar HTML.
+:::
+
 ### Texto enriquecido
 
 Este campo se traduce en un editor WYSIWYG de texto de múltiples líneas que también te permite modificar el código HTML del texto. Este campo cuenta con las siguientes restricciones:
@@ -116,9 +130,15 @@ Si cargas este campo por la API, envía las etiquetas exactas de los valores per
 
 En los campos de elección (Dropdown, Radio, Checkbox y Opciones múltiples), las opciones se gestionan en la sección **Valores permitidos** del campo: usa **Agregar valor** y **Eliminar valor** para administrarlas, y el selector para marcar el **Valor predeterminado**. Antes de guardar, la interfaz marca las opciones como **Nueva** o **Modificada** para que revises tus cambios.
 
+El **Valor predeterminado** se aplica automáticamente al crear una entrada nueva, y solo cuando el campo aún no trae un valor: no se aplica al editar una entrada que ya existe ni reemplaza lo que hayas cargado.
+
+:::warning Atención
+Esa aplicación automática solo alcanza a los campos de elección que están en el primer nivel del tipo. Si marcas un **Valor predeterminado** en un campo de elección que está dentro de un **Grupo**, el valor no se aplica a las entradas nuevas y la interfaz no te lo advierte. Deja el campo fuera del grupo si necesitas ese comportamiento.
+:::
+
 Cada valor es un elemento individual del tipo de contenido:
 
-- Al **renombrar un valor**, las entradas que lo tenían seleccionado conservan su selección con el nuevo nombre, en todas sus versiones.
+- Al **renombrar un valor**, las entradas que lo tenían seleccionado conservan su selección con el nuevo nombre, en todas sus versiones. El texto nuevo se propaga a las entradas en segundo plano, así que la API pública puede tardar un momento en devolverlo.
 - Al **eliminar un valor en uso**, este se archiva: deja de ofrecerse para nuevas selecciones, pero las entradas que ya lo tenían seleccionado lo siguen mostrando, sin pérdida de datos históricos.
 
 :::tip Tip
@@ -156,7 +176,16 @@ Utiliza este campo para agregar un selector de fechas. Limita las fechas selecci
 
 ### Ubicación
 
-Utiliza este campo para seleccionar una dirección geográfica, según los campos de Google Maps. En caso de que no dispongas de una clave de API de Google, puedes ingresar manualmente el nombre, la latitud, la longitud y las divisiones políticas de la ubicación. Estas divisiones administrativas no son estándar y varían según cada país. En el caso de Chile, las divisiones son: Región, Provincia, Comuna y Ciudad.
+Utiliza este campo para seleccionar una o más direcciones geográficas, según los campos de Google Maps. Un mismo campo Ubicación guarda una lista ordenada de ubicaciones: agrega las que necesites y usa **Eliminar ubicación** para quitar una de la lista. El orden en que las dejes es el que se entrega en la API y en los SDK.
+
+En caso de que no dispongas de una clave de API de Google, puedes ingresar manualmente la **Dirección**, la **Latitud**, la **Longitud** y las divisiones políticas de la ubicación. La **Latitud** acepta valores entre -90 y 90, y la **Longitud** entre -180 y 180; fuera de ese rango la entrada no se guarda. Estas divisiones administrativas no son estándar y varían según cada país. En el caso de Chile, las divisiones son: Región, Provincia, Comuna y Ciudad.
+
+En la API pública y en los SDK, el valor del campo es un arreglo con un objeto por ubicación, y cada objeto trae siempre las mismas ocho claves:
+
+- `location_street`: la dirección escrita en el campo **Dirección**.
+- `location`: objeto con las coordenadas `lat` y `lon`.
+- `country`: el país de la ubicación.
+- `administrative_area_level_1` a `administrative_area_level_5`: los cinco niveles de división administrativa, del mayor al menor. Los niveles que el país no usa llegan sin dato.
 
 :::warning Atención
 Para garantizar el correcto funcionamiento de los mapas de ubicación con la clave de API de Google configurada en tu cuenta, la clave tiene que tener permisos para acceder a:
@@ -168,11 +197,17 @@ Para garantizar el correcto funcionamiento de los mapas de ubicación con la cla
 
 ### Archivo
 
-Este campo te permite adjuntar un solo archivo a la entrada, utilizando el gestor de archivos.
+Este campo te permite adjuntar un solo archivo a la entrada, utilizando el gestor de archivos. Cuenta con la siguiente restricción:
+
+- **Tipos permitidos**: Limita el tipo de archivo que se puede adjuntar. Puedes elegir uno o varios valores entre **Imágenes**, **Vídeo**, **Audio** y **Documentos**; si no eliges ninguno, se acepta cualquier archivo. Si el archivo adjunto es de otro tipo, la entrada no se guarda y el campo muestra "No coincide con los tipos permitidos", seguido de los tipos que configuraste.
+
+La comprobación se hace sobre el tipo con el que el gestor de archivos clasificó el archivo al subirlo, no sobre su extensión.
 
 ### Listado de Archivos
 
-Este campo te permite adjuntar múltiples archivos a la entrada, usando el gestor de archivos.
+Este campo te permite adjuntar múltiples archivos a la entrada, usando el gestor de archivos. Cuenta con la siguiente restricción:
+
+- **Tipos permitidos**: Limita el tipo de los archivos que se pueden adjuntar, con las mismas opciones y el mismo comportamiento que en [Archivo](#archivo). Basta con que uno de los archivos adjuntos sea de otro tipo para que la entrada no se guarde.
 
 ### Contenido (enlace a una)
 
@@ -193,6 +228,39 @@ Utiliza el campo Grupo para albergar otro campo dentro él. Puedes asignar un no
 Una vez que tengas más de un tipo de campo dentro de un grupo, puedes arrastrarlos y ordenarlos según requieras. 
 
 No hay límite en la cantidad de campos que puedes incluir dentro de un grupo. 
+
+En una entrada, el grupo se comporta como una lista repetible: el mismo conjunto de campos hijos se puede completar varias veces. Para trabajar con las repeticiones:
+
+1. Abre la entrada y ubica el grupo.
+2. Haz click en **Añadir un nuevo elemento** para agregar una repetición con los mismos campos.
+3. Completa los campos de esa repetición.
+4. Arrastra las repeticiones para cambiar su orden.
+5. Para borrar una repetición, haz click en su ícono de eliminar y confirma.
+
+El orden en que dejes las repeticiones se conserva y es el que se entrega en la API y en los SDK.
+
+Por eso el valor de un campo Grupo es siempre un arreglo de objetos, incluso cuando tiene una sola repetición: cada objeto trae los campos hijos con el nombre que les diste.
+
+```json
+{
+  "fields": {
+    "my_group": {
+      "fields": [
+        { "my_field": "Primer elemento" },
+        { "my_field": "Segundo elemento" }
+      ]
+    }
+  }
+}
+```
+
+Desde Liquid, recorre las repeticiones con un ciclo y lee los campos hijos dentro de él. Cada repetición se expone como un objeto [repeatable_group_field](/es/platform/channels/liquid-markup/objects.html#field):
+
+```liquid
+{% for item in entry["my_group"] %}
+  {{ item["my_field"] }}
+{% endfor %}
+```
 
 Puedes validar el contenido de los campos de la siguiente forma: 
 


### PR DESCRIPTION
## Cambios propuestos

Completa la página de Tipos de contenido con un tipo de campo que faltaba entero y con cuatro comportamientos de campo que no estaban escritos, todos verificados contra el código de la plataforma. Cierra CONTENT-01, CONTENT-06, CONTENT-21, CONTENT-05 y CONTENT-02.

El cambio toca `docs/es/platform/content/types.md` y su espejo `docs/en/platform/content/types.md`, con ediciones equivalentes en ambos idiomas.

### Texto de múltiples líneas (CONTENT-01)

La página documentaba 16 tipos de campo y el catálogo de la UI tiene 17: faltaba **Texto de múltiples líneas**, que es el campo natural para textos largos sin formato y que hoy un modelador de contenido no encuentra en ninguna parte. Se agrega la ficha, ubicada entre Texto de una línea y Texto enriquecido, el mismo orden en que aparecen en el panel, con:

- Qué es: texto plano multilínea, sin el tope de 255 caracteres de Texto de una línea.
- Sus tres validaciones reales (**Largo mínimo**, **Largo máximo** y **Validación por expresión regular**) y la aclaración de que este campo no ofrece **Único**, que es exclusivo de Texto de una línea.
- Un callout con el cambio de comportamiento de 10.2: el valor se entrega escapado como HTML al imprimirlo con Liquid, así que el campo ya no sirve para inyectar marcado y hay que usar Texto enriquecido. Es un cambio que rompe plantillas existentes y no estaba en ninguna nota de versión, por eso va como advertencia y con la indicación de revisar las plantillas.

### Grupo (CONTENT-06)

La ficha describía el Grupo como un contenedor de campos y omitía justo lo que lo hace útil: dentro de una entrada se repite N veces. La omisión era contradictoria, porque la página de Formularios enlaza a esta misma sección como "documentación sobre Grupos repetibles". Se agrega:

- El procedimiento en la entrada: **Añadir un nuevo elemento** para agregar una repetición, arrastrar para reordenar, eliminar con confirmación.
- La consecuencia para quien consume la API pública o los SDK: el valor de un campo Grupo es siempre un arreglo de objetos, incluso con una sola repetición, con un ejemplo del JSON resultante.
- Cómo recorrer las repeticiones desde Liquid, con enlace al objeto `repeatable_group_field` de la referencia de Liquid Markup.

### Ubicación (CONTENT-21)

La ficha hablaba de "una dirección geográfica" en singular, cuando un solo campo guarda una lista ordenada de ubicaciones. Se corrige el número, se menciona **Eliminar ubicación** y se aclara que el orden que dejes es el que entrega la API. Además se agregan dos cosas que un integrador necesita y no estaban escritas en ninguna parte:

- Las ocho claves exactas del JSON de salida: `location_street`, `location` con `lat` y `lon`, `country` y los cinco niveles administrativos.
- Los rangos válidos de **Latitud** (-90 a 90) y **Longitud** (-180 a 180) para el ingreso manual sin clave de Google.

### Archivo y Listado de Archivos (CONTENT-05)

Las dos fichas daban a entender que se puede adjuntar cualquier archivo. Ambas aceptan la validación **Tipos permitidos**, un selector múltiple con cuatro valores: **Imágenes**, **Vídeo**, **Audio** y **Documentos**. Se agrega el bullet a las dos fichas con el mensaje de error que ve el editor y con la aclaración de que la comprobación se hace sobre cómo clasificó el gestor de archivos al archivo cuando se subió, no sobre su extensión, que es la confusión típica.

### Valores permitidos (CONTENT-02)

La sección ya explicaba cómo administrar los valores, pero no decía qué hace el **Valor predeterminado**. Se completan dos comportamientos:

- Se aplica solo al crear una entrada nueva, y únicamente si el campo no trae ya un valor: al editar una entrada existente no pasa nada.
- Esa aplicación automática solo alcanza a los campos de elección de primer nivel. Un valor marcado como predeterminado en un campo de elección que está dentro de un **Grupo** nunca se aplica y el panel no lo advierte, así que va como callout.

También se completa el bullet de renombrado con el efecto observable: la propagación del texto nuevo a las entradas ocurre en segundo plano, por lo que la API pública puede tardar un momento en devolverlo.

## Para el revisor

Tres puntos que conviene mirar:

1. **Tilde del título nuevo.** El locale escribe el label sin tilde ("Texto de múltiples lineas"), igual que hace con "Texto de una linea". La página ya normaliza ese segundo caso a "Texto de una línea", así que escribí el título nuevo con tilde por consistencia interna. El anclaje va sin acentos de todas formas, así que cambiarlo a la forma literal del panel no rompe ningún enlace.

2. **Ubicación sin JSON de ejemplo.** Enumeré las ocho claves en una lista en vez de mostrar un JSON completo, porque no pude determinar desde el código si un nivel administrativo sin dato se devuelve como `null` o como cadena vacía. La lista dice "llegan sin dato", que es cierto en ambos casos. Si alguien lo confirma en un ambiente, se puede sumar el ejemplo en un cambio aparte.

3. **El escape HTML también aplica a Texto de una línea.** El código escapa tanto `single_line` como `text`, pero para Texto de una línea eso ya era así desde antes de 10.2, así que no lo agregué a su ficha: no es un cambio de comportamiento y la tanda no lo pedía. Queda anotado por si se quiere documentar aparte.

## Para el revisor

**Tildes del label del campo nuevo.** `es.yml:1070` escribe el label sin tilde: "Texto de múltiples lineas", igual que "Texto de una linea" en `:1069`. La página ya normaliza ese segundo label a "Texto de una línea" en su encabezado y en el anclaje `#texto-de-una-linea`. Escribí el título nuevo como **Texto de múltiples líneas**, con tilde, para no romper la consistencia interna de la página; si la revisión prefiere cita literal del locale, hay que cambiar el H3 y su slug quedaría igual (`#texto-de-multiples-lineas`), porque el anclaje va sin acentos de todos modos.

**El escape HTML también toca Texto de una línea.** `fieldable.rb:86` es `when 'single_line', 'text'`: el escape ya existía para Texto de una línea desde antes de 10.2 y no está documentado en su ficha. Lo dejé fuera porque la tanda solo pide el campo nuevo y porque para ese campo no hay cambio de comportamiento en 10.2; queda como candidato a un gap aparte.

**Alcance del escape.** El escape vive en el drop de Liquid (`Content::Fieldable#value_by_type`), no en la representación que sirve la API pública ni en el SDK de JS. Por eso el callout dice "al imprimirlo con Liquid" y no habla de la API.

**Niveles administrativos vacíos.** No incluí un JSON de ejemplo del campo Ubicación porque no se puede determinar de forma estática si un nivel sin dato se devuelve como `null` o como cadena vacía (depende de lo que envía el panel; `Location#assign_params` asigna tal cual llega y las columnas son nullable). La enumeración de las ocho claves dice "llegan sin dato", que es cierto en ambos casos. Si alguien confirma el valor real en un ambiente, se puede sumar el ejemplo después.

**Marcadores de los ejemplos.** El JSON y el Liquid del Grupo usan `my_group` y `my_field`, en la línea de `my_space` / `my_type` que ya usa la referencia de la API. La página no tenía ejemplos propios de ese campo con los que alinearse.

**Enlace entrante que ya existía.** `docs/es/platform/customers/forms.md:82` (y su espejo `docs/en/.../forms.md:82`) enlazan a `types#grupo` describiéndolo como "documentación sobre Grupos repetibles". Con esta tanda el destino por fin explica la repetición. No toqué esos enlaces, que además apuntan sin `.html`; corregirlos es materia de otra tanda.

**Directiva de producto.** No aplica: ninguno de los cinco gaps lleva a páginas de soporte ni al módulo Soporte, así que no hubo nada que omitir.

**Números de la introducción.** La página abre con "contando con más de 15 tipos de campos". Con la ficha nueva son 17 y la frase sigue siendo cierta, así que no la toqué.

## Validación

Docker está caído en el entorno, así que la validación fue estática: diff sin `{{ }}` ni `{% %}` fuera de bloques de código, sin encabezados terminados en dos puntos y con los anclajes de los links nuevos comprobados contra los títulos de destino. El build queda confiado al CI de este PR.

Closes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)
