### PR TITLE
Completar la documentación de Entradas: filtros por autor, segmentos y campos del tipo, acciones masivas de tags, restaurar y borrar, programación de publicación, clonado y extracto

### DIFF
--- a/docs/en/platform/content/entries.md
+++ b/docs/en/platform/content/entries.md
@@ -27,14 +27,33 @@ You can also filter the view with predefined filters:
 
 - **Type**: Content [type](/en/platform/content/types).
 - **Status**: Draft, Published, Scheduled, or Archived.
-- **Category**: Category assigned to entries.
+- **Category**: Category assigned to entries. The result also includes the entries assigned to the subcategories of the category you choose.
 - **Language**: Content language.
 - **Translation**: Entry translation status. If an entry has no version in the selected language, it is considered "not translated".
 - **Tags**: Labels available in the account.
+- **Author**: Administrator who created the entry. The list only offers the users who have at least one entry in the space.
+- **Segments**: Segments assigned to the entries. This filter only appears when the space is associated with a user realm.
 - **Search bar**: Type a word to display entries that contain that word in their name or metadata.
 
 :::tip Tip
 Click on the Filters menu in the upper right of the entry list to add or remove any of the filtering options in the header.
+:::
+
+### Type field filters
+
+When you filter the list by **Type**, a **Type fields filters** block appears below the common filters, with one filter for each filterable field of the type you chose. With them you narrow the list down to the entries that hold a given value in one of their fields.
+
+Only eight field types can be used as a filter: **Boolean**, **Checkbox**, **Date**, **Decimal**, **Dropdown**, **Integer**, **Multiple options**, and **Radio**. The remaining field types of the content type do not appear in the block.
+
+Each filter adapts to the field it represents:
+
+- **Date**: filters by a date range.
+- **Integer** and **Decimal**: filter by a numeric comparison.
+- **Boolean**: filters by True or False.
+- **Checkbox**, **Dropdown**, **Multiple options**, and **Radio**: filter by the **Allowed values** you defined in the field. In **Checkbox** and in **Multiple options** you can select more than one value at a time.
+
+:::tip Tip
+The block only exists while the **Type** filter is active, because each content type defines its own fields. If you change or remove the **Type** filter, the field filters are discarded.
 :::
 
 
@@ -59,10 +78,17 @@ By using bulk editing of entries, you are overwriting the values for the selecte
 To retrieve a specific value from an entry, access the entry editing view and select the **Differences** option to review the previous values of an entry.
 :::
 
+- **Add or remove tags**: Opens a window to change the tags of the whole selection. In **Add new tags** you type or pick the tags you want to add, and under **Tags among selected elements** you see the tags those entries already have, with the number of entries that use each one: **Apply to all** adds that tag to the rest of the selection and the delete icon removes it from all of them. Click **Save** and confirm to apply the changes.
 - **Publish**: Publishes selected entries that have pending changes or are in draft status.
 - **Force publication**: If team review is enabled, space administrators can use this action to force the publication of entries that have pending changes or are in draft status, without having to go through the review process.
 - **Unpublish**
 - **Archive**: Bulk archiving only affects selected entries that are not published. If you try to archive a published entry, the action will have no effect.
+- **Restore**: Takes the selected entries out of the archive and returns them to draft status. It only reaches archived entries, so it is worth filtering the list by the **Archived** status before using it.
+- **Delete**: Deletes the archived entries in the selection. It requires the **Delete Entries** permission.
+
+:::danger Danger
+**Delete** removes the selected entries along with all their backups, and it cannot be undone. The deletion only reaches the language you have selected in the list: the translations of those entries into other languages are kept.
+:::
 
 :::tip Tip
 Bulk actions run in the background, and you may not see the changes immediately. You will need to wait a moment and refresh your view after executing a bulk action.
@@ -176,6 +202,34 @@ To unpublish:
 1. Click **Unpublish**.
 
 
