### PR TITLE
Tipos de campos especialziados en subida de archivos

### DIFF
--- a/docs/en/platform/customers/origination.md
+++ b/docs/en/platform/customers/origination.md
@@ -91,6 +91,8 @@ To include a new field, you must select a task and select the **Add** tab.
 
 Origination supports all types of input available in forms. You can see the full list of types in the [forms documentation](https://docs.modyo.com/en/platform/customers/forms#add)
 
+In addition, Input tasks offer three field types that **exist only in Origination** and are not available in forms: **Document**, **Identity document**, and **Selfie**. All three are described in [Specialized file upload fields](/en/platform/customers/origination.html#specialized-file-upload-fields).
+
 
 #### Edit fields
 
@@ -101,6 +103,92 @@ When selecting a field, you can modify its properties by going to the **Edit** t
 - **Field instructions**: Provides additional guidance for the user to understand how to complete the field. These instructions are displayed directly on the interface, below the field.
 - **Add instructions pop-up field**: Adds a help icon next to the field. When you click on this icon, a message appears with additional information or useful tips related to the field.
 - **Options**: Additional properties according to the type of field selected.
+
+#### Specialized file upload fields
+
+Input tasks include three field types designed to collect documents and images with automatic processing. All three are available only inside an Input task of an origination.
+
+| Field | What it is for |
+|---|---|
+| **Document** | Uploads a file and, optionally, extracts its text. |
+| **Identity document** | Captures an ID card on both sides or a passport, and extracts its data. |
+| **Selfie** | Captures a photo of the face and, optionally, runs a liveness check. |
+
+All three are added from the **Add** tab of the builder, like any other field, and share the common properties described in [Edit fields](/en/platform/customers/origination.html#edit-fields).
+
+##### The identity verification integration
+
+Data extraction and the liveness check depend on the **Amazon Rekognition Face Liveness** integration, in the **Identity Verification** category. It is installed and enabled per realm, in **Realm settings** → **Integrations**.
+
+If the integration is not enabled, the three fields still appear in the builder and still work for the end user as a regular file upload. The only difference is that the extraction and liveness checkboxes appear disabled, with the message **To enable this option, set up the Amazon Rekognition identity verification integration for this realm.** Any value you had already saved is not lost.
+
+:::tip Integration setup
+To edit an integration you first have to disable it: while it is enabled, editing is not available. Two integration settings change how these fields behave: the **Confidence Threshold (%)**, which decides when a liveness check passes or is rejected (90% by default), and the **Cognito Identity Pool ID**, without which the liveness challenge cannot start.
+:::
+
+##### Document
+
+Uploads a file and, if you enable it, extracts its text automatically. It has two specific options:
+
+- **Allowed Extensions**: A comma-separated list of the extensions you accept in this field, for example `pdf, doc, txt`. If you leave it empty, any extension allowed by the platform is accepted. The extensions you type must be allowed at the platform level; otherwise the field is not saved and the message **These extensions are not allowed** appears.
+- **Extract document data (OCR)**: Enables text extraction from the file. It is off by default.
+
+The field accepts a single file, with the maximum size defined in the platform (10 MB by default). The end user sees the same upload area as in the **File** field, with the list of allowed formats and the maximum size hint.
+
+Extraction works with `jpg`, `jpeg`, `png`, `tiff`, `tif`, `pdf`, and `docx` files. Any other extension can still be uploaded, but it ends up with the **Unsupported file type** status: no text is extracted from it. This is worth keeping in mind with formats that look obvious and are not, such as `doc`, `txt`, or `csv`.
+
+Extraction goes through the **Pending**, **Processing**, **Completed**, **Failed**, and **Unsupported file type** statuses. If the user replaces the file, extraction restarts and the previous result is discarded.
+
+##### Identity document
+
+Captures an identity document and extracts its data. It has three specific options:
+
+- **Accepted document types**: Checkboxes for **ID card (front and back photos)** and **Passport (single photo)**. You cannot leave both unchecked. A field created from the builder starts with only the ID card checked; one created through the API without specifying types accepts both.
+- **Default country**: Sets the country of the document. If you leave it as **The user selects the country**, the user picks the country when answering; if you choose one, the selector is not shown to them and the country is fixed.
+- **Extract document data (OCR)**: Enables extraction of the document data. It is off by default.
+
+The field accepts `jpg`, `jpeg`, and `png` images, and that format is not configurable.
+
+When answering, the user chooses between **Use camera** and **Upload file**. With an ID card, the flow has two steps: first the **Front side** and then the **Back side**, with a framing guide for each. When the first side is done, the screen returns to the start with the title of the remaining side, and the user has to press **Use camera** or **Upload file** again; the camera does not open on its own. With a passport, a single photo of the data page is requested. The **Redo front** and **Redo back** options delete the image already uploaded, not just the preview.
+
+The country has a concrete effect on extraction: it is used to interpret the dates on the document. If the country is not set and a date is ambiguous — for example `03/04/1990`, where both numbers could be month or day — the date is stored exactly as it came, without normalizing. So when you know your users' country in advance, it is worth fixing it.
+
+Extraction goes through the **Pending**, **Processing**, **Completed**, and **Failed** statuses.
+
+##### Selfie
+
+Captures a photo of the user's face. It has a single specific option:
+
+- **Face liveness check**: Adds a challenge that confirms there is a real person in front of the camera. It is off by default.
+
+The field accepts `jpg`, `jpeg`, and `png` images, and that format is not configurable. The user can take the photo with the camera or upload a file; there is no way to restrict it to one path. The front camera is shown mirrored, and the image is saved exactly as it looks in the preview.
+
+When the liveness check is enabled, its block appears **after** the user has captured or uploaded the selfie, with the **Start liveness check** button. Completing it is never mandatory: even if you mark the field as required, the only mandatory part is the photo.
+
+When the challenge finishes, the user only sees that it was completed. The verdict is calculated after the submission is sent and is not shown to them. The possible statuses are **Pending**, **Processing**, **Verified**, **Rejected**, **Failed**, and **Skipped**.
+
+:::warning What the selfie is compared against
+The face comparison is made against the image captured by the liveness challenge itself, **not** against the identity document. It confirms that whoever submits the selfie is the same person who took the challenge, not that the selfie matches the holder of the document.
+:::
+
+If the user captures the selfie again, the previous check is discarded and they have to take it again.
+
+##### Where the result is shown
+
+The extraction status and the liveness check status **are not shown today on any administration screen**. The **Documents** tab of the submission lists the files of all three fields with their name, size, and thumbnail, and in the task detail the Identity document field shows the document type, the country, and the links to **Front side** and **Back side**; the Document and Selfie fields look the same as a File field.
+
+The results are available for integration:
+
+- In **Liquid templates**, the answer of a Document field returns the file, the extraction status, and the extracted text; the answer of a Selfie field returns the file, the liveness status, and the confidence level.
+- In the **Admin API**, in addition to the above, the error code is exposed when extraction or the check fails.
+
+:::tip Liveness check rejected with no reason
+A **Rejected** check with no associated error code means the confidence level fell below the **Confidence Threshold (%)** configured in the integration. It is the most frequent case and does not indicate a technical failure.
+:::
+
+##### Use in conditional logic
+
+All three fields can be used in the conditional logic of the origination, but only with the **has no value** and **has any value** operators. It is not possible to set conditions based on the content of the document, the country, or the result of the liveness check.
 
 ### Validation
 

--- a/docs/es/platform/customers/origination.md
+++ b/docs/es/platform/customers/origination.md
@@ -91,6 +91,8 @@ Para incluir un nuevo campo debes seleccionar una tarea y seleccionar la pestañ
 
 Origination soporta todos los tipos de entrada disponibles en formularios. Puedes ver el listado completo de tipos en la [documentación de formularios](https://docs.modyo.com/es/platform/customers/forms#anadir)
 
+Además, las tareas Input ofrecen tres tipos de campo que **solo existen en Origination** y no están disponibles en los formularios: **Documento**, **Documento de identidad** y **Selfie**. Los tres se describen en [Campos especializados de subida de archivos](/es/platform/customers/origination.html#campos-especializados-de-subida-de-archivos).
+
 
 #### Editar campos
 
@@ -101,6 +103,92 @@ Al seleccionar un campo, puedes modificar sus propiedades al dirigirte a  la pes
 - **Instrucciones del campo**: proporciona orientación adicional para que el usuario comprenda cómo completar el campo. Estas instrucciones se muestran directamente en la interfaz, debajo del campo.
 - **Agregar campo Pop-up de instruciones**: Agrega un ícono de ayuda junto al campo. Al hacer clic en este ícono, se despliega un mensaje con información adicional o consejos útiles relacionados con el campo.
 - **Opciones**: Propiedades adicionales de acuerdo al tipo de campo seleccionado.
+
+#### Campos especializados de subida de archivos
+
+Las tareas Input incluyen tres tipos de campo pensados para recolectar documentos e imágenes con procesamiento automático. Los tres solo están disponibles dentro de una tarea Input de una originación.
+
+| Campo | Para qué sirve |
+|---|---|
+| **Documento** | Sube un archivo y, opcionalmente, extrae su texto. |
+| **Documento de identidad** | Captura una cédula por ambos lados o un pasaporte, y extrae sus datos. |
+| **Selfie** | Captura una foto del rostro y, opcionalmente, ejecuta una verificación de vida. |
+
+Los tres se agregan desde la pestaña **Añadir** del constructor, igual que cualquier otro campo, y comparten las propiedades comunes descritas en [Editar campos](/es/platform/customers/origination.html#editar-campos).
+
+##### La integración de verificación de identidad
+
+La extracción de datos y la verificación de vida dependen de la integración **Amazon Rekognition Face Liveness**, de la categoría **Verificación de Identidad**. Se instala y habilita por reino, en **Configuración de reino** → **Integraciones**.
+
+Si la integración no está habilitada, los tres campos siguen apareciendo en el constructor y siguen funcionando para el usuario final como una subida de archivos normal. Lo único que cambia es que las casillas de extracción y de verificación de vida aparecen deshabilitadas, con el mensaje **Para habilitar esta opción, configura la integración de verificación de identidad de Amazon Rekognition en el realm.** El valor que ya tuvieras guardado no se pierde.
+
+:::tip Configuración de la integración
+Para editar una integración primero tienes que deshabilitarla: mientras está habilitada, la edición no está disponible. Dos ajustes de la integración cambian el comportamiento de estos campos: el **Umbral de confianza (%)**, que decide cuándo una verificación de vida se aprueba o se rechaza (90% de manera predeterminada), y el **ID de Pool de Identidad de Cognito**, sin el cual el desafío de verificación de vida no puede iniciarse.
+:::
+
+##### Documento
+
+Sube un archivo y, si lo activas, extrae su texto automáticamente. Tiene dos opciones propias:
+
+- **Extensiones permitidas**: Lista separada por comas con las extensiones que aceptas en este campo, por ejemplo `pdf, doc, txt`. Si la dejas vacía se acepta cualquier extensión permitida por la plataforma. Las extensiones que escribas deben estar permitidas a nivel de plataforma; si no, el campo no se guarda y aparece el mensaje **Estas extensiones no están permitidas**.
+- **Extraer datos del documento (OCR)**: Activa la extracción del texto del archivo. Viene desactivada.
+
+El campo acepta un solo archivo, con el tamaño máximo definido en la plataforma (10 MB de manera predeterminada). El usuario final ve la misma zona de carga que en el campo **Archivo**, con la lista de formatos permitidos y la ayuda del tamaño máximo.
+
+La extracción funciona con archivos `jpg`, `jpeg`, `png`, `tiff`, `tif`, `pdf` y `docx`. Cualquier otra extensión se puede subir igual, pero queda con el estado **Tipo de archivo no soportado**: no se le extrae texto. Conviene tenerlo presente con formatos que parecen obvios y no lo son, como `doc`, `txt` o `csv`.
+
+La extracción pasa por los estados **Pendiente**, **Procesando**, **Completada**, **Falló** y **Tipo de archivo no soportado**. Si el usuario reemplaza el archivo, la extracción se reinicia y el resultado anterior se descarta.
+
+##### Documento de identidad
+
+Captura un documento de identidad y extrae sus datos. Tiene tres opciones propias:
+
+- **Tipos de documento aceptados**: Casillas para **Cédula de identidad (fotos de frente y reverso)** y **Pasaporte (una foto)**. No puedes dejar las dos desmarcadas. Un campo creado desde el constructor nace con solo la cédula marcada; uno creado por la API sin especificar tipos acepta ambos.
+- **País por defecto**: Fija el país del documento. Si lo dejas en **El usuario selecciona el país**, el usuario elige el país al responder; si eliges uno, el selector no se le muestra y el país queda fijado.
+- **Extraer datos del documento (OCR)**: Activa la extracción de los datos del documento. Viene desactivada.
+
+El campo acepta imágenes `jpg`, `jpeg` y `png`, y ese formato no es configurable.
+
+Al responder, el usuario elige entre **Usar cámara** y **Subir archivo**. Con una cédula, el flujo es en dos pasos: primero el **Frente** y luego el **Reverso**, con una guía de encuadre en cada uno. Al terminar el primer lado la pantalla vuelve al inicio con el título del lado que falta, y el usuario debe pulsar de nuevo **Usar cámara** o **Subir archivo**; la cámara no se abre sola. Con un pasaporte se pide una sola foto de la página de datos. Las opciones **Rehacer frente** y **Rehacer reverso** eliminan la imagen ya subida, no solo la vista previa.
+
+El país tiene un efecto concreto sobre la extracción: se usa para interpretar las fechas del documento. Si el país no está definido y una fecha es ambigua —por ejemplo `03/04/1990`, donde ambos números pueden ser mes o día—, la fecha se guarda tal como venía, sin normalizar. Por eso, cuando sabes de antemano el país de tus usuarios, conviene fijarlo.
+
+La extracción pasa por los estados **Pendiente**, **Procesando**, **Completada** y **Falló**.
+
+##### Selfie
+
+Captura una foto del rostro del usuario. Tiene una sola opción propia:
+
+- **Verificación de vida (liveness)**: Agrega un desafío que confirma que hay una persona real frente a la cámara. Viene desactivada.
+
+El campo acepta imágenes `jpg`, `jpeg` y `png`, y ese formato no es configurable. El usuario puede tomarse la foto con la cámara o subir un archivo; no hay forma de restringirlo a una sola vía. La cámara frontal se muestra en espejo, y la imagen se guarda tal como se ve en la vista previa.
+
+Cuando la verificación de vida está activa, el bloque correspondiente aparece **después** de que el usuario haya capturado o subido la selfie, con el botón **Iniciar verificación de vida**. Completarla nunca es obligatorio: aunque marques el campo como requerido, lo único obligatorio es la foto.
+
+Al terminar el desafío, el usuario solo ve que se completó. El veredicto se calcula después de enviar la respuesta y no se le muestra. Los estados posibles son **Pendiente**, **Procesando**, **Verificada**, **Rechazada**, **Falló** y **Omitida**.
+
+:::warning Contra qué se compara la selfie
+La comparación facial se hace contra la imagen que captura el propio desafío de verificación de vida, **no** contra el documento de identidad. Sirve para confirmar que quien envía la selfie es la misma persona que hizo el desafío, no para validar que la selfie corresponde al titular del documento.
+:::
+
+Si el usuario vuelve a capturar la selfie, la verificación anterior se descarta y tiene que hacerla de nuevo.
+
+##### Dónde se ve el resultado
+
+El estado de la extracción y el de la verificación de vida **no se muestran hoy en las pantallas de administración**. La pestaña **Documentos** de la respuesta lista los archivos de los tres campos con su nombre, tamaño y miniatura, y en el detalle de la tarea el campo Documento de identidad muestra el tipo de documento, el país y los enlaces a **Frente** y **Reverso**; los campos Documento y Selfie se ven igual que un campo Archivo.
+
+Los resultados sí quedan disponibles para integrar:
+
+- En **plantillas Liquid**, la respuesta de un campo Documento entrega el archivo, el estado de la extracción y el texto extraído; la de un campo Selfie entrega el archivo, el estado de la verificación de vida y el nivel de confianza.
+- En la **API de administración**, además de lo anterior, se expone el código de error cuando la extracción o la verificación fallan.
+
+:::tip Verificación de vida rechazada sin motivo
+Una verificación **Rechazada** sin código de error asociado significa que el nivel de confianza quedó por debajo del **Umbral de confianza (%)** configurado en la integración. Es el caso más frecuente y no indica una falla técnica.
+:::
+
+##### Uso en la lógica condicional
+
+Los tres campos se pueden usar en la lógica condicional de la originación, pero solo con los operadores **está vacío** y **tiene algún valor**. No es posible condicionar por el contenido del documento, por el país ni por el resultado de la verificación de vida.
 
 ### Validación
 


### PR DESCRIPTION
## Cambios propuestos

Documenta los tres tipos de campo que agrega la issue: **Documento**, **Documento de identidad** y **Selfie**. Todo se verificó contra el código de `modyo/modyo#20208`, ya mergeado en `master`.

### `docs/{es,en}/platform/customers/origination.md`

Sección nueva **Campos especializados de subida de archivos**, dentro de `### Input`, con:

- **Alcance**: los tres tipos solo existen en Origination y solo dentro de una tarea Input. La página decía que Origination soporta «todos los tipos de entrada disponibles en formularios», lo que ahora se queda corto: se agregó la aclaración y el enlace a la sección nueva.
- **La integración de verificación de identidad**: qué integración hay que habilitar, dónde, y qué pasa exactamente si no lo está (los campos siguen funcionando; solo se deshabilitan las casillas de OCR y verificación de vida). Incluye los dos ajustes de la integración que cambian el comportamiento: el umbral de confianza y el ID de Pool de Identidad de Cognito.
- **Documento**: extensiones permitidas, extracción de texto, los siete formatos de los que sí extrae, y los cinco estados.
- **Documento de identidad**: tipos aceptados, país por defecto, el flujo de dos pasos frente/reverso, y el efecto del país sobre la interpretación de fechas.
- **Selfie**: verificación de vida, cuándo aparece, por qué nunca es obligatoria, y contra qué se compara realmente.
- **Dónde se ve el resultado**: en Liquid y en la API; hoy no en las pantallas de administración.
- **Uso en la lógica condicional**: solo los operadores de vacío.

## Decisiones de alcance

- **Va en `origination.md`, no en `forms.md`.** El catálogo de tipos de campo está en un solo archivo con dos bloques: el de formularios no incluye estos tres tipos y el de originaciones sí. Documentarlos junto al resto de los campos de formulario habría sido incorrecto.
- **La comparación facial es contra la imagen del desafío de verificación de vida, no contra el documento de identidad.** Es la suposición natural al leer la issue y es falsa, así que quedó como advertencia explícita.
- **El estado de OCR y de verificación de vida no se muestra en ninguna pantalla de administración.** El markup existe pero está condicionado a una variable que no se asigna en ese flujo. Se documenta lo que sí es alcanzable: la pestaña Documentos, y el detalle del campo Documento de identidad con tipo, país y los enlaces a frente y reverso.
- **Un rechazo sin código de error significa que no se alcanzó el umbral configurado.** Es el caso más frecuente y no había forma de deducirlo.

## Lo que se dejó fuera a propósito

Nombres de servicios y artefactos internos (workers, colas, buckets, identificadores de trabajo, tiempos de sondeo), la variable de entorno del tamaño máximo —documentado como «10 MB de manera predeterminada»—, y `extracted_pairs`, que el modelo guarda pero no expone ni la API, ni Liquid, ni ninguna vista.

Referencia: `modyo/modyo#20208`

🤖 Generated with [Claude Code](https://claude.com/claude-code)