### PR TITLE
Completar los colores del tema de la cuenta con sus valores por defecto y su alcance real

### DIFF
--- a/docs/en/platform/core/configuration.md
+++ b/docs/en/platform/core/configuration.md
@@ -32,7 +32,7 @@ If the time zone you choose is subject to time changes, these will be automatica
 
 #### Theme colors
 
-In this section, you can customize the color palette of the entire account administration interface, including the login page. Each color has a visual picker and a text field with the HEX value, and both do the same thing: you can pick the shade in the picker or type the code by hand. The text field doesn't validate the format, so always type a six-digit HEX, because a malformed value leaves that element with its base style.
+In this section, you can customize the color palette of the entire account administration interface, including the login page. Each color has a visual picker and a text field with the HEX value, and both do the same thing: you can pick the shade in the picker or type the code by hand. The text field doesn't validate the format, so always type the full HEX code, with the leading `#` and six digits (`#RRGGBB`), because a malformed value leaves that element with its base style.
 
 The colors you can define, with their default value, are:
 

--- a/docs/en/platform/core/configuration.md
+++ b/docs/en/platform/core/configuration.md
@@ -32,14 +32,24 @@ If the time zone you choose is subject to time changes, these will be automatica
 
 #### Theme colors
 
-In this section, you can customize the color palette of the entire account administration interface, including the login page. The colors you can define are:
+In this section, you can customize the color palette of the entire account administration interface, including the login page. Each color has a visual picker and a text field with the HEX value, and both do the same thing: you can pick the shade in the picker or type the code by hand. The text field doesn't validate the format, so always type a six-digit HEX, because a malformed value leaves that element with its base style.
 
-- **Primary color** and **Primary hover color**: Colors for the main buttons and elements.
-- **Accent color** and **Accent hover color**: Colors for secondary elements and links.
-- **Navigation selected text** and **Navigation selected background**: Colors of the active element in the navigation.
-- **Page background**: General background color of the interface.
+The colors you can define, with their default value, are:
 
-When saving a color change, the page reloads to apply the new theme across the entire interface. The **Reset to default** button returns you to the original Modyo palette.
+- **Primary color** (`#32ae70`) and **Primary hover color** (`#2a9c63`): Colors for the main buttons and elements.
+- **Accent color** (`#2068d5`) and **Accent hover color** (`#1e60c4`): Colors for secondary elements and links.
+- **Navigation selected text** (`#2068d5`) and **Navigation selected background** (`#f6f9fd`): Colors of the active element in the navigation.
+- **Page background** (`#f6f9fd`): General background color of the interface.
+
+To apply the palette, adjust the colors you need and click **Save**. The page reloads so the new theme is visible across the entire interface.
+
+**Primary color**, **Primary hover color**, and **Page background** are also applied outside the admin: they are the background, link, and button colors of the transactional emails the platform sends, so a palette change is also visible in the emails your users receive. The other four colors only affect the administration interface.
+
+To go back to the original Modyo palette, click **Reset to default** and confirm in the message that appears. You don't need to save afterwards: the change is applied immediately and the page reloads.
+
+:::warning Attention
+**Reset to default** doesn't distinguish between colors: it discards all seven custom values at once, not just the one you are editing. If you have a brand palette loaded, write down its codes before resetting, because you will have to enter them again one by one.
+:::
 
 ## Profile Settings
 

--- a/docs/es/platform/core/configuration.md
+++ b/docs/es/platform/core/configuration.md
@@ -32,7 +32,7 @@ Si la zona horaria que eliges está sujeta a cambios de horarios, estos se refle
 
 #### Colores del tema
 
-En esta sección puedes personalizar la paleta de colores de toda la interfaz de administración de la cuenta, incluida la página de inicio de sesión. Cada color tiene un selector visual y un campo de texto con el valor HEX, y los dos hacen lo mismo: puedes elegir el tono en el selector o escribir el código a mano. El campo de texto no valida el formato, así que escribe siempre un HEX de seis dígitos, porque un valor mal escrito deja ese elemento con su estilo base.
+En esta sección puedes personalizar la paleta de colores de toda la interfaz de administración de la cuenta, incluida la página de inicio de sesión. Cada color tiene un selector visual y un campo de texto con el valor HEX, y los dos hacen lo mismo: puedes elegir el tono en el selector o escribir el código a mano. El campo de texto no valida el formato, así que escribe siempre el código HEX completo, con el `#` inicial y seis dígitos (`#RRGGBB`), porque un valor mal escrito deja ese elemento con su estilo base.
 
 Los colores que puedes definir, con su valor por defecto, son:
 

