### PR TITLE
Documenta la mecánica del constructor de segmentos y corrige el catálogo de filtros

### DIFF
--- a/docs/en/platform/customers/segments.md
+++ b/docs/en/platform/customers/segments.md
@@ -10,7 +10,7 @@ In this section, you'll find a list of all created segments, along with key info
 
 - **Name**: The identifier of the segment (under which the filters that define it are listed).
 - **Created On**: The date the segment was created.
-- **People**: The number of users included in the segment.
+- **People**: The number of users included in the segment. If the segment has filters the platform can't process, a warning icon with the message **Segment could not be processed** appears instead of the number; edit the segment and fix its filters to get the count back.
 
 To search for a segment by name, use the search bar at the top of the screen.
 
@@ -18,13 +18,19 @@ To search for a segment by name, use the search bar at the top of the screen.
 
 To create a segment, follow these steps:
 
-- From the administration page, click **Customers**, then select **Realms**.
-- Click on your **Realm**.
-- Select **Segments** and click **New Segment**.
-- Add the required filters for your segment.
-- Click **Next**.
-- Enter a **Name** and a **Description**.
-- Click **Save**.
+1. From the administration page, click **Customers**, then select **Realms**.
+2. Click on your **Realm**.
+3. Select **Segments** and click **New Segment**.
+4. In the first row of the builder, choose **Users who match** or **Users who don't match**.
+5. Open the **Filter** selector and choose the data you want to evaluate.
+6. Fill in the fields that appear to the right: **Filterable** (the form, campaign, tag, or origination the filter applies to), **Operator**, **Value**, and **Condition**. Not every filter asks for all four.
+7. Add the rows and groups you need with the **OR** and **AND** buttons.
+8. Click **Count matches** to review how many users the segment reaches.
+9. Click **Next**.
+10. Enter a **Name** and a **Description**.
+11. Click **Save**.
+
+The **Next** button stays disabled while any row is incomplete: every filter needs its value, the ones that offer **Condition** need you to pick one, and ranges need both ends.
 
 :::tip Tip
 Make sure each customer's profile is complete, as incomplete data will prevent a user from being included in a segment based on those criteria.