+### Schedule the publication of an entry
+
+Instead of publishing right away, you can set the date and time when the entry shows up on your sites and, in the same window, the date when it stops being visible.
+
+1. In the side menu, select Content.
+1. Click on your space.
+1. Select Entries.
+1. From the list of entries, click on the entry you want to schedule.
+1. At the top of the screen, click **Publish** to open the **Publish Options** window.
+1. Check **Publish on** and choose the date and time in **Select a date**.
+1. If you also want the entry to stop being visible on a given date, check **Unpublish on** and choose the date and time.
+1. Click **Schedule publication**.
+
+Once you confirm, the entry keeps a scheduled version and shows up in the list with the **Scheduled** status. You can keep working on its editable version without altering what was scheduled.
+
+Consider the following:
+
+- Each entry allows a single scheduled publication per language. If you schedule a second publication, the window warns you with "You are going to override the current scheduled publication" and the new one replaces the previous one.
+- If you choose **Publish now** when there is already a scheduled publication, the window warns you with "The scheduled publication will be cancelled": once you confirm, the entry is published immediately and the schedule is discarded.
+- If you choose a publication date that has already passed, the entry is published immediately instead of being scheduled.
+- The unpublish date cannot be in the past. If you try, Modyo rejects the operation with the message "The scheduled unpublish date can't be in the past".
+
+To schedule only the unpublishing of an entry that is already published, click **Unpublish** at the top of the screen, check **Unpublish on** in the **Unpublish Options** window, choose the date and time, and confirm with **Schedule unpublish**.
+
+:::tip Tip
+The full behavior of the scheduled version, including the notification you get when the action runs, is in the [versioning](/en/platform/core/#versioning) section.
+:::
+
 ### Delete entries
 
 To delete an entry:
@@ -223,6 +277,32 @@ To edit an entry, follow these steps:
 1. Modify the fields you require.
 1. Click **Save**.
 1. Click **Publish**. If the entry is undergoing team review, reviewers should update their view to note the changes.
+
+
+### Clone an Entry
+
+**Clone** creates a new entry from the one you are viewing, with the same values in all of its fields, its tags, and its segments, and it also replicates the translations that already exist.
+
+1. In the side menu, select Content.
+1. Click on your space.
+1. Select Entries.
+1. From the list of entries, click on the entry you want to clone.
+1. Click on the more actions button (...) and select **Clone**.
+
+When the copy is done, Modyo takes you to the new entry. Consider the following:
+
+- The copy is born in draft status: to make it show up on your sites you have to publish it.
+- The copy is an independent entry. Its name becomes "Copy of" followed by the original name, and its identifier is generated with the `copy-of-` prefix, so the references to the original entry from the API or the SDKs keep pointing to the original.
+- The author of the copy is the user who runs the action, not the author of the original entry.
+- The action requires the **Clone Entries** permission.
+
+:::warning Attention
+When you clone, you are redirected to the new entry, so save the pending changes of the current entry before using this action.
+:::
+
+:::tip Tip
+Do not confuse **Clone** with **Copy from Language**: **Copy from Language** brings the content of another translation into the entry you are editing and does not create a new entry.
+:::
 
 
 ## Categories
@@ -276,6 +356,13 @@ If you delete a parent category, all subcategories associated with it will be de
 Tags allow you to add more detail to your entries by combining them with Liquid on your content pages.
 
 When creating entries, you can add a tag that will appear both in the source code and in our content API, allowing you to add specific functionality to that tag.
+
+
+### Excerpt
+
+The excerpt is a short summary of the entry. You edit it in the **Properties** panel of the editing view, next to the category and the tags, and it allows up to 255 characters.
+
+Unlike fields, the excerpt is not defined in the content type: it is available in every entry without you having to create it. It is published along with the entry, and you retrieve it in `meta.excerpt` in the content API, or with `entry.meta.excerpt` in Liquid.
 
 
 ### Identifier

--- a/docs/es/platform/content/entries.md
+++ b/docs/es/platform/content/entries.md
@@ -28,7 +28,7 @@ También puedes filtrar la vista con filtros predeterminados:
 - **Tipo**: [Tipo](/es/platform/content/types) de contenido.
 - **Estado**: Borrador, publicado, programado y archivado.
 - **Categoría**: Categoría asignada a las entradas. El resultado incluye también las entradas asignadas a las subcategorías de la categoría que elijas.
-- **Idioma** Idioma del contenido.
+- **Idioma**: Idioma del contenido.
 - **Traducción**: Estado de traducción de la entrada. Si una entrada no tiene versión en el idioma seleccionado, se considera "no traducida".
 - **Tags**: Etiquetas disponibles en la cuenta.
 - **Autor**: Administrador que creó la entrada. La lista solo ofrece a los usuarios que tienen al menos una entrada en el espacio.

--- a/docs/es/platform/content/entries.md
+++ b/docs/es/platform/content/entries.md
@@ -27,14 +27,33 @@ También puedes filtrar la vista con filtros predeterminados:
 
 - **Tipo**: [Tipo](/es/platform/content/types) de contenido.
 - **Estado**: Borrador, publicado, programado y archivado.
-- **Categoría**: Categoría asignada a las entradas.
+- **Categoría**: Categoría asignada a las entradas. El resultado incluye también las entradas asignadas a las subcategorías de la categoría que elijas.
 - **Idioma** Idioma del contenido.
 - **Traducción**: Estado de traducción de la entrada. Si una entrada no tiene versión en el idioma seleccionado, se considera "no traducida".
 - **Tags**: Etiquetas disponibles en la cuenta.
+- **Autor**: Administrador que creó la entrada. La lista solo ofrece a los usuarios que tienen al menos una entrada en el espacio.
+- **Segmentos**: Segmentos asignados a las entradas. Este filtro aparece solo cuando el espacio está asociado a un reino de usuarios.
 - **Barra de búsqueda**: Filtra por el contenido del título de las entradas.
 
 :::tip Tip
 Da click en el menú de Filters en la parte superior derecha de la lista de entradas para agregar o eliminar cualquiera de las opciones de filtrado del encabezado.
+:::
+
+### Filtros por campos del tipo
+
+Cuando filtras el listado por **Tipo**, debajo de los filtros comunes aparece el bloque **Filtros de campos de contenido**, con un filtro por cada campo filtrable del tipo que elegiste. Con ellos acotas el listado a las entradas que tienen un valor determinado en uno de sus campos.
+
+Solo ocho tipos de campo se pueden usar como filtro: **Booleano**, **Checkbox**, **Decimal**, **Dropdown**, **Entero**, **Fecha**, **Opciones múltiples** y **Radio**. Los demás tipos de campo del tipo de contenido no aparecen en el bloque.
+
+Cada filtro se adapta al campo que representa:
+
+- **Fecha**: filtra por un rango de fechas.
+- **Entero** y **Decimal**: filtran por una comparación numérica.
+- **Booleano**: filtra por True o False.
+- **Checkbox**, **Dropdown**, **Opciones múltiples** y **Radio**: filtran por los **Valores permitidos** que definiste en el campo. En **Checkbox** y en **Opciones múltiples** puedes marcar más de un valor a la vez.
+
+:::tip Tip
+El bloque solo existe mientras el filtro de **Tipo** esté activo, porque cada tipo de contenido define sus propios campos. Si cambias o quitas el filtro de **Tipo**, los filtros por campo se descartan.
 :::
 
 
@@ -59,10 +78,17 @@ Al usar la edición masiva de entradas estás sobreescribiendo los valores para 
 Para recuperar un valor específico de una entrada, accede a la vista de edición de entradas y selecciona la opción **Diferencias** para revisar los valores previos de una entrada.
 :::
 
+- **Agregar o quitar tags**: Abre una ventana para modificar los tags de toda la selección. En **Añadir nuevos tags** escribes o eliges los tags que quieres sumar, y bajo **Tags en los elementos seleccionados** ves los tags que ya tienen esas entradas, con la cantidad de entradas que usa cada uno: **Aplicar a todas** suma ese tag al resto de la selección y el ícono de eliminar lo quita de todas. Da click en **Guardar** y confirma para aplicar los cambios.
 - **Publicar**:  Publica las entradas seleccionadas que tengan cambios pendientes o estén en estado borrador.
 - **Forzar publicación**: Si está habilitada la revisión en equipo, los administradores del espacio pueden usar esta acción para forzar la publicación de entradas que tienen cambios pendientes o estén en estado borrador, sin necesidad de pasar por el proceso de revisión.
 - **Despublicar**
 - **Archivar**: Archivar en masa solo tiene efecto en las entradas seleccionadas que no estén publicadas. Si intentas archivar una entrada publicada, la acción no tendrá efecto.
+- **Restaurar**: Saca del archivo las entradas seleccionadas y las devuelve al estado borrador. Solo alcanza a las entradas archivadas, así que conviene filtrar el listado por el estado **Archivado** antes de usarla.
+- **Borrar**: Elimina las entradas archivadas de la selección. Requiere el permiso **Eliminar Entradas**.
+
+:::danger Peligro
+**Borrar** elimina las entradas seleccionadas junto con todos sus respaldos y no se puede deshacer. El borrado alcanza solo al idioma que tienes seleccionado en el listado: las traducciones de esas entradas a otros idiomas se conservan.
+:::
 
 :::tip Tip
 Las acciones masivas se ejecutan en segundo plano y es posible que no veas los cambios inmediatamente, por lo que deberás esperar un momento y refrescar la vista luego de ejecutar una acción masiva.
@@ -176,6 +202,34 @@ Para despublicar:
 1. Haz click en **Despublicar**.
 
 
+### Programar la publicación de una entrada
+
+En lugar de publicar de inmediato, puedes fijar la fecha y la hora en que la entrada aparece en tus sitios y, en la misma ventana, la fecha en que deja de estar visible.
+
+1. En el menú lateral, selecciona Content.
+1. Haz click en tu espacio.
+1. Selecciona Entradas.
+1. Del listado de entradas, da click en la entrada que quieres programar.
+1. En la parte superior de la pantalla, haz click en **Publicar** para abrir la ventana **Opciones de Publicación**.
+1. Marca **Publicar en** y elige la fecha y la hora en **Selecciona una fecha**.
+1. Si además quieres que la entrada deje de estar visible en una fecha determinada, marca **Despublicar en** y elige la fecha y la hora.
+1. Haz click en **Programar publicación**.
+
+Al confirmar, la entrada queda con una versión programada y aparece en el listado con el estado **Programado**. Puedes seguir trabajando en su versión editable sin alterar lo que quedó programado.
+
+Ten en cuenta:
+
+- Cada entrada admite una sola publicación programada por idioma. Si programas una segunda publicación, la ventana te advierte con "Vas a sobreescribir la actual publicación programada" y la nueva reemplaza a la anterior.
+- Si eliges **Publicar ahora** cuando ya hay una publicación programada, la ventana te advierte con "La publicación programada será cancelada": al confirmar, la entrada se publica de inmediato y la programación se descarta.
+- Si eliges una fecha de publicación que ya pasó, la entrada se publica de inmediato en lugar de quedar programada.
+- La fecha de despublicación no puede estar en el pasado. Si lo intentas, Modyo rechaza la operación con el mensaje "La fecha de despublicación programada no puede estar en el pasado".
+
+Para programar solo la despublicación de una entrada que ya está publicada, haz click en **Despublicar** en la parte superior de la pantalla, marca **Despublicar en** en la ventana **Opciones de despublicación**, elige la fecha y la hora, y confirma con **Programar despublicación**.
+
+:::tip Tip
+El comportamiento completo de la versión programada, incluida la notificación que recibes cuando la acción se ejecuta, está en la sección de [versionado](/es/platform/core/#versionado).
+:::
+
 ### Eliminar entradas
 
 Para eliminar una entrada:
@@ -223,6 +277,32 @@ Para editar una entrada, sigue estos pasos:
 1. Modifica los campos que requieras.
 1. Da click en **Guardar**.
 1. Da click en **Publicar**.  Si la entrada está en proceso de revisión en equipo, los revisores deberán actualizar su vista para notar los cambios.
+
+
+### Clonar una entrada
+
+**Clonar** crea una entrada nueva a partir de la que estás viendo, con los mismos valores en todos sus campos, sus tags y sus segmentos, y replica también las traducciones que ya existan.
+
+1. En el menú lateral, selecciona Content.
+1. Haz click en tu espacio.
+1. Selecciona Entradas.
+1. Del listado de entradas, da click en la entrada que quieres clonar.
+1. Haz click en el botón de más acciones (...) y selecciona **Clonar**.
+
+Cuando la copia termina, Modyo te lleva a la entrada nueva. Ten en cuenta:
+
+- La copia nace en estado borrador: para que aparezca en tus sitios tienes que publicarla.
+- La copia es una entrada independiente. Su nombre queda como "Copia de" seguido del nombre original y su identificador se genera con el prefijo `copy-of-`, así que las referencias a la entrada original desde la API o los SDKs siguen apuntando a la original.
+- El autor de la copia es el usuario que ejecuta la acción, no el autor de la entrada original.
+- La acción requiere el permiso **Clonar Entradas**.
+
+:::warning Atención
+Al clonar serás redirigido a la entrada nueva, así que guarda los cambios pendientes de la entrada actual antes de usar esta acción.
+:::
+
+:::tip Tip
+No confundas **Clonar** con **Copiar desde idioma**: **Copiar desde idioma** trae el contenido de otra traducción a la entrada que estás editando y no crea una entrada nueva.
+:::
 
 
 ## Categorías
@@ -276,6 +356,13 @@ Si eliminas una categoría padre, se eliminarán todas las subcategorías asocia
 Los tags permiten agregar mayor detalle a tus entradas al combinarlos con Liquid en tus páginas de contenido.
 
 Al crear entradas, puedes agregar un tag que aparecerá tanto en el código fuente como en nuestra API de contenido, permitiéndote agregar funcionalidades específicas a ese tag.
+
+
+### Extracto
+
+El extracto es un resumen breve de la entrada. Lo editas en el panel **Propiedades** de la vista de edición, junto a la categoría y a los tags, y admite hasta 255 caracteres.
+
+A diferencia de los campos, el extracto no se define en el tipo de contenido: está disponible en todas las entradas sin que tengas que crearlo. Se publica junto con la entrada y lo recuperas en `meta.excerpt` en la API de contenido, o con `entry.meta.excerpt` en Liquid.
 
 
 ### Identificador


### PR DESCRIPTION
## Cambios propuestos

Completa la documentación del listado y de la vista de edición de Entradas con lo que el panel ya ofrece y la documentación no recogía: tres filtros, tres acciones masivas, la programación de publicación y despublicación, la acción de clonar y la propiedad Extracto.

### `docs/es/platform/content/entries.md` y `docs/en/platform/content/entries.md`

**Filtros del listado (CONTENT-07)**

- Se agregan los filtros **Autor** (solo ofrece administradores que tienen al menos una entrada en el espacio) y **Segmentos** (aparece únicamente cuando el espacio está asociado a un reino de usuarios).
- Se precisa que el filtro **Categoría** trae también las entradas asignadas a sus subcategorías.
- Nueva sección **Filtros por campos del tipo**: describe el bloque **Filtros de campos de contenido** que aparece al filtrar por **Tipo**, enumera los ocho tipos de campo filtrables (**Booleano**, **Checkbox**, **Decimal**, **Dropdown**, **Entero**, **Fecha**, **Opciones múltiples** y **Radio**), aclara que los demás tipos de campo no se pueden usar como filtro y detalla cómo se comporta cada uno (rango de fechas, comparación numérica, True/False, valores permitidos).

**Acciones masivas (CONTENT-08)**

- Se documentan las tres acciones que faltaban: **Agregar o quitar tags**, con el recorrido del modal (**Añadir nuevos tags**, **Tags en los elementos seleccionados**, **Aplicar a todas**); **Restaurar**, que devuelve las entradas archivadas al estado borrador; y **Borrar**, que requiere el permiso **Eliminar Entradas**.
- Se añade un callout `:::danger` que advierte que el borrado masivo elimina también los respaldos, no se puede deshacer y alcanza solo al idioma seleccionado, conservando las traducciones a otros idiomas.

**Programar la publicación de una entrada (CONTENT-09)**

- Nueva sección con el paso a paso de la ventana **Opciones de Publicación**: **Publicar en**, **Selecciona una fecha**, **Despublicar en** y **Programar publicación**.
- Se explica el comportamiento asociado: la entrada queda con una versión programada y estado **Programado**, solo se admite una publicación programada por idioma, publicar de inmediato cancela la programación previa, una fecha pasada publica al instante y la despublicación programada rechaza fechas en el pasado.
- Se agrega el camino corto para programar solo la despublicación desde la ventana **Opciones de despublicación**, y un enlace a la sección de versionado de Core para el comportamiento general de la versión programada.

**Clonar una entrada (CONTENT-18)**

- Nueva sección con los pasos de la acción **Clonar** del menú de más acciones, que replica campos, tags, segmentos y todas las traducciones existentes.
- Se aclara que la copia nace en borrador, que es una entrada independiente cuyo nombre lleva el prefijo "Copia de" y cuyo identificador se genera con el prefijo `copy-of-`, que el autor pasa a ser quien ejecuta la acción y que requiere el permiso **Clonar Entradas**.
- Se agrega un aviso de que la acción redirige a la entrada nueva y una nota que la distingue de **Copiar desde idioma**, que ya estaba documentada y no crea una entrada nueva.

**Extracto (CONTENT-19)**

- Nueva propiedad **Extracto** junto a Tags e Identificador: dónde se edita (panel **Propiedades**), su límite de 255 caracteres, que no se define en el tipo de contenido y que se recupera en `meta.excerpt` desde la API de contenido y como `entry.meta.excerpt` en Liquid.

Cierra los gaps CONTENT-07, CONTENT-08, CONTENT-09, CONTENT-18 y CONTENT-19.

## Para el revisor

1. **CONTENT-19 queda a medias por alcance de la tanda.** La ficha pedía dos bullets: el **Extracto** de la entrada (entries.md) y el campo **Descripción** de la configuración General del espacio (spaces.md:49-64, textarea con tope de 4095 caracteres, `SpaceGeneralSettings.js:26-33`). La tanda declara como página únicamente `docs/es/platform/content/entries.md`, así que documenté solo el Extracto y no toqué spaces.md. El bullet de **Descripción** sigue pendiente y debería asignarse a la tanda que cubra spaces.md.

2. **El label real de la acción es "Clonar", no "Duplicar".** La ficha CONTENT-18 habla de "duplicar", pero el botón usa `admin.commons.clone` = "Clonar" / "Clone" (`EntryHeader.js:333`); la función JS se llama `duplicateEntry` y el endpoint es `copy`, pero nada de eso llega a la pantalla. Documenté el label del locale. Esto genera una diferencia deliberada con `channels/pages.md:40`, que llama "Duplicar" a la acción equivalente de páginas: ahí el label del panel sí es distinto y esa página además la está tocando el PR abierto #992, así que no la alineé.

3. **"Multiple options" contra "Multiple choice" en docs/en.** El label exacto de `admin.content.fields.multiple` en en.yml es "Multiple options" y así lo cité, pero `docs/en/platform/content/types.md:107` titula ese tipo de campo "Multiple choice". Preferí el locale por la regla de citación de labels; si se quiere consistencia interna habría que corregir types.md en otra tanda (es.yml y docs/es coinciden en "Opciones múltiples", ahí no hay conflicto).

4. **El label del filtro de idioma difiere entre locales.** El filtro usa `admin.content.locale`, que es "Idioma" en es.yml pero "Locale" en en.yml, mientras el bullet existente de docs/en lo llama "**Language**". Para no arrastrar el desajuste, en el callout `:::danger` del borrado masivo evité nombrar el filtro y escribí "el idioma que tienes seleccionado en el listado" / "the language you have selected in the list". El bullet preexistente lo dejé como está porque la tanda no lo pide.

5. **Visibilidad exacta de Restaurar y Borrar.** `EntryIndex.js:444-472` decide la visibilidad con una mezcla de estado del filtro y estado de las filas seleccionadas, y hay un caso (sin filtro de estado y sin selección total) en que el botón se muestra igual aunque la selección no tenga archivadas. Documenté el efecto observable y accionable ("solo alcanza a las entradas archivadas, conviene filtrar por **Archivado**") en vez de la regla de visibilidad del componente, que no es estable ni útil para el lector.

6. **Alcance del borrado masivo.** `entries_worker.rb:77-82` acota el `destroy_all` a `locale` y al estado archived, y la confirmación del panel lo dice explícitamente. Lo documenté como pérdida de datos con `:::danger`, que es el único uso de ese callout en la tanda.

7. **Módulo Soporte omitido.** La pantalla vacía del listado de entradas (`EntryIndex.js:325-336`) incluye un enlace `admin.commons.modyo_support` hacia el soporte de Modyo. Por la directiva de producto no lo mencioné en ninguna de las dos páginas.

8. **Sin internos de infraestructura.** Dejé fuera nombres de endpoint de administración, `Tasks::PublishTask`, los workers en background de las acciones masivas más allá del aviso ya existente, la columna `content_entries.excerpt` y la clase `FILTERABLE_FIELDS`. El tope de 255 caracteres del extracto se documenta porque es el `maxLength` visible del textarea, no porque sea el tipo de columna.

9. **Enlaces nuevos.** Agregué `/es/platform/core/#versionado` y `/en/platform/core/#versioning`, siguiendo la excepción de enlazar el índice del módulo con ruta de directorio. Ambos anclajes existen (`## Versionado` en `docs/es/platform/core/README.md:60` y `## Versioning` en `docs/en/platform/core/README.md:61`). Los enlaces preexistentes a `/es/platform/core/key-concepts` de la misma página no los toqué.

10. **Sin colisión con los PRs abiertos.** Ninguno de los 12 PRs abiertos de modyo-docs toca `content/entries.md` ni `core/README.md`, así que estas ediciones no dependen de contenido que ellos estén definiendo ni lo repiten.

## Validación

Docker está caído en el entorno, así que la validación fue estática: diff sin `{{ }}` ni `{% %}` fuera de bloques de código, sin encabezados terminados en dos puntos y con los anclajes de los links nuevos comprobados contra los títulos de destino. El build queda confiado al CI de este PR.

Closes #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)