--- a/docs/es/platform/core/configuration.md
+++ b/docs/es/platform/core/configuration.md
@@ -32,14 +32,24 @@ Si la zona horaria que eliges está sujeta a cambios de horarios, estos se refle
 
 #### Colores del tema
 
-En esta sección puedes personalizar la paleta de colores de toda la interfaz de administración de la cuenta, incluida la página de inicio de sesión. Los colores que puedes definir son:
+En esta sección puedes personalizar la paleta de colores de toda la interfaz de administración de la cuenta, incluida la página de inicio de sesión. Cada color tiene un selector visual y un campo de texto con el valor HEX, y los dos hacen lo mismo: puedes elegir el tono en el selector o escribir el código a mano. El campo de texto no valida el formato, así que escribe siempre un HEX de seis dígitos, porque un valor mal escrito deja ese elemento con su estilo base.
 
-- **Color principal** y **Color principal al pasar el cursor**: Colores de los botones y elementos principales.
-- **Color de acento** y **Color de acento al pasar el cursor**: Colores de los elementos secundarios y enlaces.
-- **Texto de navegación seleccionado** y **Fondo de navegación seleccionado**: Colores del elemento activo en la navegación.
-- **Fondo de página**: Color de fondo general de la interfaz.
+Los colores que puedes definir, con su valor por defecto, son:
 
-Al guardar un cambio de color, la página se recarga para aplicar el nuevo tema en toda la interfaz. Con el botón **Restablecer a predeterminado** vuelves a la paleta original de Modyo.
+- **Color principal** (`#32ae70`) y **Color principal al pasar el cursor** (`#2a9c63`): Colores de los botones y elementos principales.
+- **Color de acento** (`#2068d5`) y **Color de acento al pasar el cursor** (`#1e60c4`): Colores de los elementos secundarios y enlaces.
+- **Texto de navegación seleccionado** (`#2068d5`) y **Fondo de navegación seleccionado** (`#f6f9fd`): Colores del elemento activo en la navegación.
+- **Fondo de página** (`#f6f9fd`): Color de fondo general de la interfaz.
+
+Para aplicar la paleta, ajusta los colores que necesites y haz click en **Guardar**. La página se recarga para que el nuevo tema se vea en toda la interfaz.
+
+**Color principal**, **Color principal al pasar el cursor** y **Fondo de página** se aplican además fuera del panel: son los colores del fondo, los enlaces y los botones de los correos transaccionales que envía la plataforma, así que un cambio de paleta también se nota en los correos que reciben tus usuarios. Los otros cuatro colores solo afectan a la interfaz de administración.
+
+Para volver a la paleta original de Modyo, haz click en **Restablecer a predeterminado** y confirma en el mensaje que aparece. No necesitas guardar después: el cambio se aplica de inmediato y la página se recarga.
+
+:::warning Atención
+**Restablecer a predeterminado** no distingue entre colores: descarta los siete valores personalizados de una sola vez, no solo el que estás editando. Si tienes cargada una paleta de marca, anota sus códigos antes de restablecer, porque tendrás que volver a ingresarlos uno por uno.
+:::
 
 ## Configuración de Perfil
 


### PR DESCRIPTION
## Cambios propuestos

Completa la documentación de los colores del tema de la cuenta con lo que faltaba tras la primera pasada: los valores por defecto, cómo se ingresan, qué pasa exactamente al restablecer y hasta dónde llega el efecto de la paleta.

### `docs/es/platform/core/configuration.md` y `docs/en/platform/core/configuration.md`

En la sección **Colores del tema** (dentro de **Visualización**), se amplió el bloque que ya existía:

