### PR TITLE
Corregir la documentación de la búsqueda por id y uuid en el listado de respuestas

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -622,13 +622,13 @@ You can search in two ways, which you can also combine in the same query:
 The available keys for `key=value` pairs are:
 
 - **User data**: `first_name`, `last_name`, `second_last_name`, `email`, and `username`.
-- **Identifiers**: `id` and `uuid`. These two do not behave like the rest: each one searches two places at once and requires the exact value. They are explained in [Search by identifier](/en/platform/customers/origination.html#search-by-identifier).
+- **Identifiers**: `id` and `uuid`. These two do not behave like the rest: each one searches two places at once and does not allow partial matches. They are explained in [Search by identifier](/en/platform/customers/origination.html#search-by-identifier).
 - **User custom fields**: The custom field key, with or without the `_ucf_` prefix. For example, `pais=Chile` and `_ucf_pais=Chile` are equivalent.
 - **Flow questions**: The question identifier defined in the origination flow. For example, `rut=18301757`.
 
 When using `key=value` pairs, keep the following in mind:
 
-- The key must be written in full, while the value does allow partial matches. The `id` and `uuid` keys are the exception: they require the exact value.
+- The key must be written in full, while the value does allow partial matches. The `id` and `uuid` keys are the exception: they do not allow partial matches.
 - To search for values or phrases with spaces, use double quotes. For example, `first_name="Jean Pierre"` or `"crédito hipotecario"`.
 - All conditions are combined together, so a submission must satisfy every term and pair in the query to appear in the results.
 - If the key does not exist or the value is empty, the term is searched as free text without generating errors.
@@ -656,9 +656,9 @@ The `id` and `uuid` keys are different from the rest: each one searches **two pl
 
 The practical consequence is that a single value can bring results from two different sources. For example, `id=42` returns the submission whose id is 42 and, in addition, every submission of the user whose id is 42, even though they are unrelated. If you are after one specific submission, check the user column to rule out the ones that came in through the other path.
 
-Both keys require the exact value, unlike the rest of the search:
+Neither key allows partial matches, unlike the rest of the search:
 
-- `uuid` is case-sensitive and does not allow partial matches. Copy the full identifier exactly as it appears in the platform: half a uuid returns nothing.
+- `uuid` is also case-sensitive. Copy the full identifier exactly as it appears in the platform: half a uuid returns nothing.
 - `id` is read as a whole number and only keeps the leading digits of the value. Type digits only: `id=18.301.757` searches for the submission with id `18`, and `id=abc` returns no results. Neither case shows any warning.
 
 If you paste a uuid into the box without the key, the search treats it as free text and only finds the submission with that uuid, not the submissions of the user with that uuid. For the latter you have to type `uuid=`.

--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -612,22 +612,23 @@ The roles you already had keep the access they had: those that saw the full deta
 
 The submission list includes a search box that allows you to find submissions by the user's data, the values of their custom fields, the answers entered in the flow fields, and the content of the tasks.
 
-The search requires a minimum of 3 characters, is case- and accent-insensitive, and finds partial matches. For example, `lau` finds "Claudio" and `perez` finds "Pérez".
+The search requires a minimum of 3 characters, is case- and accent-insensitive, and finds partial matches. For example, `lau` finds "Claudio" and `perez` finds "Pérez". The `id` and `uuid` keys are the exception and are explained below.
 
 You can search in two ways, which you can also combine in the same query:
 
-- **Free text**: Type one or more terms and the search will find them in the user's data, the values of their custom fields, and the content of the answers.
+- **Free text**: Type one or more terms and the search will find them in the user's data, the values of their custom fields, the answers entered in the flow fields, and the content of the tasks.
 - **Key=value pairs**: Type the key of a field followed by `=` and the value to search for, to narrow the search down to that specific field.
 
 The available keys for `key=value` pairs are:
 
-- **User fields**: `first_name`, `last_name`, `second_last_name`, `email`, `username`, `uuid`, and `id`.
+- **User data**: `first_name`, `last_name`, `second_last_name`, `email`, and `username`.
+- **Identifiers**: `id` and `uuid`. These two do not behave like the rest: each one searches two places at once and requires the exact value. They are explained in [Search by identifier](/en/platform/customers/origination.html#search-by-identifier).
 - **User custom fields**: The custom field key, with or without the `_ucf_` prefix. For example, `pais=Chile` and `_ucf_pais=Chile` are equivalent.
 - **Flow questions**: The question identifier defined in the origination flow. For example, `rut=18301757`.
 
 When using `key=value` pairs, keep the following in mind:
 
-- The key must be written in full, while the value does allow partial matches.
+- The key must be written in full, while the value does allow partial matches. The `id` and `uuid` keys are the exception: they require the exact value.
 - To search for values or phrases with spaces, use double quotes. For example, `first_name="Jean Pierre"` or `"crédito hipotecario"`.
 - All conditions are combined together, so a submission must satisfy every term and pair in the query to appear in the results.
 - If the key does not exist or the value is empty, the term is searched as free text without generating errors.
@@ -642,6 +643,25 @@ Some search examples:
 | `rut=18301757` | Submissions where the question with identifier `rut` contains "18301757". |
 | `first_name="Jean Pierre"` | Submissions whose user contains "Jean Pierre" in their name. |
 | `pais=Chile rut=18301757 hipotecario` | Submissions that meet all three conditions at once. |
+| `id=42` | The submission whose id is 42 and, in addition, every submission of the user whose id is 42. |
+
+##### Search by identifier
+
+The `id` and `uuid` keys are different from the rest: each one searches **two places at once**, and a match in either one is enough for the submission to show up in the results.
+
+| Key    | Where it searches                                      |
+|--------|--------------------------------------------------------|
+| `id`   | The user's id **or** the submission's id.              |
+| `uuid` | The user's uuid **or** the submission's uuid.          |
+
+The practical consequence is that a single value can bring results from two different sources. For example, `id=42` returns the submission whose id is 42 and, in addition, every submission of the user whose id is 42, even though they are unrelated. If you are after one specific submission, check the user column to rule out the ones that came in through the other path.
+
+Both keys require the exact value, unlike the rest of the search:
+
+- `uuid` is case-sensitive and does not allow partial matches. Copy the full identifier exactly as it appears in the platform: half a uuid returns nothing.
+- `id` is read as a whole number and only keeps the leading digits of the value. Type digits only: `id=18.301.757` searches for the submission with id `18`, and `id=abc` returns no results. Neither case shows any warning.
+
+If you paste a uuid into the box without the key, the search treats it as free text and only finds the submission with that uuid, not the submissions of the user with that uuid. For the latter you have to type `uuid=`.
 
 :::tip Results update
 Recent changes to a submission may take a few seconds to be reflected in the search results. Changes to the user's data, the values of their custom fields, and segments are reflected in a deferred manner.

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -613,22 +613,23 @@ Los roles que ya tenías conservan el acceso que tenían: los que veían el deta
 
 El listado de respuestas incluye una caja de búsqueda que te permite encontrar respuestas por los datos del usuario, los valores de sus campos personalizados, las respuestas ingresadas en los campos del flujo y el contenido de las tareas.
 
-La búsqueda requiere un mínimo de 3 caracteres, no distingue mayúsculas ni acentos y encuentra coincidencias parciales. Por ejemplo, `lau` encuentra a "Claudio" y `perez` encuentra a "Pérez".
+La búsqueda requiere un mínimo de 3 caracteres, no distingue mayúsculas ni acentos y encuentra coincidencias parciales. Por ejemplo, `lau` encuentra a "Claudio" y `perez` encuentra a "Pérez". Las claves `id` y `uuid` son la excepción y se explican más abajo.
 
 Puedes buscar de dos formas, que además puedes combinar en una misma consulta:
 
-- **Texto libre**: Escribe uno o más términos y la búsqueda los encontrará en los datos del usuario, los valores de sus campos personalizados y el contenido de las respuestas.
+- **Texto libre**: Escribe uno o más términos y la búsqueda los encontrará en los datos del usuario, los valores de sus campos personalizados, las respuestas ingresadas en los campos del flujo y el contenido de las tareas.
 - **Pares clave=valor**: Escribe la clave de un campo seguida de `=` y el valor a buscar para acotar la búsqueda a ese campo específico.
 
 Las claves disponibles para los pares `clave=valor` son:
 
-- **Campos del usuario**: `first_name`, `last_name`, `second_last_name`, `email`, `username`, `uuid` e `id`.
+- **Datos del usuario**: `first_name`, `last_name`, `second_last_name`, `email` y `username`.
+- **Identificadores**: `id` y `uuid`. Estas dos no se comportan como el resto: cada una busca en dos lugares a la vez y exige el valor exacto. Se explican en [Buscar por identificador](/es/platform/customers/origination.html#buscar-por-identificador).
 - **Campos personalizados del usuario**: La clave del campo personalizado, con o sin el prefijo `_ucf_`. Por ejemplo, `pais=Chile` y `_ucf_pais=Chile` son equivalentes.
 - **Preguntas del flujo**: El identificador de la pregunta definido en el flujo de originación. Por ejemplo, `rut=18301757`.
 
 Al usar pares `clave=valor` ten en cuenta lo siguiente:
 
-- La clave debe escribirse completa, mientras que el valor sí admite coincidencias parciales.
+- La clave debe escribirse completa, mientras que el valor sí admite coincidencias parciales. Las claves `id` y `uuid` son la excepción: exigen el valor exacto.
 - Para buscar valores o frases con espacios usa comillas dobles. Por ejemplo, `first_name="Jean Pierre"` o `"crédito hipotecario"`.
 - Todas las condiciones se combinan entre sí, por lo que una respuesta debe cumplir todos los términos y pares de la consulta para aparecer en los resultados.
 - Si la clave no existe o el valor está vacío, el término se busca como texto libre sin generar errores.
@@ -643,6 +644,25 @@ Algunos ejemplos de búsquedas:
 | `rut=18301757` | Respuestas donde la pregunta con identificador `rut` contiene "18301757". |
 | `first_name="Jean Pierre"` | Respuestas cuyo usuario contiene "Jean Pierre" en su nombre. |
 | `pais=Chile rut=18301757 hipotecario` | Respuestas que cumplen las tres condiciones a la vez. |
+| `id=42` | La respuesta cuyo id es 42 y, además, todas las respuestas del usuario cuyo id es 42. |
+
+##### Buscar por identificador
+
+Las claves `id` y `uuid` son distintas del resto: cada una busca **en dos lugares a la vez** y basta que coincida uno de los dos para que la respuesta aparezca en los resultados.
+
+| Clave  | Dónde busca                                        |
+|--------|----------------------------------------------------|
+| `id`   | El id del usuario **o** el id de la respuesta.     |
+| `uuid` | El uuid del usuario **o** el uuid de la respuesta. |
+
+La consecuencia práctica es que un mismo valor puede traer resultados de dos orígenes distintos. Por ejemplo, `id=42` devuelve la respuesta cuyo id es 42 y, además, todas las respuestas del usuario cuyo id es 42, aunque no tengan ninguna relación entre sí. Si lo que buscas es una respuesta puntual, revisa la columna del usuario para descartar las que llegaron por la otra vía.
+
+Ambas claves exigen el valor exacto, a diferencia del resto de la búsqueda:
+
+- `uuid` distingue mayúsculas de minúsculas y no admite coincidencias parciales. Copia el identificador completo tal como aparece en la plataforma: la mitad de un uuid no devuelve nada.
+- `id` se interpreta como un número entero y solo conserva los dígitos iniciales del valor. Escríbelo únicamente con dígitos: `id=18.301.757` busca la respuesta con id `18`, y `id=abc` no devuelve resultados. En ninguno de los dos casos aparece un aviso.
+
+Si pegas un uuid en la caja sin la clave, la búsqueda lo trata como texto libre y solo encuentra la respuesta con ese uuid, no las del usuario con ese uuid. Para lo segundo tienes que escribir `uuid=`.
 
 :::tip Actualización de los resultados
 Los cambios recientes en una respuesta pueden tardar unos segundos en reflejarse en los resultados de la búsqueda. Los cambios en los datos del usuario, en los valores de sus campos personalizados y en los segmentos se reflejan de forma diferida.

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -623,13 +623,13 @@ Puedes buscar de dos formas, que además puedes combinar en una misma consulta:
 Las claves disponibles para los pares `clave=valor` son:
 
 - **Datos del usuario**: `first_name`, `last_name`, `second_last_name`, `email` y `username`.
-- **Identificadores**: `id` y `uuid`. Estas dos no se comportan como el resto: cada una busca en dos lugares a la vez y exige el valor exacto. Se explican en [Buscar por identificador](/es/platform/customers/origination.html#buscar-por-identificador).
+- **Identificadores**: `id` y `uuid`. Estas dos no se comportan como el resto: cada una busca en dos lugares a la vez y no admite coincidencias parciales. Se explican en [Buscar por identificador](/es/platform/customers/origination.html#buscar-por-identificador).
 - **Campos personalizados del usuario**: La clave del campo personalizado, con o sin el prefijo `_ucf_`. Por ejemplo, `pais=Chile` y `_ucf_pais=Chile` son equivalentes.
 - **Preguntas del flujo**: El identificador de la pregunta definido en el flujo de originación. Por ejemplo, `rut=18301757`.
 
 Al usar pares `clave=valor` ten en cuenta lo siguiente:
 
-- La clave debe escribirse completa, mientras que el valor sí admite coincidencias parciales. Las claves `id` y `uuid` son la excepción: exigen el valor exacto.
+- La clave debe escribirse completa, mientras que el valor sí admite coincidencias parciales. Las claves `id` y `uuid` son la excepción: no admiten coincidencias parciales.
 - Para buscar valores o frases con espacios usa comillas dobles. Por ejemplo, `first_name="Jean Pierre"` o `"crédito hipotecario"`.
 - Todas las condiciones se combinan entre sí, por lo que una respuesta debe cumplir todos los términos y pares de la consulta para aparecer en los resultados.
 - Si la clave no existe o el valor está vacío, el término se busca como texto libre sin generar errores.
@@ -657,9 +657,9 @@ Las claves `id` y `uuid` son distintas del resto: cada una busca **en dos lugare
 
 La consecuencia práctica es que un mismo valor puede traer resultados de dos orígenes distintos. Por ejemplo, `id=42` devuelve la respuesta cuyo id es 42 y, además, todas las respuestas del usuario cuyo id es 42, aunque no tengan ninguna relación entre sí. Si lo que buscas es una respuesta puntual, revisa la columna del usuario para descartar las que llegaron por la otra vía.
 
-Ambas claves exigen el valor exacto, a diferencia del resto de la búsqueda:
+Ninguna de las dos admite coincidencias parciales, a diferencia del resto de la búsqueda:
 
-- `uuid` distingue mayúsculas de minúsculas y no admite coincidencias parciales. Copia el identificador completo tal como aparece en la plataforma: la mitad de un uuid no devuelve nada.
+- `uuid` distingue además mayúsculas de minúsculas. Copia el identificador completo tal como aparece en la plataforma: la mitad de un uuid no devuelve nada.
 - `id` se interpreta como un número entero y solo conserva los dígitos iniciales del valor. Escríbelo únicamente con dígitos: `id=18.301.757` busca la respuesta con id `18`, y `id=abc` no devuelve resultados. En ninguno de los dos casos aparece un aviso.
 
 Si pegas un uuid en la caja sin la clave, la búsqueda lo trata como texto libre y solo encuentra la respuesta con ese uuid, no las del usuario con ese uuid. Para lo segundo tienes que escribir `uuid=`.


### PR DESCRIPTION
## Cambios propuestos

La sección **Buscar respuestas** describía `id` y `uuid` como «campos del usuario». En realidad cada una busca **en dos lugares a la vez**, y además son las únicas dos claves que exigen el valor exacto. Todo lo que sigue se verificó contra `master` de la plataforma.

### `docs/{es,en}/platform/customers/origination.md`

- **Lista de claves disponibles**: `uuid` e `id` salen de «Datos del usuario» y pasan a una viñeta propia, **Identificadores**, con enlace a la sección nueva.
- **Sección nueva `Buscar por identificador`**: tabla con dónde busca cada clave, la consecuencia práctica del O lógico, y las reglas de coincidencia exacta de cada una.
- **Regla general de coincidencias parciales**: se le agrega la excepción de `id` y `uuid`.
- **Frase de «no distingue mayúsculas ni acentos»**: se acota, porque aparecía antes de las excepciones y quien se detuviera ahí quedaba mal informado.
- **Tabla de ejemplos**: fila nueva con `id=42` mostrando el resultado real.
- **Viñeta de texto libre**: se completa con las respuestas de los campos del flujo y el contenido de las tareas, que la introducción de la sección ya prometía pero la viñeta omitía.

## Lo que se corrige, con evidencia

`app/models/concerns/modyo/originations/submissions/searchable.rb:333-336`:

```ruby
when uuid then { bool: { should: [{ term: { user_uuid: value } }, { term: { uuid: value } }],
                           minimum_should_match: 1 } }
when id   then { bool: { should: [{ term: { user_id: value.to_i } }, { term: { id: value.to_i } }],
                           minimum_should_match: 1 } }
```

- **Es un O lógico**, no un Y: `minimum_should_match: 1`. Por eso `id=42` devuelve la respuesta 42 y todas las respuestas del usuario 42, que son entidades sin relación.
- **Coincidencia exacta**: ambas usan `term`, sin el comodín que sí tienen `first_name`, `last_name`, `second_last_name`, `email` y `username` en `text_value_clause` (`:371-378`). Media uuid no devuelve nada.
- **`uuid` distingue mayúsculas**: `uuid` y `user_uuid` están mapeados como `keyword` sin normalizer (`:73` y `:95`), a diferencia de los campos de texto, que llevan `lowercase_normalizer` (`:43-48`).
- **`id` trunca en el primer no dígito**: `value.to_i`, sin validación. `id=18.301.757` busca el id `18` y `id=abc` no devuelve resultados, en ambos casos en silencio.
- **En texto libre solo participa el uuid de la respuesta**: `FREE_TEXT_FLAT_FIELDS` (`:37-38`) incluye `uuid^3` pero no `user_uuid`. Un uuid pegado sin la clave no encuentra las respuestas del usuario.

## Lo que se revisó y se dejó igual

- **«La clave debe escribirse completa»** es correcta: el parser resuelve la clave por coincidencia exacta contra el mapa de claves conocidas y degrada a texto libre lo que no calce, según fija el spec (`submission_search_query_parser_spec.rb:47`, `number=5` no resuelve). El comodín de `key_partial_clause` opera sobre la clave ya resuelta, no sobre lo que escribe el usuario.
- **El mínimo de 3 caracteres** aplica al largo total de la caja (`UISearch.js:41`), así que `id=7` pasa sin problema y no entra en conflicto con lo nuevo.

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)