### PR TITLE
objects.md: objetos y atributos nuevos de 10.2

### DIFF
--- a/docs/en/platform/channels/liquid-markup/objects.md
+++ b/docs/en/platform/channels/liquid-markup/objects.md
@@ -31,6 +31,7 @@ Account objects are mainly used in the context of account authentication, which 
 | **account.url**        | The Modyo Platform URL, including the protocol and sub-domain.                                             | ```https://test.modyo.com```                  |
 | **account.host**       | The name of the Modyo Platform sub-domain.                                                                 | ```test```                                    |
 | **account.google_key** | If there is authentication with Google, it returns the credential key; otherwise, it returns empty (void). | ```AIzaSyDmrYmbFpzqdIxHycHbgtJrs9lhKOfggEE``` |
+| **account.name**       | The name of the account.                                                                                   | ```Modyo```                                   |
 
 ## adminuser
 
@@ -121,6 +122,7 @@ Create dynamic content in your spaces using Entries. In this object you have acc
 | Object                  | Description                                                                                  | Example                                                                   |
 |-------------------------|----------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
 | **entry.meta.space**         | Name of the space associated with the entry.                                                 | ```space1```                                                              |
+| **entry.meta.space_uid**     | Unique ID of the space associated with the entry. While `entry.meta.space` returns the display name, this is the identifier used to index `spaces` in templates. | ```space-1```                                                             |
 | **entry.meta.category**      | Category path for this entry.                                                                | ```category-1/category-2```                                               |
 | **entry.meta.category_name** | Category name for this entry.                                                                | ```category 2```                                                          |
 | **entry.meta.category_slug** | This entry's category slug.                                                                  | ```category-2```                                                          |
@@ -303,6 +305,17 @@ Extends the functionality of the Grid object and contains the following addition
 | **side_right_three_cols_grid.col1_widgets**       | Array of widget type objects. |         |
 | **side_right_three_cols_grid.col2_widgets**       | Array of widget type objects. |         |
 | **side_right_three_cols_grid.col3_widgets**       | Array of widget type objects. |         |
+
+## group
+
+Group objects represent a group of account administrators. They are not an end user segment: they group the people who work in the admin. The available attributes are:
+
+| Object         | Description         | Example                                    |
+|----------------|---------------------|--------------------------------------------|
+| **group.uuid** | The group's UUID.   | ```9f1c0c2e-3f5a-4a1b-9c3d-2b6f8a1e4d70``` |
+| **group.name** | The group's name.   | ```Risk analysts```                        |
+
+You reach this object from the `assignee_group` attribute of a pending review, a task validation or a pending review task response, which is where the group the work was assigned to is recorded.
 
 ## location
 
@@ -584,6 +597,8 @@ Every task response shares the attributes it inherits from the base response: `t
 |-----------------------------------------------|---------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 | **pending_review_task_response.approved**     | Whether the task has been approved.                                 | ```true```                                                                                                                                        |
 | **pending_review_task_response.content**      | The content of the review.                                          | ```This is the content of the review```                                                                                                           |
+| **pending_review_task_response.assignee**     | Administrator assigned to the review. Returns an adminuser object.  |                                                                                                                                                   |
+| **pending_review_task_response.assignee_group** | Administrator group assigned to the review. Returns a group object. |                                                                                                                                                 |
 | **code_snippet_task_response.data**           | The content of the code snippet. Alias for the `content` attribute. | ```{"submission"=>{"fields"=>{"car"=>"fiat", "year"=>1999, "color"=>"black", "extras"=>["ac", "gps", "sunroof"], "expiration"=>"2026-02-01"}}}``` |
 | **code_snippet_task_response.completed**      | Whether the task has been completed.                                | ```false```                                                                                                                                       |
 | **code_snippet_task_response.content**        | The content of the code snippet.                                    | ```{"submission"=>{"fields"=>{"car"=>"fiat", "year"=>1999, "color"=>"black", "extras"=>["ac", "gps", "sunroof"], "expiration"=>"2026-02-01"}}}``` |
@@ -608,6 +623,24 @@ Every task response shares the attributes it inherits from the base response: `t
 |------------------------------------------------------------|----------------------------------------------------|----------------|
 | **user_input_task_response.task**                          | The user input task to which the response belongs. |                |
 | **user_input_task_response.fields['question_identifier']** | The answers for the user input task response.      | ```response``` |
