### PR TITLE
Corregir la ubicación de las Variables Globales y documentar los idiomas, el valor por defecto, la activación y el listado

### DIFF
--- a/docs/en/platform/channels/global-variables.md
+++ b/docs/en/platform/channels/global-variables.md
@@ -16,22 +16,93 @@ Modyo offers the functionality to define variables globally and reuse them in al
 :::tip Tip
 You can use plain text, HTML, JavaScript, and CSS within global variables; however, you cannot use Liquid code. The content has a maximum of 65,535 characters.
 
-To get the variable value anywhere that accepts Liquid markup (entries, widgets, templates), use: <span v-pre>`{{vars.Name}}`</span>
+To get the variable value anywhere that accepts Liquid markup (entries, widgets, templates), use: <span v-pre>`{{ vars.identifier }}`</span>
 :::
 
-### Create a Global Variable
+## Variable Scopes
+
+A variable lives in one of three scopes, and each scope has its own screen:
+
+- **Account**: in the Channels side menu, click **Variables**. Whatever you create here is available to every web app in the account.
+- **App**: inside a web app, under **App settings**, click **App variables**. Here you create variables that belong to the app and overwrite, for that app only, the value of an account variable. See [Site Variables](/en/platform/channels/sites.html#site-variables).
+- **Widget**: in the **Variables** tab of the widget definition. See [Widget Variables](/en/platform/channels/widgets.html#widget-variables).
+
+When a variable is resolved, the most specific scope always wins: the widget value overrides the app value, and the app value overrides the account value. Be careful when reusing, in a widget or an app, an identifier that already exists at the account level.
+
+## Create a Global Variable
 
 To create a global variable, follow these steps:
 
-1. From the main side menu, click **Settings**, then select **Global Variables**.
-2. Here you can see the list of all global variables for the account, their general information, and a button to copy their name in Liquid. Click **New Variable**.
-3. Fill in the **Name** and **Value** of the variable.
+1. From the side menu, click Channels and then **Variables**.
+2. Here you can see the list of the account's global variables, their general information, and a button to copy their **Liquid markup**. Click **New Variable**.
+3. Fill in the **Name** and the **Value** of the variable.
 4. Click **Save**.
 
-Global variables can be used to add values for different languages. If required, you also have the option to override global variable values in sites and widgets, using the [site configuration](/en/platform/channels/sites#site-variables) and [custom widgets](/en/platform/channels/widgets#widget-variables) sections, respectively.
+The text you type in **Name** is normalized as you type: it is lowercased and spaces are replaced with hyphens. That result is the identifier you use to read the variable from Liquid, there is no separate title. The value you save is tied to the app's language and is marked as the default value.
+
+## Values per Language
+
+A variable does not store a single value, but one value per language, and only three languages are supported: **Spanish**, **English**, and **Portuguese**. Any other language code is rejected on save.
+
+To add or change the value of a language:
+
+1. In the list, click the variable's name.
+2. In the window header, pick the language in the selector next to the title.
+3. Type the **Value** and click **Save**.
+
+Exactly one of the values is marked as the variable's default value: it is the one returned when the variable is accessed without a resolved language. The **Default** column in the list tells you which one it is. To change it, leave the **Locale** filter on the language you want to promote, select one or more variables, and use the **Set as default** bulk action.
+
+Widget variables do not have this dimension: they store a single value, with no language.
+
+:::tip Tip
+**Name** can only be edited from the value marked as default. If you open the variable in another language, the field is disabled.
+:::
+
+## Activate and Deactivate a Variable
+
+You can deactivate a variable without deleting it. Select one or more variables in the list and use the **Deactivate** bulk action. To revert it, switch the **Active** filter to **No**, select the variables, and use **Activate**.
+
+While a variable is deactivated:
+
+- It cannot be edited. When you open it you see the notice "This variable is deactivated. If you want to edit it you must activate it first" and the save button becomes **Activate**.
+- It stops being available in Liquid: templates that use it start receiving an empty string.
+
+## The Variable List
+
+On the account and app screens, the list shows one row per variable with its **Status**, **Name**, **Value**, whether it is the **Default** value, and a button that copies its **Liquid markup**.
+
+The **Status** column uses these indicators:
+
+- **Translated** or **Not translated**, depending on whether the variable has a value loaded in the language you are filtering by.
+- **Not overwritten**, on the app screen, when the variable comes from the account and this app does not give it its own value yet.
+- **Overwritten**, when the variable also exists in a higher scope and is being given a different value here.
+
+To narrow the list you have the **Locale**, **Active**, and **Translation** filters, the latter with the **Translated** and **Not translated** options. On the app screen the **Overwritten** filter is added. The search box filters by identifier. By default, only the active variables of the app's language are listed.
+
+In the **Variables** tab of a widget definition you also see the **In use** indicator, which marks the variables the widget code actually references.
+
+## Read a Variable from Liquid
+
+To read a variable anywhere that accepts Liquid markup, use <code v-pre>vars.identifier</code>, where the identifier is the one shown in **Name**. The button in the **Liquid markup** column copies the full expression, ready to paste into a template.
+
+When rendering, Modyo layers three sets of values and the last one wins:
+
+1. The value marked as default for each variable.
+2. The value of the language configured in the app.
+3. The value of the active language of the request being rendered.
+
+Scope inheritance is applied on top of that result: account, then app, and finally widget.
+
+:::tip Tip
+If the identifier does not exist in any scope, or if the variable is deactivated, <code v-pre>vars.identifier</code> returns an empty string and the render continues: no error is raised and the page is not interrupted. Keep this in mind when a variable's value disappears from a template without any signal.
+:::
+
+## Change a Variable's Identifier
+
+The **Name** of an existing variable is locked. To edit it, you have to unlock the field with **Unlock identifier field** and confirm the notice.
 
 :::warning Attention
-When using global variables, variables defined at the lowest level will always take precedence (first those defined in the widget, then those defined in the site, and finally those defined at the account level). Therefore, you must be careful when defining variables in widgets or the site with the same name as account variables.
+Changing the identifier breaks every reference that already uses that variable: templates, widgets, content, the API, and the SDKs stop finding it and start receiving an empty string. If you need a different identifier, create a new variable, update the references, and only then delete the old one.
 :::
 
 :::danger Danger

--- a/docs/es/platform/channels/global-variables.md
+++ b/docs/es/platform/channels/global-variables.md
@@ -16,22 +16,93 @@ Modyo ofrece la funcionalidad de definir variables globalmente y reutilizarlas e
 :::tip Tip
 Puedes usar texto plano, HTML, JavaScript y CSS dentro de las variables globales; sin embargo, no puedes usar código Liquid. El contenido tiene un máximo de 65.535 caracteres.
 
-Para obtener el valor de la variable en cualquier lugar que acepte Liquid markup (entradas, widgets, plantillas), usa: <span v-pre>`{{vars.Nombre}}`</span>
+Para obtener el valor de la variable en cualquier lugar que acepte Liquid markup (entradas, widgets, plantillas), usa: <span v-pre>`{{ vars.identificador }}`</span>
 :::
 
-### Crear una variable global
+## Alcances de las variables
+
+Una variable vive en uno de tres alcances y cada alcance tiene su propia pantalla:
+
+- **Cuenta**: en el menú lateral de Channels, haz clic en **Variables**. Lo que crees aquí está disponible en todas las aplicaciones web de la cuenta.
+- **Aplicación**: dentro de una aplicación web, en **Configuración de la aplicación**, haz clic en **Variables de la aplicación**. Aquí creas variables propias de la aplicación y sobrescribes, solo para ella, el valor de una variable de la cuenta. Consulta [Variables del sitio](/es/platform/channels/sites.html#variables-del-sitio).
+- **Widget**: en la pestaña **Variables** de la definición del widget. Consulta [Variables del Widget](/es/platform/channels/widgets.html#variables-del-widget).
+
+Al resolver una variable gana siempre el alcance más específico: el valor del widget pisa al de la aplicación y el de la aplicación pisa al de la cuenta. Por eso debes ser cuidadoso al reutilizar en un widget o en una aplicación un identificador que ya existe a nivel de cuenta.
+
+## Crear una variable global
 
 Para crear una variable global, sigue estos pasos:
 
-1. Desde el menú lateral principal, haz clic en **Configuración**, luego selecciona **Variables Globales**.
-2. Aquí podrás ver el listado de todas las variables globales de la cuenta, su información general y un botón para copiar su nombre en Liquid. Haz clic en **Nueva Variable**.
-3. Rellena el **Nombre** y **Valor** de la variable.
+1. Desde el menú lateral, haz clic en Channels y luego en **Variables**.
+2. Aquí ves el listado de las variables globales de la cuenta, su información general y un botón para copiar su **Código de Liquid**. Haz clic en **Nueva Variable**.
+3. Rellena el **Nombre** y el **Valor** de la variable.
 4. Haz clic en **Guardar**.
 
-Las variables globales se pueden utilizar para añadir valores para distintos idiomas. Si lo requieres, también tienes la opción de sobrescribir los valores de variables globales en sitios y widgets, utilizando los apartados de [configuración del sitio](/es/platform/channels/sites#variables-del-sitio) y [widgets personalizados](/es/platform/channels/widgets#variables-del-widget), respectivamente.
+El texto que escribes en **Nombre** se normaliza mientras escribes: pasa a minúsculas y los espacios se reemplazan por guiones. Ese resultado es el identificador con el que consumes la variable desde Liquid, no hay un título aparte. El valor que guardas queda asociado al idioma de la aplicación y marcado como valor por defecto.
+
+## Valores por idioma
+
+Una variable no guarda un único valor, sino un valor por idioma, y los idiomas admitidos son solo tres: **Español**, **Inglés** y **Portugués**. Cualquier otro código de idioma se rechaza al guardar.
+
+Para añadir o cambiar el valor de un idioma:
+
+1. En el listado, haz clic en el nombre de la variable.
+2. En la cabecera de la ventana, elige el idioma en el selector que aparece junto al título.
+3. Escribe el **Valor** y haz clic en **Guardar**.
+
+Exactamente uno de los valores queda marcado como valor por defecto de la variable: es el que se devuelve cuando se accede a la variable sin un idioma resuelto. La columna **Por defecto** del listado te dice cuál es. Para cambiarlo, deja el filtro **Idioma** en el idioma que quieres promover, selecciona una o más variables y usa la acción masiva **Marcar como predeterminado**.
+
+Las variables del widget no tienen esta dimensión: guardan un solo valor, sin idioma.
+
+:::tip Tip
+El **Nombre** solo se puede editar desde el valor marcado como por defecto. Si abres la variable en otro idioma, el campo aparece deshabilitado.
+:::
+
+## Activar y desactivar una variable
+
+Puedes desactivar una variable sin borrarla. Selecciona una o más variables en el listado y usa la acción masiva **Desactivar**. Para revertirlo, cambia el filtro **Activo** a **No**, selecciona las variables y usa **Activar**.
+
+Mientras una variable está desactivada:
+
+- No se puede editar. Al abrirla verás el aviso "Esta variable está desactivada. Si quieres modificarla, debes activarla primero" y el botón de guardar pasa a ser **Activar**.
+- Deja de estar disponible en Liquid: las plantillas que la usan pasan a recibir una cadena vacía.
+
+## El listado de variables
+
+En las pantallas de cuenta y de aplicación, el listado muestra una fila por variable con su **Estado**, **Nombre**, **Valor**, si es el valor **Por defecto** y un botón que copia su **Código de Liquid**.
+
+La columna **Estado** usa estos indicadores:
+
+- **Traducida** o **No traducida**, según si la variable tiene un valor cargado en el idioma por el que estás filtrando.
+- **No sobrescrita**, en la pantalla de la aplicación, cuando la variable viene de la cuenta y esta aplicación todavía no le da un valor propio.
+- **Sobrescrita**, cuando la variable existe también en un alcance superior y aquí se le está dando otro valor.
+
+Para acotar el listado tienes los filtros **Idioma**, **Activo** y **Traducción**, este último con las opciones **Traducida** y **No traducida**. En la pantalla de la aplicación se suma el filtro **Sobrescrita**. El buscador filtra por identificador. Por defecto solo se listan las variables activas del idioma de la aplicación.
+
+En la pestaña **Variables** de la definición de un widget verás además el indicador **En uso**, que marca las variables que el código del widget realmente referencia.
+
+## Consumir una variable desde Liquid
+
+Para leer una variable desde cualquier lugar que acepte Liquid markup, usa <code v-pre>vars.identificador</code>, donde el identificador es el que aparece en **Nombre**. El botón de la columna **Código de Liquid** copia la expresión completa lista para pegar en una plantilla.
+
+Al renderizar, Modyo superpone tres capas de valores y gana la última:
+
+1. El valor marcado como por defecto de cada variable.
+2. El valor del idioma configurado en la aplicación.
+3. El valor del idioma activo de la solicitud que se está renderizando.
+
+Sobre ese resultado se aplica la herencia entre alcances: cuenta, luego aplicación y por último widget.
+
+:::tip Tip
+Si el identificador no existe en ningún alcance, o si la variable está desactivada, <code v-pre>vars.identificador</code> devuelve una cadena vacía y el render continúa: no se levanta un error ni se interrumpe la página. Tenlo presente cuando el valor de una variable desaparece de una plantilla sin dar señales.
+:::
+
+## Cambiar el identificador de una variable
+
+El **Nombre** de una variable ya creada está bloqueado. Para editarlo tienes que desbloquear el campo con **Habilitar campo identificador** y confirmar el aviso.
 
 :::warning Atención
-Cuando uses las variables globales, siempre se tomará como preferencia las variables definidas en el nivel más bajo (primero las definidas en el widget, luego las definidas en el sitio y, por último, las definidas a nivel de cuenta). Por lo tanto, debes ser cuidadoso al definir variables en widgets o el sitio con el mismo nombre que las variables de la cuenta.
+Cambiar el identificador rompe todas las referencias que ya usan esa variable: plantillas, widgets, contenidos, la API y los SDK dejan de encontrarla y pasan a recibir una cadena vacía. Si necesitas otro identificador, crea una variable nueva, actualiza las referencias y recién entonces elimina la anterior.
 :::
 
 :::danger Peligro


### PR DESCRIPTION
## Cambios propuestos

Cierra el gap **LIQUID-TAGS-15**, que unifica **LIQUID-TAGS-14** y **CHANNELS-21**: la página de Variables Globales mandaba al lector a un menú que no existe y describía la pantalla en una sola línea ("Rellena el **Nombre** y **Valor** de la variable"), dejando fuera todo lo que hace realmente falta para parametrizar un tema sin tocar código.

### docs/es/platform/channels/global-variables.md y docs/en/platform/channels/global-variables.md

Se corrige la ubicación y se completa la ficha de la pantalla:

- **Alcances de las variables**: sección nueva. Las variables globales de la cuenta no viven en Configuración sino en el menú de Channels, en la opción **Variables** (`/admin/channels/global_variables`). Además se documenta la segunda pantalla que la página nunca mencionó: **Configuración de la aplicación** > **Variables de la aplicación** dentro de cada aplicación web. Los tres alcances (cuenta, aplicación y widget) quedan distinguidos con su ubicación y su enlace a la página que los detalla.
- **Crear una variable global**: los pasos apuntan al menú real y se explica que el campo **Nombre** se slugifica mientras escribes y que ese resultado *es* el identificador con el que se consume la variable desde Liquid; no hay un título visible aparte de la clave.
- **Valores por idioma**: sección nueva. Una variable guarda un valor por idioma y los idiomas admitidos son solo tres, **Español**, **Inglés** y **Portugués**; cualquier otro se rechaza. Se explica cómo cambiar de idioma desde el selector de la ventana, que exactamente un valor queda marcado como valor por defecto y es el que se devuelve cuando se accede sin idioma resuelto, y cómo moverlo con la acción masiva **Marcar como predeterminado**, incluido el detalle no evidente de que promueve el idioma que tengas puesto en el filtro **Idioma**.
- **Activar y desactivar una variable**: sección nueva. Acciones masivas **Desactivar** y **Activar**, el aviso que bloquea la edición mientras está desactivada, y el efecto observable: la variable deja de estar disponible en Liquid.
- **El listado de variables**: sección nueva. Columnas **Estado**, **Nombre**, **Valor**, **Por defecto** y **Código de Liquid**; los indicadores **Traducida** / **No traducida**, **Sobrescrita** / **No sobrescrita** y **En uso**; y los filtros **Idioma**, **Activo**, **Traducción** y **Sobrescrita**, con la aclaración de que por defecto solo se listan las variables activas del idioma de la aplicación.
- **Consumir una variable desde Liquid**: sección nueva, el contrato que faltaba. Se documenta que la lectura devuelve una cadena vacía y el render continúa cuando el identificador no existe o la variable está desactivada, sin error ni interrupción, y la precedencia real por idioma: gana el idioma activo de la solicitud, luego el idioma configurado en la aplicación y por último el valor marcado por defecto, encadenado con la herencia cuenta > aplicación > widget.
- **Cambiar el identificador de una variable**: sección nueva con la advertencia que la propia UI muestra al desbloquear el campo, que hasta ahora no estaba escrita en ninguna parte: cambiar el identificador rompe todas las referencias existentes en plantillas, contenidos, API y SDK.
- En el tip de la cabecera, el marcador pasa de `vars.Nombre` a `vars.identificador`, que es lo que la plataforma copia con el botón de **Código de Liquid**.

No se modifica `docs/.vuepress/config.js`: la página ya está registrada en el sidebar de Channels en los dos idiomas.

## Para el revisor

1. **Precedencia por idioma, corregida respecto del hallazgo original.** El hallazgo la tenía invertida. En `app/models/concerns/modyo/global_variabilizable.rb:49` la expresión es `default_hash_vars(default_lang).merge(localizable_hash_vars(lang))`, y dentro de `default_hash_vars` es `vars_to_hash(get_vars(default: true)).merge(vars_to_hash(get_vars(lang: default_lang)))`. O sea que el valor marcado por defecto es la capa más débil, no la más fuerte, y el idioma activo de la solicitud gana. La página lo dice en ese orden.

2. **"Idioma por defecto" no es un campo de la pantalla.** El hallazgo listaba un campo **Idioma por defecto**. Las claves `admin.global_vars.column.default` y `admin.global_vars.help_default` siguen en los locales pero ninguna vista de master las usa. Lo que la pantalla ofrece de verdad es el filtro **Idioma**, la columna **Por defecto** con Si/No y la acción masiva **Marcar como predeterminado**, y eso es lo que documenté. No inventé la etiqueta.

3. **El formato del listado de valores del widget no se repite aquí.** El punto del hallazgo sobre "un valor por línea y un asterisco en el valor por defecto" ya está escrito en `docs/es/platform/channels/widgets.md`, en la sección **Variables del Widget**. En vez de duplicarlo, la página nueva enlaza a esa sección y solo agrega lo que allí falta: que las variables de widget no tienen dimensión de idioma, porque se guardan siempre con un único valor.

4. **"En uso" pertenece a la pestaña del widget, no al listado.** El indicador sale de `WidgetParametersTab.js:17`, que es la pestaña **Variables** de la definición del widget, no de `GlobalVariableIndex`. Lo documenté con ese alcance explícito para no sugerir que aparece en el listado de cuenta.

5. **"Channels" sin negrita, siguiendo la página vecina.** `admin.channels.label` es "Canales" en `es.yml`, pero el corpus entero (incluida `global-snippets.md`, la página hermana en el mismo directorio) escribe "Channels" sin negrita para el módulo. Mantuve esa forma y reservé la negrita para las etiquetas que sí verifiqué palabra por palabra en los locales: **Variables**, **Configuración de la aplicación**, **Variables de la aplicación**, **Nueva Variable**, **Nombre**, **Valor**, **Guardar**, **Estado**, **Por defecto**, **Código de Liquid**, **Idioma**, **Activo**, **Traducción**, **Traducida**, **No traducida**, **Sobrescrita**, **No sobrescrita**, **En uso**, **Desactivar**, **Activar**, **Marcar como predeterminado** y **Habilitar campo identificador**.

6. **Sigue existiendo una página duplicada.** `docs/es/platform/channels/global-variables.md` y `docs/es/platform/core/global-variables.md` compiten por el mismo tema, y la de `core/` todavía dice "Puedes crear variables globales en la configuración de la cuenta", con el mismo error de ubicación que este PR corrige. No la toqué porque está fuera del alcance de la tanda, pero conviene resolver el duplicado en otra: o se borra y se redirige, o se reduce a un enlace.

7. **El :::danger Peligro final se conserva tal cual.** No entra en el diff; solo cambia de vecino, porque ahora cierra la página después de la sección del identificador.

8. **Diferencias entre `releases/10.2-stable` y `origin/master`.** Verifiqué en `origin/master` cada afirmación de la página: la ruta bajo `scope :channels`, el ítem `menu_label`, la pantalla de settings del sitio, `LANGUAGES = %w[en es pt]`, `ensure_uniq_default`, `active_variables`, `get_data_value` devolviendo `''`, el `liquid_markup` del serializer y los filtros del índice. No encontré nada que invalide el gap ni que cambie lo redactado.

## Para el revisor

**Anclajes.** Simulé las cuatro ediciones con `assert t.count(old_string) == 1` acumulando en orden sobre cada archivo: las cuatro son únicas hoy y ninguna depende del resultado de otra. El archivo resultante no deja `{{` ni `{%` fuera de `v-pre`, no tiene tabulaciones ni espacios no separables, y todos los encabezados quedan en H1/H2 sin dos puntos finales.

**Divergencias entre la ficha y `origin/master`.** Tres, todas resueltas documentando lo de master:
1. La ficha listaba un campo **Idioma por defecto** en la pantalla. Las claves `admin.global_vars.column.default` y `help_default` existen en los locales pero están muertas: ninguna vista de master las renderiza. En su lugar documenté lo que sí existe (filtro **Idioma**, columna **Por defecto**, acción masiva **Marcar como predeterminado**). No inventé la etiqueta ausente.
2. La ficha decía que "el identificador que se usa en la plantilla no es el nombre visible sino la clave". En master no hay dos campos: el campo etiquetado **Nombre** se slugifica en vivo y ese es el identificador (`GlobalVariableModal.js:132-145`). Lo redacté así, que es más preciso y evita que el lector busque un campo que no está.
3. La ficha citaba la validación como "El idioma %{value} no esta disponible". El literal real lleva tilde ("no está disponible") y sale por API, no por la UI, que solo ofrece los tres idiomas en un selector. Preferí no pegar el string con interpolación y decir en prosa que solo hay tres idiomas admitidos.

**Punto ya documentado en el corpus.** El punto (5) del hallazgo (un valor por línea, asterisco en el valor por defecto) ya está escrito en `docs/es/platform/channels/widgets.md`, sección **Variables del Widget**, y en su espejo en inglés. No lo repetí: enlazo a esa sección y solo agrego lo que allí falta, que las variables de widget no tienen valores por idioma. El gap no se salta por esto, porque los otros seis puntos sí eran nuevos.

**PRs abiertos.** Ninguno de los 12 toca `global-variables.md`. El #1010 agrega la fila `vars` a la tabla de contexto de `liquid-markup/variables.md` y enlaza a esta página: no repito esa tabla, esta página es el destino. El #1004 toca `sites.md` y `widgets.md` solo por CLI y no cambia las anclas `#variables-del-sitio` / `#site-variables` ni `#variables-del-widget` / `#widget-variables`, que verifiqué que existen hoy en los cuatro archivos.

**Etiqueta "Channels" vs "Canales".** `admin.channels.label` es "Canales" en `es.yml`, pero todo el corpus, incluida la página hermana `global-snippets.md` del mismo directorio, escribe "Channels" sin negrita. Seguí el corpus y dejé "Channels" sin negrita, reservando la negrita solo para etiquetas verificadas literalmente. Es la única desviación consciente de la regla de citar `es.yml`; si la revisora prefiere **Canales**, es un cambio de dos líneas.

**Página duplicada fuera de alcance.** `docs/es/platform/core/global-variables.md` sigue diciendo "Puedes crear variables globales en la configuración de la cuenta", el mismo error de ubicación que este PR corrige en `channels/`. No la edité porque la tanda declara una sola página, pero queda un duplicado que ahora se contradice con la página buena. Conviene una tanda que la borre o la reduzca a un enlace.

**Enlace a `sites.md`.** La sección **Variables del sitio** a la que enlazo todavía dice "En **Configuración del sitio**, haz click en **Variables del Sitio**", etiquetas que en master ya no existen. Corregí la ubicación en mi página, pero el enlace lleva a una sección que aún la tiene mal. No toqué `sites.md` porque está fuera de la tanda y además la está tocando el PR abierto #1004.

**Permisos.** No documenté permisos aunque existen agrupados y verificados (**Ver Variables Globales** / **Administrar Variables Globales** en el grupo de organización, y **Ver Variables de Aplicación** / **Administrar Variables de la Aplicación** en el grupo de Canales). El hallazgo no los pide y hay solapamiento con `view_variables` / `admin_variables`, que apuntan a las mismas acciones desde otro grupo; documentarlos sin desambiguar ese solapamiento habría sido más confuso que útil, y además pisa terreno de la página de roles.

**Directiva de producto.** La tanda no toca páginas de soporte ni el módulo Soporte en ningún punto, así que no hubo nada que omitir.

## Validación

Docker está caído en el entorno, así que la validación fue estática: diff sin `{{ }}` ni `{% %}` fuera de bloques de código, sin encabezados terminados en dos puntos y con los anclajes de los links nuevos comprobados contra los títulos de destino. El build queda confiado al CI de este PR.

Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)