- **Cómo se ingresa cada color**: se aclara que cada campo tiene un selector visual y un campo de texto con el valor HEX, que ambos son equivalentes, y que el campo de texto no valida el formato, por lo que un HEX mal escrito deja ese elemento con su estilo base.
- **Valores por defecto**: se agrega el HEX de fábrica de los siete campos, junto al label de cada uno: **Color principal** `#32ae70`, **Color principal al pasar el cursor** `#2a9c63`, **Color de acento** `#2068d5`, **Color de acento al pasar el cursor** `#1e60c4`, **Texto de navegación seleccionado** `#2068d5`, **Fondo de navegación seleccionado** `#f6f9fd` y **Fondo de página** `#f6f9fd`.
- **Cómo se aplica la paleta**: se explicita que los cambios se confirman con **Guardar** y que la página se recarga para reflejar el nuevo tema.
- **Alcance real de la paleta**: se documenta que **Color principal**, **Color principal al pasar el cursor** y **Fondo de página** además tiñen el fondo, los enlaces y los botones de los correos transaccionales que envía la plataforma, y que los otros cuatro colores solo afectan a la interfaz de administración. Esto no estaba en la página y es lo que hace que un cambio de marca se note también en el correo que reciben los usuarios.
- **Restablecer a predeterminado**: se documenta que pide una confirmación, que descarta los siete valores personalizados a la vez y no solo el que se está editando, y que no requiere guardar después porque se aplica de inmediato. Se agrega un callout de atención recomendando anotar los códigos de la paleta de marca antes de restablecer, porque hay que volver a ingresarlos uno por uno.

Los labels de UI se citan con el texto exacto de los locales del panel en cada idioma.

Cierra el gap **CONFIGURACIONES-02**.

## Para el revisor

1. LA SECCIÓN YA EXISTÍA, ESTO ES UNA AMPLIACIÓN. La ficha de CONFIGURACIONES-02 se levantó cuando la página tenía "3 bullets, líneas 26-30" y "0 hits en docs". Eso ya no es así: los commits 1475c5f65 ("Documenta el branding a nivel de cuenta: logo, favicon y colores del tema") y 96265f346, ambos ya en master de modyo-docs, crearon "#### Colores del tema" con los 7 labels, el botón Restablecer, la recarga al guardar y el alcance panel + pantalla de inicio de sesión. Por eso NO creé la sección ni la dupliqué: reemplacé su cuerpo agregando solo lo que faltaba (valores por defecto, ingreso en HEX, confirmación del restablecer, alcance en correos). Si el orquestador espera una sección nueva, el diff va a verse más chico de lo previsto y eso es intencional.

2. CORRIJO EL ALCANCE QUE AFIRMA LA FICHA. La ficha dice que los colores "tiñen los botones de los correos transaccionales (views/mailer/message.html.erb:334-339)". En origin/master eso se queda corto en dos sentidos: (a) no son los 7 colores, son 3 (primary_color, primary_hover y page_background); (b) no son solo los botones: page_background pinta el fondo del mensaje (message.html.erb:32, :57, :171) y primary_color pinta enlaces y bordes además de los botones (:147, :172, :175, :187, :191-192). Documenté los 3 colores y los 3 elementos observables, y dejé explícito que los otros 4 no salen del panel.

3. NO HAY VALIDACIÓN DE FORMATO EN EL SERVIDOR. Revisé account.rb y api/admin/accounts_controller.rb en origin/master y ninguno valida que el valor sea un HEX. El campo de texto del ColorPicker manda el string tal cual. La frase "un valor mal escrito deja ese elemento con su estilo base" describe el comportamiento observable del navegador ante un valor de color inválido; es la formulación más conservadora que encontré sin entrar en detalle de implementación. Si producto prefiere no insinuar que se puede escribir basura, esa sola oración se puede cortar sin tocar el resto.

4. Anoto además que "Restablecer a predeterminado" guarda solo, sin pasar por **Guardar** (resetColors llama a saveAccount directamente). Es un comportamiento asimétrico respecto del resto del formulario y por eso lo dejé explícito; si en algún momento se unifica, esa frase queda obsoleta.

5. DIRECTIVA DE PRODUCTO SOBRE SOPORTE: no aplica a esta tanda. El gap no toca páginas de soporte ni el módulo Soporte y no hubo nada que omitir por ese motivo.

6. Sin riesgo de build de VuePress: el contenido nuevo no usa llaves dobles ni etiquetas de plantilla fuera de bloques de código, así que no hizo falta v-pre. Los HEX van en backticks, que es como los muestra el corpus.

7. Ninguno de los 12 PRs abiertos toca configuration.md (verificado con gh pr list --json files), así que no hay conflicto ni contenido dependiente que evitar repetir.

## Validación

Docker está caído en el entorno, así que la validación fue estática: diff sin `{{ }}` ni `{% %}` fuera de bloques de código, sin encabezados terminados en dos puntos y con los anclajes de los links nuevos comprobados contra los títulos de destino. El build queda confiado al CI de este PR.

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