+
+### repeatable_group
+
+A repeatable group brings together several questions the user can answer more than once, for example to enter the details of each dependent. To read the answers, index `fields` with the identifier of the group question: you get the collection of answered groups, and on each element you index `fields` again with the identifier of the question you want to read.
+
+| Object                                                  | Description                                            | Example        |
+|---------------------------------------------------------|--------------------------------------------------------|----------------|
+| **repeatable_group.fields['question_identifier']**      | The answer to that question inside the repeatable group. | ```response``` |
+
+```liquid
+{% for group in user_input_task_response.fields['group_identifier'] %}
+  {{ group.fields['question_identifier'] }}
+{% endfor %}
+```
+
+:::warning Attention
+Do not confuse this object with `repeatable_group_field`, which appears in the [field](/en/platform/channels/liquid-markup/objects.html#field) reference. That one is a content field from the Content module; `repeatable_group` holds the answers to a form from the Customers module. They share the name and are unrelated.
+:::
 
 ## type
 
@@ -655,6 +688,14 @@ Use user objects to get information about your users from the Customers module.
 | **user.username**                    | The user's username.                                    | ```ivan@modyo.com```                                 |
 | **user.uuid**                        | The uuid of the user.                                   | ```cdc7f0e2-b5c3-4b92-aa34-962ffa0bi572```           |
 | **user.realm_uid**                   | The user's realm.                                       | ```my-realm```                                       |
+| **user.invited_submissions**         | Collection of submissions the user was invited to through an active invitation. Cancelled invitations are excluded and the order goes from the most recent to the oldest. |                     |
+| **user.unsubscribe_link**            | The user's unsubscribe link, for messaging templates.   | ```https://test.modyo.com/realms/default/mailing/unsubscribe?unsubscribe_token=ab12cd34``` |
+
+`user.invited_submissions` returns a collection, so it composes with the [by_origination](/en/platform/channels/liquid-markup/filters.html) filter to keep only the submissions of a given origination:
+
+```liquid
+{% assign source = user.invited_submissions | by_origination: origination.uid | first %}
+```
 | **user.current_login_at**            | Timestamp of current login.                             | ```2025-10-21 11:00:00 UTC```                        |
 | **user.current_login_ip**            | IP used for current login.                              | ```203.0.113.10```                                   |
 | **user.last_login_at**               | Timestamp of previous login.                            | ```2025-10-19 09:30:01 UTC```                        |

--- a/docs/en/platform/channels/liquid-markup/objects.md
+++ b/docs/en/platform/channels/liquid-markup/objects.md
@@ -633,8 +633,8 @@ A repeatable group brings together several questions the user can answer more th
 | **repeatable_group.fields['question_identifier']**      | The answer to that question inside the repeatable group. | ```response``` |
 
 ```liquid
-{% for group in user_input_task_response.fields['group_identifier'] %}
-  {{ group.fields['question_identifier'] }}
+{% for answered_group in user_input_task_response.fields['group_identifier'] %}
+  {{ answered_group.fields['question_identifier'] }}
 {% endfor %}
 ```
 

--- a/docs/es/platform/channels/liquid-markup/objects.md
+++ b/docs/es/platform/channels/liquid-markup/objects.md
@@ -640,8 +640,8 @@ Un grupo repetible reúne varias preguntas que el usuario puede responder más d
 | **repeatable_group.fields['identificador_de_la_pregunta']** | Respuesta de esa pregunta dentro del grupo repetible.       | ```respuesta``` |
 
 ```liquid
-{% for grupo in user_input_task_response.fields['identificador_del_grupo'] %}
-  {{ grupo.fields['identificador_de_la_pregunta'] }}
+{% for grupo_respondido in user_input_task_response.fields['identificador_del_grupo'] %}
+  {{ grupo_respondido.fields['identificador_de_la_pregunta'] }}
 {% endfor %}
 ```
 

--- a/docs/es/platform/channels/liquid-markup/objects.md
+++ b/docs/es/platform/channels/liquid-markup/objects.md
@@ -31,6 +31,7 @@ Los objetos de Cuenta se utilizan principalmente en el contexto de autenticació
 | **account.url**        | La URL de Modyo Platform, incluido el protocolo y el subdominio.                                          | ```https://test.modyo.com```                  |
 | **account.host**       | El nombre del subdominio de Modyo Platform.                                                               | ```test```                                    |
 | **account.google_key** | Si hay autenticación con Google, devuelve la clave de credencial; de lo contrario, devuelve vacío (void). | ```AIzaSyDmrYmbFpzqdIxHycHbgtJrs9lhKOfggEE``` |
+| **account.name**       | El nombre de la cuenta.                                                                                   | ```Modyo```                                   |
 
 ## adminuser
 
@@ -121,6 +122,7 @@ Crea contenido dinámico en tus espacios usando Entradas. En este objeto tienes 
 | Objeto                  | Descripción                                                                                                                           | Ejemplo                                                                   |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
 | **entry.meta.space**         | Nombre del espacio asociado a la entrada.                                                                                             | ```espacio1```                                                            |
+| **entry.meta.space_uid**     | ID único del espacio asociado a la entrada. Mientras `entry.meta.space` devuelve el nombre visible, este es el identificador con el que se indexa `spaces` en las plantillas. | ```espacio-1```                                                           |
 | **entry.meta.category**      | Ruta de la categoría de esta entrada.                                                                                                 | ```category-1/category-2```                                               |
 | **entry.meta.category_name** | Nombre de la categoría de esta entrada.                                                                                               | ```category 2```                                                          |
 | **entry.meta.category_slug** | Slug de la categoría de esta entrada.                                                                                                 | ```category-2```                                                          |
@@ -308,6 +310,17 @@ Extiende la funcionalidad del objeto Grid y contiene los siguientes atributos ad
 | **side_right_three_cols_grid.col1_widgets**       | Array de objetos de tipo widget. |         |
 | **side_right_three_cols_grid.col2_widgets**       | Array de objetos de tipo widget. |         |
 | **side_right_three_cols_grid.col3_widgets**       | Array de objetos de tipo widget. |         |
+
+## group
+
+Los objetos de group representan un grupo de administradores de la cuenta. No son un segmento de usuarios finales: agrupan a quienes trabajan en el panel. Los atributos disponibles son:
+
+| Objeto         | Descripción       | Ejemplo                                    |
+|----------------|-------------------|--------------------------------------------|
+| **group.uuid** | UUID del grupo.   | ```9f1c0c2e-3f5a-4a1b-9c3d-2b6f8a1e4d70``` |
+| **group.name** | Nombre del grupo. | ```Analistas de riesgo```                  |
+
+Llegas a este objeto desde el atributo `assignee_group` de una revisión pendiente, de una validación de tarea o de una respuesta de tarea de revisión, que es donde queda registrado el grupo al que se asignó el trabajo.
 
 ## location
 
@@ -591,6 +604,8 @@ Toda respuesta de tarea comparte los atributos que hereda de la respuesta base: 
 |-----------------------------------------------|---------------------------------------------------------|-----------------------------------------------|
 | **pending_review_task_response.approved**     | Indica si la tarea de revisión fue aprobada.            | ```true```                                    |
 | **pending_review_task_response.content**      | Contenido de la revisión.                               | ```Este es el contenido de la revisión```     |
+| **pending_review_task_response.assignee**     | Administrador asignado a la revisión. Devuelve un objeto adminuser. |                                   |
+| **pending_review_task_response.assignee_group** | Grupo de administradores asignado a la revisión. Devuelve un objeto group. |                          |
 | **code_snippet_task_response.data**           | Contenido del snippet de código (alias de `content`).   | ```{"submission"=>{"fields"=>{"car"=>"fiat", "year"=>1999, "color"=>"black", "extras"=>["ac", "gps", "sunroof"], "expiration"=>"2026-02-01"}}}``` |
 | **code_snippet_task_response.completed**      | Indica si la tarea de snippet fue completada.           | ```false```                                   |
 | **code_snippet_task_response.content**        | Contenido del snippet de código.                        | ```{"submission"=>{"fields"=>{"car"=>"fiat", "year"=>1999, "color"=>"black", "extras"=>["ac", "gps", "sunroof"], "expiration"=>"2026-02-01"}}}```                               |
@@ -615,6 +630,24 @@ Toda respuesta de tarea comparte los atributos que hereda de la respuesta base: 
 |---------------------------------------------------------------------|--------------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | **user_input_task_response.task**                                   | Tarea de entrada de usuario a la que pertenece la respuesta. |                                                                                           |
 | **user_input_task_response.fields['identificador_de_la_pregunta']** | Respuestas de la tarea de entrada de usuario.                | ```respuesta``` |
+
+### repeatable_group
+
+Un grupo repetible reúne varias preguntas que el usuario puede responder más de una vez, por ejemplo para cargar los datos de cada carga familiar. Para leer las respuestas, indexa `fields` con el identificador de la pregunta de tipo grupo: obtienes la colección de grupos respondidos, y sobre cada elemento vuelves a indexar `fields` con el identificador de la pregunta que quieres leer.
+
+| Objeto                                                     | Descripción                                                 | Ejemplo         |
+|------------------------------------------------------------|-------------------------------------------------------------|-----------------|
+| **repeatable_group.fields['identificador_de_la_pregunta']** | Respuesta de esa pregunta dentro del grupo repetible.       | ```respuesta``` |
+
+```liquid
+{% for grupo in user_input_task_response.fields['identificador_del_grupo'] %}
+  {{ grupo.fields['identificador_de_la_pregunta'] }}
+{% endfor %}
+```
+
+:::warning Atención
+No confundas este objeto con `repeatable_group_field`, que aparece en la ficha de [field](/es/platform/channels/liquid-markup/objects.html#field). Ese es un campo de contenido del módulo Content; `repeatable_group` corresponde a las respuestas de un formulario del módulo Customers. Comparten el nombre y no tienen relación.
+:::
 
 ## target
 
@@ -684,6 +717,14 @@ Usa los objetos de user para obtener información de tus usuarios del módulo Cu
 | **user.username**                    | Username del usuario.                                          | ```ivan@modyo.com```                                 |
 | **user.uuid**                        | UUID del usuario.                                              | ```cdc7f0e2-b5c3-4b92-aa34-962ffa0bi572```           |
 | **user.realm_uid**                   | Realm del usuario.                                             | ```my-realm```                                       |
+| **user.invited_submissions**         | Colección de respuestas a las que el usuario fue invitado mediante una invitación activa. Se excluyen las invitaciones canceladas y el orden va de la más reciente a la más antigua. |                     |
+| **user.unsubscribe_link**            | Enlace de baja del usuario, para plantillas de mensajería.     | ```https://test.modyo.com/realms/default/mailing/unsubscribe?unsubscribe_token=ab12cd34``` |
+
+`user.invited_submissions` entrega una colección, así que se compone con el filtro [by_origination](/es/platform/channels/liquid-markup/filters.html) para quedarte con las respuestas de una originación puntual:
+
+```liquid
+{% assign source = user.invited_submissions | by_origination: origination.uid | first %}
+```
 
 ## user_agent
 


### PR DESCRIPTION
## Cambios propuestos

Documenta cinco incorporaciones de 10.2 a la referencia de objetos Liquid que no tenían ficha. Todo se verificó contra `master` de la plataforma, no contra `releases/10.2-stable`.

### `docs/{es,en}/platform/channels/liquid-markup/objects.md`

- **`## account`** · fila `account.name`. El drop de cuenta es de alcance global y tiene solo cuatro atributos (`url`, `host`, `google_key`, `name`), así que faltaba un cuarto de la ficha.
- **`## entry`** · fila `entry.meta.space_uid`, con la distinción explícita frente a `entry.meta.space`: uno devuelve el nombre visible del espacio y el otro el identificador con el que se indexa `spaces` en las plantillas.
- **`## group`** · ficha nueva, insertada entre `grid` y `location` para respetar el orden alfabético de la página. Trae `group.uuid` y `group.name`, la aclaración de que es un grupo de administradores y no un segmento de usuarios finales, y las tres vías por las que se alcanza.
- **`### Tipos de Respuesta de Tareas`** · filas `pending_review_task_response.assignee` y `.assignee_group`, que faltaban en la tabla.
- **`### repeatable_group`** · ficha nueva bajo `## submission`, junto a `user_input_task_response`, que es su única vía de acceso. Incluye el bucle Liquid completo y una advertencia para no confundirlo con `repeatable_group_field`, que comparte nombre pero es un campo de contenido de Content.
- **`## user`** · filas `user.invited_submissions` y `user.unsubscribe_link`, más el ejemplo de composición con el filtro `by_origination`.

### Nota de verificación

`account.name` funciona en Liquid, pero no aparece en `config/liquid/liquid_drop_list.yml`. Ese archivo lo genera una tarea que no se ha vuelto a correr, y solo alimenta el autocompletado del editor de plantillas mediante el endpoint `available_drops`: no restringe el acceso a los atributos. Lo mismo aplica a la ficha de `group`, que tampoco figura en esa lista.

## Gaps que cierra

`LIQUID-OBJETOS-10`, `LIQUID-OBJETOS-11`, `LIQUID-OBJETOS-14`, `LIQUID-OBJETOS-19`, `LIQUID-OBJETOS-20`

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)