### PR TITLE
Documentar el ciclo de vida del reino y del usuario final: creación y eliminación de reinos, revocación de sesiones y rutas del reino

### DIFF
--- a/docs/en/platform/customers/profile.md
+++ b/docs/en/platform/customers/profile.md
@@ -1,3 +1,7 @@
+---
+search: true
+---
+
 # User Profile
 
 The **user profile** is the space where each user can:
@@ -32,7 +36,7 @@ In this section, each user can modify their profile data. Depending on the [real
 - Mobile
 - Profile Image
 - Date of Birth
-- Gender
+- Gender: **Male**, **Female**, **Non-binary**, **Other (not listed)** or **Prefer not to say**
 - Language
 - [Custom Fields](/en/platform/customers/settings#custom-fields)
 - Password
@@ -43,3 +47,42 @@ Additionally, users have the option to permanently delete their account.
 :::danger Peligro
 Account deletion is irreversible. If a user performs this action, they will need to register again to access the platform.
 :::
+
+## Realm routes
+
+Every session and profile view of a realm hangs from the same prefix, built with your account URL and the realm identifier: `https://my_account.modyo.com/realms/my_realm/`.
+
+| Route | What it is for |
+| --- | --- |
+| `/login` | The realm's login view. |
+| `/logout` | Log out. |
+| `/signup` | Registration form. |
+| `/activate/:activation_code` | Activates and verifies the account from the link in the activation email, and leaves the user logged in. The link expires after a week. |
+| `/password` | Form to request password recovery. |
+| `/password/reset/:token` | Sets a new password from the link that arrives by email. The link expires after 3 days. |
+| `/password/confirm_info/:token` | Data confirmation screen that may show up during recovery; once saved, the user is verified. |
+| `/password/change` | Password change for a logged-in user, asking for their current password. |
+| `/reset_password` | Forced password change. Only reachable by users with a pending change; everyone else is sent back to the site. |
+| `/profile` | The user's profile, with their notifications. |
+| `/profile/edit` | Editing of the profile information. |
+| `/profile/change_email` | Email change request. The user confirms their current password and the new address stays pending until they verify it. |
+| `/confirm_email/:activation_code` | Confirms the new address from the verification link. The link expires after 5 minutes. |
+| `/profile/delete_user` | Permanent deletion of the user's account. |
+| `/otp_login` | Login view with a one-time code, available when the realm has Soft login enabled: it asks for the user's identifier instead of the password. |
+| `/otp_signup` | Sends the one-time code of a Soft login registration and takes the user to the code screen. |
+| `/otp_code` | Screen where the user types the 6-digit code they received. |
+| `/session/access/:token` | Starts the session from a single-use access token, which is invalidated as soon as it is used. |
+
+You can review the details of the login with a code in [Soft login](/en/platform/customers/settings.html#soft-login).
+
+:::tip Tip
+There is no Liquid drop that returns the registration URL: build it with the realm identifier. For login, logout, and the profile you do have **site.login_url**, **site.logout_url**, and **site.profile_url**, which you can review in [Objects](/en/platform/channels/liquid-markup/objects.html#site).
+:::
+
+### Redirection parameters
+
+- `site`: Identifier of the site the user came from. The platform adds it on its own when the user enters from a site, and uses it to send them back there when they are done.
+- `redirect_uri`: URL the user is sent to after logging in. The realm routes that accept it are `/login`, `/otp_login`, `/activate/:activation_code`, and `/session/access/:token`.
+- `redirect_to`: URL the user is sent to after logging out at `/logout`. It is also the parameter used by a site's `/login` route, as explained in [Redirect Login](/en/platform/customers/settings.html#redirect-login).
+
+The destination URL has to be a relative path or point to a site in your own account. If it isn't, the platform discards it and applies the redirection defined in **After logging in, redirect to** of the [Realm Settings](/en/platform/customers/settings.html#general).

--- a/docs/en/platform/customers/profile.md
+++ b/docs/en/platform/customers/profile.md
@@ -44,7 +44,7 @@ In this section, each user can modify their profile data. Depending on the [real
 
 Additionally, users have the option to permanently delete their account.
 
-:::danger Peligro
+:::danger Danger
 Account deletion is irreversible. If a user performs this action, they will need to register again to access the platform.
 :::
 

--- a/docs/en/platform/customers/realms.md
+++ b/docs/en/platform/customers/realms.md
@@ -11,6 +11,29 @@ Each realm has specific configurations for login, registration, integrations, fo
 Changes made to a realm will only affect the users of that realm and not those of other realms.
 :::
 
+## Create a Realm
+
+To create a realm, follow these steps:
+
+1. In the side menu, click **Customers**.
+2. Click **Realms**.
+3. Click the **New Realm** button.
+4. Enter the realm's **Name**.
+5. Review the **Identifier** the platform suggests from the name and adjust it if you need to.
+6. Click **Create**.
+
+The **Identifier** becomes part of the route where the realm's users authenticate: it is the value that appears in the URLs of the realm's profile, login, registration, and password recovery views. See the full list in [Realm routes](/en/platform/customers/profile.html#realm-routes).
+
+When you create the realm you are registered as its **Realm Admin**, and the platform takes you to its **Overview**.
+
+:::tip Tip
+You need a role with the **Create Realms** permission to see the **New Realm** button.
+:::
+
+:::warning Attention
+You can change the **Identifier** later from the [Realm Settings](/en/platform/customers/settings.html#general), but that changes every URL of the realm, including login and logout, and breaks the links you have already published on your sites.
+:::
+
 ## Overview
 
 The **Overview** section provides a general summary of the key elements of the realm, including:
@@ -26,3 +49,13 @@ You will also find a chronological log of all activities carried out within the 
 This section also includes relevant information such as the main configurations of the realm, the sites where it is used, the integrated identity providers, and their corresponding identifiers.
 
 This overview allows you to efficiently manage each realm and understand how it connects with users and other key elements of the platform.
+
+## Delete a Realm
+
+To delete a realm, go to its [Realm Settings](/en/platform/customers/settings.html#general) and use the **Delete realm** field in the **General** section. To confirm, you must type the realm's full name exactly as it appears in the list: if the text doesn't match, the platform doesn't run the action.
+
+Deletion runs in the background, so the realm may still show up in the list for a while after you confirm it.
+
+:::danger Danger
+Deleting a realm erases all its information: users, forms, message campaigns, and segments. On top of that, the sites that use it become public, with no access control. This action is irreversible.
+:::

--- a/docs/en/platform/customers/settings.md
+++ b/docs/en/platform/customers/settings.md
@@ -14,7 +14,7 @@ Here you can modify both the user's visual experience and the settings related t
 In this section, you can configure general aspects of the realm, such as:
 
 - **Title**
-- **Identifier**: The URL of the realm's profile, login, registration, and password recovery views.
+- **Identifier**: The URL of the realm's profile, login, registration, and password recovery views. See the full list in [Realm routes](/en/platform/customers/profile.html#realm-routes).
 - **Disable platform credentials**: By checking this box, you deactivate Modyo credentials in the realm and only allow access via SSO.
 
 :::danger Danger

--- a/docs/en/platform/customers/users.md
+++ b/docs/en/platform/customers/users.md
@@ -45,7 +45,13 @@ To add a new user, click the **New User** button and complete the following fiel
 - **Tags**: Labels to identify the user.
 
 :::tip Tip
-To send the password to the user's email, check the box below the email field. The user can change the password once they access the platform.
+To send the password to the user's email, check the box below the email field.
+:::
+
+Users you create from the admin are left with a pending password change: the first time they log in, the platform takes them to the password change screen and doesn't let them continue until they set a new one. The same happens when an administrator sets a password for them from **Edit**.
+
+:::tip Tip
+If the realm has [Soft login](/en/platform/customers/settings.html#soft-login) enabled, users aren't asked for a password to log in, so this forced change doesn't apply.
 :::
 
 If you need to add additional fields to the form or select a default avatar for users without one, go to the **Sign Up** section in the [Realm Settings](/en/platform/customers/settings).
@@ -105,15 +111,20 @@ Here, you can add custom notes about users. Only administrators can view, add, o
 
 #### Devices
 
-Displays the user's devices with active sessions. An administrator can remotely end sessions.
+Displays the user's devices with active sessions, including the browser and operating system, the start date, and the **IP Address** of each one. An administrator can remotely end those sessions:
+
+- To end a single session, click **Log out** next to the device.
+- To end all of them at once, click **Log out all devices**, above the list. This option shows up when there is more than one active session.
+
+When you revoke a session, the device loses access and the user has to authenticate again to get back in.
 
 ### Additional options
 
 In the contextual menu, you can perform the following actions:
 
-- **Edit**: Opens the user editing modal.
-- **Deactivate**: Deactivates a user, preventing them from logging in.
-- **Delete**: Removes the user from the platform. Only administrators can perform this action.
+- **Edit**: Opens the user editing modal. If you assign them a new password, the user must change it the next time they log in.
+- **Deactivate**: Deactivates a user, prevents them from logging in again, and revokes all their active sessions, which also signs them out of any session they had open at that moment.
+- **Delete**: Removes the user from the platform. Only administrators can perform this action. The platform deactivates them immediately and the final deletion runs in a background process, so their record may still show up in the list for a while.
 
 :::tip Tip
 - Modifying a user may result in changes to the list of segments they belong to.

--- a/docs/es/platform/customers/profile.md
+++ b/docs/es/platform/customers/profile.md
@@ -1,3 +1,7 @@
+---
+search: true
+---
+
 # Perfil de Usuario
 
 El **perfil de usuario** es el espacio donde cada usuario puede:
@@ -32,7 +36,7 @@ En esta sección, cada usuario puede modificar los datos de su perfil, dependien
 - Móvil
 - Imagen de Usuario
 - Fecha de Nacimiento
-- Género
+- Género: **Masculino**, **Femenino**, **No binario**, **Otro (no listado)** o **Prefiero no decir**
 - Idioma
 - [Custom fields](/es/platform/customers/settings#custom-fields)
 - Contraseña
@@ -43,3 +47,42 @@ Además, los usuarios tienen la opción de eliminar su cuenta de manera definiti
 :::danger Peligro
 La eliminación de la cuenta es irreversible. Si un usuario realiza esta acción, deberá registrarse nuevamente para acceder a la plataforma.
 :::
+
+## Rutas del reino
+
+Todas las vistas de sesión y de perfil de un reino cuelgan del mismo prefijo, formado por la URL de tu cuenta y el identificador del reino: `https://my_account.modyo.com/realms/my_realm/`.
+
+| Ruta | Para qué sirve |
+| --- | --- |
+| `/login` | Vista de inicio de sesión del reino. |
+| `/logout` | Cierre de sesión. |
+| `/signup` | Formulario de registro. |
+| `/activate/:activation_code` | Activa y verifica la cuenta desde el enlace del correo de activación, y deja al usuario con la sesión iniciada. El enlace caduca a la semana. |
+| `/password` | Formulario para pedir la recuperación de la contraseña. |
+| `/password/reset/:token` | Define una contraseña nueva desde el enlace que llega por correo. El enlace caduca a los 3 días. |
+| `/password/confirm_info/:token` | Confirmación de datos que puede aparecer durante la recuperación; al guardarla, el usuario queda verificado. |
+| `/password/change` | Cambio de contraseña de un usuario con sesión iniciada, pidiéndole su contraseña actual. |
+| `/reset_password` | Cambio de contraseña obligatorio. Solo es accesible para los usuarios que tienen el cambio pendiente; al resto los devuelve al sitio. |
+| `/profile` | Perfil del usuario, con sus notificaciones. |
+| `/profile/edit` | Edición de la información del perfil. |
+| `/profile/change_email` | Solicitud de cambio de correo. El usuario confirma su contraseña actual y la dirección nueva queda pendiente hasta que la verifica. |
+| `/confirm_email/:activation_code` | Confirma la dirección nueva desde el enlace de verificación. El enlace caduca a los 5 minutos. |
+| `/profile/delete_user` | Baja definitiva de la cuenta del usuario. |
+| `/otp_login` | Vista de ingreso con código de un solo uso, disponible cuando el reino tiene el Soft login habilitado: pide el identificador del usuario en lugar de la contraseña. |
+| `/otp_signup` | Envía el código de un solo uso de un registro con Soft login y lleva al usuario a la pantalla del código. |
+| `/otp_code` | Pantalla donde el usuario escribe el código de 6 dígitos que recibió. |
+| `/session/access/:token` | Inicia la sesión a partir de un token de acceso de un solo uso, que queda invalidado apenas se usa. |
+
+Puedes conocer el detalle del ingreso con código en [Soft login](/es/platform/customers/settings.html#soft-login).
+
+:::tip Tip
+No existe un drop de Liquid que entregue la URL de registro: ármala con el identificador del reino. Para el inicio y el cierre de sesión y para el perfil sí tienes **site.login_url**, **site.logout_url** y **site.profile_url**, que puedes revisar en [Objetos](/es/platform/channels/liquid-markup/objects.html#site).
+:::
+
+### Parámetros de redirección
+
+- `site`: Identificador del sitio desde el que llegó el usuario. La plataforma lo agrega automáticamente cuando el usuario entra desde un sitio y lo usa para devolverlo ahí al terminar.
+- `redirect_uri`: URL a la que se envía al usuario después de iniciar sesión. Las rutas del reino que lo aceptan son `/login`, `/otp_login`, `/activate/:activation_code` y `/session/access/:token`.
+- `redirect_to`: URL a la que se envía al usuario después de cerrar sesión en `/logout`. Es también el parámetro que usa la ruta `/login` de un sitio, como se explica en [Redireccionar Login](/es/platform/customers/settings.html#redireccionar-login).
+
+La URL de destino tiene que ser una ruta relativa o apuntar a un sitio de tu misma cuenta. Si no lo es, la plataforma la descarta y aplica la redirección definida en **Después de iniciar sesión, redirigir a** de la [Configuración de reino](/es/platform/customers/settings.html#general).

--- a/docs/es/platform/customers/realms.md
+++ b/docs/es/platform/customers/realms.md
@@ -11,6 +11,29 @@ Cada reino tiene configuraciones específicas para inicio de sesión, registro, 
 Los cambios realizados en un reino afectarán únicamente a los usuarios de ese reino y no a los de otros.
 :::
 
+## Crear un Reino
+
+Para crear un reino, sigue estos pasos:
+
+1. En el menú lateral, haz click en **Customers**.
+2. Haz click en **Reinos**.
+3. Haz click en el botón **Nuevo reino**.
+4. Escribe el **Nombre** del reino.
+5. Revisa el **Identificador** que la plataforma propone a partir del nombre y ajústalo si lo necesitas.
+6. Haz click en **Crear**.
+
+El **Identificador** forma parte de la ruta en la que se autentican los usuarios del reino: es el valor que aparece en las URL de las vistas de perfil, inicio de sesión, registro y recuperación de contraseña. Conoce el listado completo en [Rutas del reino](/es/platform/customers/profile.html#rutas-del-reino).
+
+Al crear el reino quedas registrado como **Realm Admin** de ese reino y la plataforma te lleva a su **Resumen**.
+
+:::tip Tip
+Necesitas un rol con el permiso **Crear Reinos** para ver el botón **Nuevo reino**.
+:::
+
+:::warning Atención
+Puedes cambiar el **Identificador** más adelante desde la [Configuración de reino](/es/platform/customers/settings.html#general), pero eso cambia todas las URL del reino, incluidas las de inicio y cierre de sesión, y deja sin efecto los enlaces que ya tengas publicados en tus sitios.
+:::
+
 ## Resumen
 
 La sección **Resumen** proporciona una visión general de los elementos clave del reino, que incluyen:
@@ -26,3 +49,13 @@ También encontrarás un registro cronológico de todas las actividades realizad
 En esta sección, también encontrarás información relevante, como las configuraciones principales del reino, los sitios donde se utiliza, los proveedores de identidad integrados y sus identificadores correspondientes.
 
 Este resumen te permite administrar eficientemente cada reino y entender cómo se conecta con los usuarios y otros elementos clave de la plataforma.
+
+## Eliminar un Reino
+
+Para eliminar un reino, entra a su [Configuración de reino](/es/platform/customers/settings.html#general) y usa el campo **Eliminar reino** de la sección **General**. Para confirmar tienes que escribir el nombre completo del reino, tal como aparece en el listado: si el texto no coincide exactamente, la plataforma no ejecuta la acción.
+
+La eliminación corre en segundo plano, así que es posible que el reino siga apareciendo en el listado un rato después de confirmarla.
+
+:::danger Peligro
+Eliminar un reino borra toda su información: usuarios, formularios, campañas de mensajes y segmentos. Además, los sitios que lo usan quedan públicos, sin control de acceso. Esta acción es irreversible.
+:::

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -14,7 +14,7 @@ Aquí puedes modificar tanto la experiencia visual del usuario como la configura
 En esta sección, puedes configurar aspectos generales del reino, como:
 
 - **Título**.
-- **Identificador**: La URL de las vistas de perfil, inicio de sesión, registro y recuperación de contraseña del reino.
+- **Identificador**: La URL de las vistas de perfil, inicio de sesión, registro y recuperación de contraseña del reino. Revisa el listado completo en [Rutas del reino](/es/platform/customers/profile.html#rutas-del-reino).
 - **Deshabilitar credenciales de la plataforma**: Al marcar esta casilla, desactivas las credenciales de Modyo en el reino y permites únicamente el acceso a través de SSO.
 
 :::danger Peligro

--- a/docs/es/platform/customers/users.md
+++ b/docs/es/platform/customers/users.md
@@ -112,8 +112,8 @@ Aquí puedes agregar notas personalizadas sobre los usuarios. Solo los administr
 
 Muestra los dispositivos del usuario que tienen una sesión activa, con el navegador y el sistema operativo, la fecha de inicio y la **Dirección IP** de cada uno. Un administrador puede cerrar esas sesiones de forma remota:
 
-- Para cerrar una sesión puntual, haz click en **Cerrar sesión** junto al dispositivo.
-- Para cerrarlas todas de una vez, haz click en **Cerrar sesión en todos los dispositivos**, sobre el listado. Esta opción aparece cuando hay más de una sesión activa.
+- Para cerrar una sesión puntual, haz clic en **Cerrar sesión** junto al dispositivo.
+- Para cerrarlas todas de una vez, haz clic en **Cerrar sesión en todos los dispositivos**, sobre el listado. Esta opción aparece cuando hay más de una sesión activa.
 
 Al revocar una sesión, el dispositivo pierde el acceso y el usuario tiene que autenticarse de nuevo para volver a entrar.
 

--- a/docs/es/platform/customers/users.md
+++ b/docs/es/platform/customers/users.md
@@ -45,7 +45,13 @@ Para agregar un nuevo usuario, haz clic en el botón **Nuevo Usuario** y complet
 - **Tags**: Etiquetas para identificar al usuario.
 
 :::tip Tip
-Para enviar la contraseña al correo del usuario, marca la casilla debajo del campo de correo electrónico. El usuario puede cambiar la contraseña una vez que acceda a la plataforma.
+Para enviar la contraseña al correo del usuario, marca la casilla debajo del campo de correo electrónico.
+:::
+
+Los usuarios que creas desde el administrador quedan con el cambio de contraseña pendiente: la primera vez que inicien sesión, la plataforma los lleva a la pantalla de cambio de contraseña y no los deja continuar hasta que definan una nueva. Lo mismo ocurre cuando un administrador les fija una contraseña desde **Editar**.
+
+:::tip Tip
+Si el reino tiene habilitado el [Soft login](/es/platform/customers/settings.html#soft-login), a los usuarios no se les pide contraseña para entrar, así que este cambio obligatorio no aplica.
 :::
 
 Si necesitas agregar campos adicionales al formulario o seleccionar un avatar predeterminado para usuarios sin avatar, ve a la sección **Regístrate** en la [Configuración de Reino](/es/platform/customers/settings).
@@ -104,15 +110,20 @@ Aquí puedes agregar notas personalizadas sobre los usuarios. Solo los administr
 
 #### Dispositivos
 
-Muestra los dispositivos del usuario que tienen una sesión activa. Un administrador puede cerrar sesiones de forma remota.
+Muestra los dispositivos del usuario que tienen una sesión activa, con el navegador y el sistema operativo, la fecha de inicio y la **Dirección IP** de cada uno. Un administrador puede cerrar esas sesiones de forma remota:
+
+- Para cerrar una sesión puntual, haz click en **Cerrar sesión** junto al dispositivo.
+- Para cerrarlas todas de una vez, haz click en **Cerrar sesión en todos los dispositivos**, sobre el listado. Esta opción aparece cuando hay más de una sesión activa.
+
+Al revocar una sesión, el dispositivo pierde el acceso y el usuario tiene que autenticarse de nuevo para volver a entrar.
 
 ### Opciones adicionales
 
 En el menú contextual puedes ejecutar las siguientes acciones:
 
-- **Editar**: Abre el modal de edición de usuario.
-- **Desactivar**: Desactiva un usuario e impide que pueda iniciar sesión.
-- **Eliminar**: Borra al usuario de la plataforma. Solo los administradores pueden realizar esta acción.
+- **Editar**: Abre el modal de edición de usuario. Si le asignas una contraseña nueva, el usuario tiene que cambiarla la próxima vez que inicie sesión.
+- **Desactivar**: Desactiva un usuario, le impide volver a iniciar sesión y revoca todas sus sesiones activas, por lo que también lo saca de las sesiones que tuviera abiertas en ese momento.
+- **Borrar**: Borra al usuario de la plataforma. Solo los administradores pueden realizar esta acción. La plataforma lo desactiva de inmediato y el borrado definitivo corre en un proceso en segundo plano, así que su registro puede seguir apareciendo un rato en el listado.
 
 :::tip Tip
 - Modificar un usuario puede resultar en que se modifique el listado de segmentos a los que pertenece ese usuario.


### PR DESCRIPTION
## Cambios propuestos

Cierra tres huecos del dominio de Customers que, juntos, completan el ciclo de vida de un reino y de sus usuarios finales: cómo se crea y se borra un reino, qué pasa de verdad cuando desactivas o borras un usuario, y cuáles son las URL de sesión y perfil de un reino.

### `platform/customers/realms.md` (es + en)

Gap **CUSTOMERS-EX-02**. La página explicaba qué es un reino y describía la pantalla **Resumen**, pero no tenía ningún bloque de procedimiento, que es el estándar de la casa para las fichas de feature de platform.

- Sección nueva **Crear un Reino** con los pasos numerados del modal **Nuevo reino** (**Nombre** e **Identificador**), la explicación de que el identificador forma parte de la ruta en la que se autentican los usuarios del reino, el permiso que hace falta (**Crear Reinos**) y el aviso de que cambiar el identificador más adelante cambia todas las URL del reino.
- Se documenta que quien crea el reino queda como **Realm Admin** y que la plataforma lo lleva al **Resumen** del reino recién creado.
- Sección nueva **Eliminar un Reino**, que hasta ahora solo existía como un campo suelto de la zona de peligro en `settings.md`: desde dónde se ejecuta, que hay que escribir el nombre completo del reino para confirmar, que la eliminación corre en segundo plano y qué se pierde con ella.

### `platform/customers/users.md` (es + en)

Gap **CUSTOMERS-16**. La página listaba las acciones sin sus efectos observables, y el tip de creación de usuarios decía lo contrario de lo que hace la plataforma.

- Se corrige el tip que decía que el usuario "puede cambiar la contraseña una vez que acceda": los usuarios creados desde el administrador quedan con el cambio de contraseña pendiente y la plataforma se lo exige en el primer ingreso. Se aclara que lo mismo pasa cuando un administrador les fija una contraseña desde **Editar**, y que la exigencia no aplica en reinos con **Soft login**.
- **Desactivar** ahora explica que además revoca todas las sesiones activas del usuario, no solo le impide volver a entrar.
- La acción de borrado explica que primero se desactiva al usuario y que el borrado definitivo corre en segundo plano, así que el registro puede seguir apareciendo un rato en el listado. Se ajusta el label a **Borrar**, que es el texto real del panel.
- **Dispositivos** ahora detalla qué muestra cada sesión y que se pueden cerrar de a una con **Cerrar sesión** o todas de golpe con **Cerrar sesión en todos los dispositivos**.

### `platform/customers/profile.md` (es + en)

Gap **CUSTOMERS-20**. Un desarrollador de plantillas no tenía de dónde sacar las URL de registro, recuperación de contraseña, activación, edición de perfil o soft login.

- Sección nueva **Rutas del reino** con la tabla completa de rutas de sesión y perfil bajo el prefijo del reino, incluidas las caducidades de los enlaces de activación, recuperación y confirmación de correo.
- Subsección **Parámetros de redirección** con `site`, `redirect_uri` y `redirect_to`, y la restricción de que el destino tiene que ser una ruta relativa o un sitio de la misma cuenta.
- Se enumeran los valores que acepta el campo **Género** en la edición de perfil.
- Se agrega el frontmatter `search: true`, que era la única página de platform sin él.
- Se anota que no hay ningún drop de Liquid que entregue la URL de registro, y se enlazan los que sí existen en la referencia de objetos.

### `platform/customers/settings.md` (es + en)

Una sola línea: el bullet del **Identificador** ahora enlaza al listado completo de rutas del reino.

Gaps cerrados: **CUSTOMERS-EX-02**, **CUSTOMERS-16**, **CUSTOMERS-20**.

## Para el revisor

1. Ficha vs master, acción masiva: la ficha de CUSTOMERS-16 afirma que la revocación de sesiones ocurre "individual o por acción masiva". En origin/master, `app/workers/bulk_update_users_worker.rb#toggle_activation` solo hace `update_all(active: false)` y nunca toca `session_grants`; la revocación está únicamente en `users_controller.rb#deactivate` y en `#update` cuando se apaga `active`. Documenté la revocación solo para la acción individual y dejé el bullet de **Desactivar** de acciones masivas sin tocar. Si el equipo considera que la asimetría es un bug, conviene abrir un ticket en la plataforma antes de documentarla como comportamiento esperado.

2. Ficha vs master, límite de reinos: la ficha pide decir que la creación "está sujeta al límite de reinos del plan". No existe ninguna validación de ese tipo en origin/master (grep de `realm_limit`, `max_realms`, `realms_limit` en `app`, `config` y `lib`: cero resultados), así que lo omití.

3. Cambio de label: en `docs/es/.../users.md` cambié **Eliminar** por **Borrar** en la acción del menú contextual. `UserHeader.js` usa `admin.commons.delete`, que en `es.yml` es "Borrar", y el resto del corpus (settings.md, forms.md, spaces.md, roles.md, entries.md) ya usa **Borrar**. Si prefieres no tocar ese label, la edición se revierte cambiando esa sola palabra.

4. Comportamiento no documentado a propósito: `profiles_controller.rb#confirm_email` en master reescribe también el `username` del usuario con la dirección nueva, de forma incondicional. Como en reinos que no usan el correo como nombre de usuario eso parece un efecto no intencionado, la tabla solo dice que confirma la dirección nueva y que el enlace caduca a los 5 minutos.

5. Directiva de producto: `config/routes.rb` expone rutas de casos de soporte (`/cases`, `/cases/:case_number/comment`) dentro de `site_routes`. Quedaron fuera por completo de la tabla de rutas y no se menciona el módulo en ninguna parte de la tanda.

6. Nada de infraestructura: el límite de tiempo entre cambios de contraseña (`validate_change_password_limit`) depende de una variable de entorno, así que no publiqué el número. Tampoco se mencionan jobs por nombre: el borrado de usuario y el de reino se describen solo como "un proceso en segundo plano".

7. Dependencia entre archivos: `realms.md` y `settings.md` (ambos idiomas) enlazan a `profile.html#rutas-del-reino` / `#realm-routes`. Si el orquestador descarta las ediciones de `profile.md`, esos cuatro enlaces quedan rotos y el build de VuePress no lo detecta.

8. Posible conflicto con PRs abiertos: toco una línea de `settings.md` (el bullet **Identificador** / **Identifier**, línea 17 en ambos idiomas). Es la única intersección con una página que otros PRs podrían estar editando; si hay conflicto, esa edición se puede soltar sin afectar al resto de la tanda salvo por el enlace del punto 7.

9. Anclajes usados que dependen de encabezados ajenos: `settings.html#soft-login`, `settings.html#general`, `settings.html#redireccionar-login` (en inglés `#redirect-login`, sobre el encabezado `## Redirect Login ##`) y `objects.html#site`. Los cuatro existen hoy en master en ambos idiomas.

## Validación

Docker está caído en el entorno, así que la validación fue estática: diff sin `{{ }}` ni `{% %}` fuera de bloques de código, sin encabezados terminados en dos puntos y con los anclajes de los links nuevos comprobados contra los títulos de destino. El build queda confiado al CI de este PR.

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)