@@ -34,40 +40,78 @@ Make sure each customer's profile is complete, as incomplete data will prevent a
 If your access to the realm is [restricted by segments](/en/platform/customers/settings.html#restrict-scope-with-segments), you cannot create new segments, since these start from the realm's entire universe of users. You can edit and delete the segments within your scope.
 :::
 
+### How filters are combined
+
+Each row of the builder is one filter, and it starts with a selector that decides whether it adds or subtracts users:
+
+- **Users who match**: includes the users who meet the row's condition.
+- **Users who don't match**: includes the users who don't meet it. Any filter can be inverted, not just some of them.
+
+Rows are organized into groups, and that is where the final result comes from:
+
+- Inside a group, rows are combined with **OR**: it is enough for the user to meet one of them. Use the **OR** button to add another row to the group.
+- Groups are combined with each other using **AND**: the user has to meet every group. Use the **AND** button to add a new group.
+
+So a group with **Gender** and another group with **Age** leave only the users who meet both conditions, while those same two rows inside a single group leave the users who meet either one.
+
+Some filters accept several values at once and also show a **Condition** selector:
+
+- **All**: the user must meet every value you selected.
+- **Any**: meeting one is enough.
+
+For example, in **User tag** with the `my_tag` and `my_other_tag` tags, **All** leaves only the users who have both and **Any** leaves the users who have at least one.
+
+:::tip Tip
+**Condition** only appears on the filters that accept several values, such as **User tag**, **Answered**, or **Submission status**. When it appears, it is required.
+:::
+
+### Matches preview
+
+Before saving, you can review the segment's reach. Click **Count matches**, at the bottom of the builder, and the screen shows you how many users meet the filters you have written so far. The number does not refresh on its own: every time you change a filter, ask for it again with the reload button next to the count.
+
+:::warning Attention
+The count is a preview calculated on the spot, and it neither creates nor saves the segment. If the count returns an error, review the filters before continuing.
+:::
+
 ## Filters
 
 Filters allow you to create segments based on user profile information and their activity on the site. You can include users who meet certain criteria or exclude those who do not.
 
 The default filters available on the platform include:
 
-- Activation status
-- Age
-- Submission status (of an origination)
-- Task status (of an origination)
-- Form responses
-- Birth date
-- Custom field value
-- Device
-- Delivered mail
-- Mail reported as spam
-- Form response count
-- Gender
-- Last login date
-- Log count
-- Login Date
-- Mail not opened
-- Count of opened mails
-- Seen notification
-- Count of opened notifications
-- Registration date
-- User Tags
-- User Field Values
-- Order Completed
-- Order failed
-- Order confirming
-- Order paid
-- Order paying
-- Order rejected
+- **Activation status**
+- **Age**
+- **Submission status** (of an origination)
+- **Task status** (of an origination)
+- **Answered**
+- **Birth date**
+- **Custom Field value**
+- **Login Device**
+- **Email delivered**
+- **Spam Email reported**
+- **Form responses count**
+- **Gender**
+- **Last login date**
+- **Log count**
+- **Login at date**
+- **Emails not opened**
+- **Emails opened count**
+- **Emails opened**
+- **Notifications opened**
+- **Notifications opened count**
+- **Registered date**
+- **User tag**
+- **User field values**
+- **Completed orders**
+- **Confirmation failed orders**
+- **Confirming orders**
+- **Paid orders**
+- **Paying orders**
+- **Rejected orders**
+
+Three of them work on the same data and are easy to mix up: **Emails opened** looks for the users who opened a specific campaign within a date range, **Emails not opened** for the ones who did not open it, and **Emails opened count** compares how many emails the user opened in total.
+
+Others work with a closed list of values: **Activation status** accepts **Activated** or **Deactivated**, and **Login Device** accepts **Desktop**, **Mobile**, or **Tablet**.
 
 To create an advanced filter that fits your needs, refer to the [Custom Fields](/en/platform/customers/settings#custom-fields) section.
 
@@ -80,6 +124,18 @@ The update of segments to which a user belongs is performed as a background proc
 
 The speed of the update depends on the system load, so some users might not see segmented content immediately after performing actions that include or exclude them from a segment.
 :::
+
+### Operators
+
+The operator a filter offers depends on the type of value it compares:
+
+- **Dates**, such as **Birth date**, **Registered date**, or **Login at date**: **Before**, **After**, **On**, and **Between**.
+- **Numbers**, such as **Age** or a numeric custom field: **Less than**, **Greater than**, **Equals**, and **Between**.
+- **Counts**, the filters that count events such as **Form responses count**, **Log count**, **Emails opened count**, and **Notifications opened count**: **Less than or equal to**, **Greater than or equal to**, **Equals**, and **Between**.
+
+Filters that work with a closed list of options, such as **Gender** or **Login Device**, do not ask for an operator: you pick the value directly.
+
+When you choose **Between**, the screen asks for two values and the second one has to be greater than the first. If it is not, the panel warns you with **Max value must be greater than min value** and the segment is not saved until you fix it.
 
 ### Origination filters
 

--- a/docs/es/platform/customers/segments.md
+++ b/docs/es/platform/customers/segments.md
@@ -113,7 +113,7 @@ Tres de ellos trabajan sobre el mismo dato y conviene no confundirlos: **Correos
 
 Otros trabajan con una lista cerrada de valores: **Estado de activación** acepta **Activado** o **Desactivado**, y **Dispositivo** acepta **Escritorio**, **Móvil** o **Tablet**.
 
-Para crear un filtro avanzado, que se ajuste a tus necesidades, , consulta la sección [Custom Fields](/es/platform/customers/settings#custom-fields).
+Para crear un filtro avanzado que se ajuste a tus necesidades, consulta la sección [Custom Fields](/es/platform/customers/settings#custom-fields).
 
 :::warning Atención
 La actualización de segmentos a los que pertenece un usuario se realiza en un proceso en segundo plano y puede no ser inmediata. Esto ocurre:

--- a/docs/es/platform/customers/segments.md
+++ b/docs/es/platform/customers/segments.md
@@ -10,7 +10,7 @@ En esta sección, encontrarás una lista de todos los segmentos creados, con inf
 
 - **Nombre**: Identificador del segmento (bajo este se encuentran los filtros que lo componen).
 - **Creado el**: Fecha de creación del segmento.
-- **Personas**: Número de usuarios que forman parte del segmento.
+- **Personas**: Número de usuarios que forman parte del segmento. Si el segmento tiene filtros que la plataforma no puede procesar, en lugar del número aparece un icono de alerta con el mensaje **No se pudo procesar el segmento**; edita el segmento y corrige sus filtros para recuperar el conteo.
 
 Para buscar un segmento por nombre, utiliza la barra de búsqueda en la parte superior de la pantalla.
 
@@ -18,13 +18,19 @@ Para buscar un segmento por nombre, utiliza la barra de búsqueda en la parte su
 
 Para crear un segmento, sigue estos pasos:
 
-- Desde la página de administración, haz clic en **Customers**, luego selecciona **Reinos**.
-- Haz clic en tu **Reino**.
-- Selecciona **Segmentos** y haz clic en **Nuevo Segmento**.
-- Agrega los filtros necesarios para tu segmento.
-- Haz clic en **Siguiente**.
-- Escribe un **Nombre** y una **Descripción**.
-- Haz clic en **Guardar**.
+1. Desde la página de administración, haz clic en **Customers**, luego selecciona **Reinos**.
+2. Haz clic en tu **Reino**.
+3. Selecciona **Segmentos** y haz clic en **Nuevo Segmento**.
+4. En la primera fila del constructor, elige **Usuarios que coinciden** o **Usuarios que no coinciden**.
+5. Abre el selector **Filtro** y elige el dato que quieres evaluar.
+6. Completa los campos que aparezcan a la derecha: **Filtrable** (el formulario, la campaña, el tag o la originación sobre la que se aplica el filtro), **Operador**, **Valor** y **Condición**. No todos los filtros piden los cuatro.
+7. Agrega las filas y los grupos que necesites con los botones **O** e **Y**.
+8. Haz clic en **Contar las coincidencias** para revisar a cuántos usuarios alcanza el segmento.
+9. Haz clic en **Siguiente**.
+10. Escribe un **Nombre** y una **Descripción**.
+11. Haz clic en **Guardar**.
+
+El botón **Siguiente** permanece deshabilitado mientras alguna fila esté incompleta: todo filtro necesita su valor, los que ofrecen **Condición** necesitan que elijas una, y los rangos necesitan sus dos extremos.
 
 :::tip Tip
 Asegúrate de que la ficha de cada cliente esté completa, ya que los datos incompletos impedirán que un usuario sea incluido en un segmento basado en esos criterios.
@@ -34,40 +40,78 @@ Asegúrate de que la ficha de cada cliente esté completa, ya que los datos inco
 Si tu acceso al reino está [restringido por segmentos](/es/platform/customers/settings.html#restringir-el-alcance-con-segmentos), no puedes crear segmentos nuevos, ya que estos parten del universo total de usuarios del reino. Sí puedes editar y borrar los segmentos de tu alcance.
 :::
 
+### Cómo se combinan los filtros
+
+Cada fila del constructor es un filtro y empieza con un selector que decide si suma o resta usuarios:
+
+- **Usuarios que coinciden**: incluye a quienes cumplen la condición de la fila.
+- **Usuarios que no coinciden**: incluye a quienes no la cumplen. Cualquier filtro se puede invertir, no solo algunos.
+
+Las filas se organizan en grupos, y de ahí sale el resultado final:
+
+- Dentro de un grupo, las filas se combinan con **O**: basta con que el usuario cumpla una de ellas. Usa el botón **O** para agregar otra fila al grupo.
+- Los grupos se combinan entre sí con **Y**: el usuario tiene que cumplir todos los grupos. Usa el botón **Y** para agregar un grupo nuevo.
+
+Así, un grupo con **Género** y otro grupo con **Edad** dejan solo a quienes cumplen las dos cosas, mientras que esas mismas dos filas dentro de un mismo grupo dejan a quienes cumplen cualquiera de las dos.
+
+Algunos filtros aceptan varios valores a la vez y muestran además un selector **Condición**:
+
+- **Todos**: el usuario debe cumplir con todos los valores que elegiste.
+- **Cualquiera**: basta con que cumpla uno.
+
+Por ejemplo, en **Tag de usuarios** con los tags `my_tag` y `my_other_tag`, **Todos** deja solo a quien tiene los dos y **Cualquiera** deja a quien tiene al menos uno.
+
+:::tip Tip
+La **Condición** solo aparece en los filtros que admiten varios valores, como **Tag de usuarios**, **Respondió** o **Estado de respuesta**. Cuando aparece, es obligatoria.
+:::
+
+### Vista previa de coincidencias
+
+Antes de guardar puedes revisar el alcance del segmento. Haz clic en **Contar las coincidencias**, al pie del constructor, y la pantalla te muestra cuántos usuarios cumplen los filtros que llevas escritos. El número no se actualiza solo: cada vez que cambies un filtro, vuelve a pedirlo con el botón de recarga que queda junto al conteo.
+
+:::warning Atención
+El conteo es una vista previa que se calcula en el momento y no crea ni guarda el segmento. Si el conteo devuelve un error, revisa los filtros antes de continuar.
+:::
+
 ## Filtros
 
 Los filtros te permiten crear segmentos basados en la información de las fichas de usuario y su actividad en el sitio. Puedes incluir usuarios que coincidan con ciertos criterios o excluir a los que no los cumplan.
 
 Los filtros predeterminados en la plataforma incluyen:
 
-- Estado de activación
-- Edad
-- Estado de respuesta (de una originación)
-- Estado de tarea (de una originación)
-- Respuestas de formulario
-- Fecha de nacimiento
-- Valor de custom field
-- Dispositivo
-- Correo entregado
-- Correo reportado como spam
-- Conteo de respuestas a formularios
-- Género
-- Última fecha de inicio de sesión
-- Conteo de logs
-- Fecha de inicio de sesión
-- Correo no abiertos
-- Conteo de correos abiertos
-- Notificación leída
-- Conteo de notificaciones abiertas
-- Fecha de registro
-- Tags de usuario
-- Valores de campo de usuarios
-- Orden completada
-- Orden fallida
-- Orden confirmando
-- Orden pagada
-- Orden pagando
-- Orden rechazada
+- **Estado de activación**
+- **Edad**
+- **Estado de respuesta** (de una originación)
+- **Estado de tarea** (de una originación)
+- **Respondió**
+- **Fecha de nacimiento**
+- **Valor del custom field**
+- **Dispositivo**
+- **Correo entregado**
+- **Correo reportado como spam**
+- **Conteo de respuestas a formulario**
+- **Género**
+- **Última fecha de inicio de sesión**
+- **Conteo de Logs**
+- **Fecha de inicio de sesión**
+- **Correos no abiertos**
+- **Conteo de correos abiertos**
+- **Correos abiertos**
+- **Notificación leída**
+- **Conteo de notificaciones abiertas**
+- **Fecha de registro**
+- **Tag de usuarios**
+- **Valores de campo de usuario**
+- **Órdenes completadas**
+- **Órdenes fallidas**
+- **Órdenes confirmando**
+- **Órdenes pagadas**
+- **Órdenes en pago**
+- **Órdenes rechazadas**
+
+Tres de ellos trabajan sobre el mismo dato y conviene no confundirlos: **Correos abiertos** busca a quienes abrieron una campaña concreta dentro de un rango de fechas, **Correos no abiertos** a quienes no la abrieron, y **Conteo de correos abiertos** compara cuántos correos abrió el usuario en total.
+
+Otros trabajan con una lista cerrada de valores: **Estado de activación** acepta **Activado** o **Desactivado**, y **Dispositivo** acepta **Escritorio**, **Móvil** o **Tablet**.
 
 Para crear un filtro avanzado, que se ajuste a tus necesidades, , consulta la sección [Custom Fields](/es/platform/customers/settings#custom-fields).
 
@@ -80,6 +124,18 @@ La actualización de segmentos a los que pertenece un usuario se realiza en un p
 
 La velocidad de la actualización depende de la carga del sistema, por lo que algunos usuarios podrían no ver contenido segmentado de inmediato tras realizar acciones que los incluyen o excluyen de un segmento.
 :::
+
+### Operadores
+
+El operador que ofrece un filtro depende del tipo de valor que compara:
+
+- **Fechas**, como **Fecha de nacimiento**, **Fecha de registro** o **Fecha de inicio de sesión**: **Antes del**, **Después del**, **El** y **Entre**.
+- **Números**, como **Edad** o un custom field numérico: **Menor que**, **Mayor que**, **Igual a** y **Entre**.
+- **Conteos**, los filtros que cuentan eventos como **Conteo de respuestas a formulario**, **Conteo de Logs**, **Conteo de correos abiertos** y **Conteo de notificaciones abiertas**: **Menor o igual que**, **Mayor o igual que**, **Igual a** y **Entre**.
+
+Los filtros que trabajan con una lista cerrada de opciones, como **Género** o **Dispositivo**, no piden operador: eliges el valor directamente.
+
+Cuando eliges **Entre**, la pantalla pide dos valores y el segundo tiene que ser mayor que el primero. Si no lo es, el panel avisa con **El valor máximo debe ser mayor que el valor mínimo** y el segmento no se guarda hasta que lo corrijas.
 
 ### Filtros de originación
 


### PR DESCRIPTION
## Cambios propuestos

Documenta cómo se construye un segmento y deja el catálogo de filtros alineado con lo que muestra el panel.

**docs/es/platform/customers/segments.md**

- **Crear un Segmento**: el procedimiento pasa a estar numerado y recorre el constructor real: el selector **Usuarios que coinciden** / **Usuarios que no coinciden**, el selector **Filtro**, y los campos **Filtrable**, **Operador**, **Valor** y **Condición**. Se agrega la nota de que **Siguiente** queda deshabilitado mientras haya una fila incompleta.
- Nueva sección **Cómo se combinan los filtros**: cualquier filtro se puede invertir, las filas de un grupo se combinan con **O**, los grupos entre sí con **Y**, y los filtros que aceptan varios valores muestran una **Condición** de **Todos** o **Cualquiera**.
- Nueva sección **Vista previa de coincidencias**: el botón **Contar las coincidencias** estima el alcance antes de guardar y el número solo se refresca cuando lo vuelves a pedir.
- Nueva sección **Operadores**: qué operadores ofrece cada tipo de valor (fechas, números y conteos), qué filtros no piden operador porque trabajan con opciones fijas, y la regla de **Entre**, donde el segundo valor debe ser mayor que el primero.
- **Filtros**: se agrega el filtro que faltaba, **Correos abiertos**, y se corrigen las 13 etiquetas que no coincidían con la pantalla (**Respondió**, **Valor del custom field**, **Tag de usuarios**, **Valores de campo de usuario**, **Conteo de respuestas a formulario**, **Correos no abiertos**, **Conteo de Logs** y los seis filtros de órdenes, ahora en plural). Se explica la diferencia entre **Correos abiertos**, **Correos no abiertos** y **Conteo de correos abiertos**, y se documentan los valores cerrados de **Estado de activación** y **Dispositivo**.
- En el listado de segmentos se aclara que la columna **Personas** muestra un aviso de **No se pudo procesar el segmento** cuando sus filtros no son válidos.

**docs/en/platform/customers/segments.md**

- Espejo completo de todo lo anterior, con las etiquetas del panel en inglés.

Cierra los gaps **CUSTOMERS-08** y **CUSTOMERS-09**.

## Para el revisor

Ajustes respecto de las fichas, verificados en origin/master:

1. CUSTOMERS-09 (b) afirma que la **Condición** Todos/Cualquiera es una propiedad del **grupo** y que los grupos se pueden anidar. En master no es así: `condition_type` es una columna de `Segments::Filter` (filter.rb, build_filter_attributes) y el selector se renderiza por FILA en InternalGroup.js, solo cuando el filtro entrega `condition_type_opts` (tags, respuestas con alternativas, estado de respuesta, filtros con `multiple_filterables`). Además la estructura es de dos niveles fijos, `{ and: [ { or: [...] } ] }` (NewSegment.js), sin anidamiento arbitrario. Documenté lo que hace master: grupos unidos con **Y**, filas dentro del grupo unidas con **O**, y **Condición** como propiedad del filtro que admite varios valores. Esto es coherente con lo que ya decía "### Filtros de originación", que describía la Condición como opción del filtro.

2. CUSTOMERS-09 (e) dice que la pantalla muestra el conteo "en vivo". En master es a demanda: botón **Contar las coincidencias** y luego un botón de recarga (NewSegment.js#renderMatchesCount → actions.js#countMatches → POST .../segments/count_matches). Lo redacté como vista previa a demanda y avisé explícitamente de que el número no se refresca solo.

3. El label de `multiple_log_count_filter` (el tipo que sí está en FILTERS) es **Conteo de Logs** con L mayúscula; existe además `log_count_filter` con el título "Conteo de logs", pero ese tipo no está en FILTERS y no aparece en el selector. Usé el de FILTERS.

4. El espejo en inglés cambia más etiquetas que el español porque en.yml diverge más de lo documentado: **Device** → **Login Device**, **Seen notification** → **Notifications opened**, **Order failed** → **Confirmation failed orders**, **Login Date** → **Login at date**, **Registration date** → **Registered date**, **Delivered mail** → **Email delivered**, entre otras. Todas salen de `admin.segments.<tipo>.title` de config/locales/admin/en.yml.

5. La tanda no roza páginas de soporte ni el módulo Soporte, así que la directiva de producto no obligó a omitir nada.

6. Dejé sin tocar dos cosas fuera del alcance de la tanda que detecté de paso en la página: la errata "que se ajuste a tus necesidades, , consulta" en la línea del enlace a Custom Fields, y que la lista de columnas del índice de segmentos no menciona **Procesado por última vez en**, que sí existe en SegmentsIndex.js.

7. Convertí el procedimiento de "## Crear un Segmento" de viñetas a pasos numerados, como pide el estilo de la casa para procedimientos de UI, y puse en negrita las etiquetas del catálogo de filtros. El ancla `#crear-un-segmento` no cambia, que es la que usan `admin.people.segments.empty.docs_url` y `admin.segments.link_documentation` desde el panel.

## Validación

Docker está caído en el entorno, así que la validación fue estática: diff sin `{{ }}` ni `{% %}` fuera de bloques de código, sin encabezados terminados en dos puntos y con los anclajes de los links nuevos comprobados contra los títulos de destino. El build queda confiado al CI de este PR.

Closes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)
