### PR TITLE
Incluir un ID en los datasets, para poder diferenciar el valor que se muestra del valor que se guarda.

### DIFF
--- a/docs/en/platform/customers/settings.md
+++ b/docs/en/platform/customers/settings.md
@@ -465,6 +465,93 @@ Deleting a customizable field permanently deletes all user values associated wit
 In addition to saving user-specific values, you can use customizable field values to create [segments](/en/platform/customers/segments) filters, allowing you to separate users based on their custom values.
 :::
 
+### Data Sets
+
+A data set is a reusable list of alternatives that lives inside the realm. Instead of repeating the same options in every form, you define them once and use them in **forms**, in **originations**, and in **user custom fields** of the dropdown type.
+
+You will find them in the realm side menu, under **Realm settings** → **Data Set**. To manage them you need the **Admin Data Sets** grouped permission.
+
+#### Data set types
+
+When you create a data set you choose its type, and that choice cannot be changed later:
+
+- **Simple**: A flat list of alternatives. It feeds **Dropdown** fields and user custom fields of the dropdown type.
+- **Nested**: A tree of alternatives, where each option can have child options. It feeds **Nested Questions** fields. It supports up to 5 levels of depth by default; if you go beyond that, saving fails and points to the alternative that exceeds the limit.
+
+Alternative labels cannot be repeated, regardless of case. In a simple data set the restriction covers the whole list; in a nested one it applies **between sibling alternatives**, so two different branches can each have an option with the same name.
+
+#### Using a data set in a field
+
+In the field editor, check **Use data set** and pick the data set from the selector. The checkbox is only available while the field is new: once saved, a regular field cannot be turned into a data set field, nor the other way around.
+
+The data set editor shows a **Data set usage** panel with the forms, originations, and custom fields that use it. A data set in use cannot be deleted.
+
+#### Bulk load of alternatives
+
+To load many alternatives at once, check **Use bulk alternatives** and paste the list. The checkbox is only available while the data set has no alternatives: it is meant to populate it, not to add to what is already there.
+
+- In a **simple** data set, one alternative per line.
+- In a **nested** data set, one full branch per line, with levels separated by a semicolon or a tab. The latter lets you paste straight from a spreadsheet.
+
+Blank lines are discarded and repeated ones are ignored. In nested data sets, branches that share their first levels are merged: `Chile;Región Metropolitana;Providencia` and `Chile;Región Metropolitana;Las Condes` produce a single `Chile` with a single `Región Metropolitana`.
+
+#### External identifiers
+
+An alternative is identified by its label, which is a text meant for the end user: it can carry accents and spaces, and it changes over time. If an external system needs to recognize the chosen option, tying itself to that text is fragile. That is what external identifiers are for: a stable code per alternative, which you define and integrators receive along with the answer.
+
+To turn them on, check **Use external ids** in the data set editor. An **EXTERNAL ID** column appears with one field per alternative; in nested data sets, at every level of the tree.
+
+##### External identifier rules
+
+- **It is mandatory on every alternative.** With the checkbox on, you cannot save if any one is empty. That includes turning it on for a data set that already had alternatives: you have to fill them all in before you can save.
+- **It only accepts letters, numbers, hyphens, and underscores.** No spaces, dots, or accents. The editor normalizes what you type as you type it, so you cannot enter invalid characters by hand.
+- **It is always stored in lowercase**, with no leading or trailing spaces.
+- **It is unique across the whole data set.** Unlike labels, uniqueness is not limited to sibling alternatives: a code used in one branch cannot be repeated in another one or at another level. The comparison ignores case.
+
+Turning the checkbox **off** deletes the external identifiers of every alternative in the data set. The platform asks for confirmation before applying it, with the message **Disabling external ids will delete the external id of every alternative in this data set. Do you want to continue?**
+
+##### Bulk load with external identifiers
+
+With the checkbox on, the bulk load format changes: each alternative is written as `label:identifier`.
+
+- In a **simple** data set, one alternative per line:
+
+```text
+Checking Account:001
+Sight Account:002
+Savings Account:003
+```
+
+- In a **nested** data set, one branch per line, with each level in the same format:
+
+```text
+Chile:cl; Región Metropolitana:rm; Providencia:prov
+Chile:cl; Región Metropolitana:rm; Las Condes:lcd
+Perú:pe; Lima:lim; Miraflores:mir
+```
+
+If a single line is malformed, **no alternative is imported**: the whole load is rejected and the message points to the line and the text that caused the problem. A line with no `:`, one with no identifier, one with no label, and one whose identifier does not match the format are all rejected. The same label arriving with two different identifiers is rejected too.
+
+:::warning Attention
+In nested data sets the help example mentions only the semicolon as the level separator, but a tab works as well, just like in the bulk load without identifiers.
+:::
+
+##### How they are consumed
+
+Once configured, external identifiers are available where integrators need them:
+
+- When you query the data set through the **Admin API**, each alternative includes its `external_id`, and the data set reports whether the option is on through `use_external_ids`.
+- When you query a user's answer through the **Admin API**, the `external_id` of the chosen alternative is included.
+- In **Liquid templates**, the answer exposes `answer.external_id`.
+
+In a nested data set, the identifier delivered is the one of the selected **leaf**, not the one of the whole branch: the answer points to a single alternative, the one at the last level.
+
+:::tip Data sets without external identifiers
+Reading `external_id` from a data set that does not have the option enabled never raises an error. In Liquid it returns an empty string, and the same happens when reading it from an answer that is not a data set answer. You can add the read to your templates before you finish configuring the data sets without breaking anything.
+:::
+
+Turning external identifiers on does not change how an answer is chosen or stored, and it does not affect the conditional logic of originations. The data sets you already had keep working the same way as long as you do not check the box.
+
 ### Security
 
 #### Password Policy

--- a/docs/es/platform/customers/settings.md
+++ b/docs/es/platform/customers/settings.md
@@ -465,6 +465,93 @@ Al eliminar un campo personalizable, eliminas permanentemente todos los valores 
 Además de guardar valores específicos de los usuarios, puedes utilizar los valores de los campos personalizables para crear filtros de [segmentos](/es/platform/customers/segments) lo que te permite separar a los usuarios según sus valores personalizados.
 :::
 
+### Data Sets
+
+Un data set es una lista de alternativas reutilizable que vive dentro del reino. En vez de repetir las mismas opciones en cada formulario, las defines una vez y las usas en **formularios**, en **originaciones** y en **campos personalizados de usuario** de tipo lista desplegable.
+
+Los encuentras en el menú lateral del reino, en **Configuración de reino** → **Data Set**. Para administrarlos necesitas el permiso agrupado **Administrar Data Sets**.
+
+#### Tipos de data set
+
+Al crear un data set eliges su tipo, y esa elección no se puede cambiar después:
+
+- **Simple**: Una lista plana de alternativas. Alimenta campos de tipo **Lista desplegable** y campos personalizados de usuario de tipo lista desplegable.
+- **Anidado**: Un árbol de alternativas, donde cada opción puede tener opciones hijas. Alimenta campos de tipo **Preguntas Anidadas**. Admite hasta 5 niveles de profundidad de manera predeterminada; si te pasas, el guardado falla indicando la alternativa que excede el límite.
+
+Las etiquetas de las alternativas no se pueden repetir, sin distinguir mayúsculas. En un data set simple la restricción alcanza a toda la lista; en uno anidado se aplica **entre alternativas hermanas**, así que dos ramas distintas sí pueden tener una opción con el mismo nombre.
+
+#### Usar un data set en un campo
+
+En el editor del campo, marca **Usar data set** y elige el data set en el selector. La casilla solo está disponible mientras el campo es nuevo: una vez guardado, un campo normal no se puede convertir en campo de data set ni al revés.
+
+El editor del data set muestra un panel **Uso del data set** con los formularios, las originaciones y los campos personalizados que lo usan. Un data set en uso no se puede eliminar.
+
+#### Carga masiva de alternativas
+
+Para cargar muchas alternativas de una vez, marca **Utilizar ingreso masivo de alternativas** y pega el listado. La casilla solo está disponible mientras el data set no tenga alternativas: sirve para poblarlo, no para agregar a lo que ya existe.
+
+- En un data set **simple**, una alternativa por línea.
+- En un data set **anidado**, una rama completa por línea, con los niveles separados por punto y coma o por tabulación. Esto último permite pegar directamente desde una planilla.
+
+Las líneas en blanco se descartan y las repetidas se ignoran. En los anidados, las ramas que comparten los primeros niveles se fusionan: `Chile;Región Metropolitana;Providencia` y `Chile;Región Metropolitana;Las Condes` producen un solo `Chile` con una sola `Región Metropolitana`.
+
+#### Identificadores externos
+
+Una alternativa se identifica por su etiqueta, que es un texto pensado para el usuario final: puede llevar tildes y espacios, y cambia con el tiempo. Si un sistema externo necesita reconocer la opción elegida, atarse a ese texto es frágil. Para eso están los identificadores externos: un código estable por alternativa, que tú defines y que los integradores reciben junto con la respuesta.
+
+Para activarlos, marca **Usar external ids** en el editor del data set. Aparece una columna **EXTERNAL ID** con un campo por alternativa; en los data sets anidados, en todos los niveles del árbol.
+
+##### Reglas del identificador externo
+
+- **Es obligatorio en todas las alternativas.** Con la casilla marcada no puedes guardar si alguna quedó vacía. Esto incluye activarla sobre un data set que ya tenía alternativas: hay que completarlas todas antes de poder guardar.
+- **Solo admite letras, números, guion medio y guion bajo.** Nada de espacios, puntos ni tildes. El editor normaliza lo que escribes mientras tecleas, así que no puedes ingresar caracteres inválidos a mano.
+- **Se guarda siempre en minúsculas**, sin espacios al principio ni al final.
+- **Es único en todo el data set.** A diferencia de las etiquetas, la unicidad no se limita a las alternativas hermanas: un código usado en una rama no se puede repetir en otra ni en otro nivel. La comparación ignora mayúsculas.
+
+Al **desactivar** la casilla se borran los identificadores externos de todas las alternativas del data set. La plataforma te pide confirmación antes de aplicarlo, con el mensaje **Al desactivar los external ids se borrará el external id de todas las alternativas de este data set. ¿Deseas continuar?**
+
+##### Carga masiva con identificadores externos
+
+Con la casilla marcada, el formato de la carga masiva cambia: cada alternativa se escribe como `etiqueta:identificador`.
+
+- En un data set **simple**, una alternativa por línea:
+
+```text
+Cuenta Corriente:001
+Cuenta Vista:002
+Cuenta de Ahorro:003
+```
+
+- En un data set **anidado**, una rama por línea, con cada nivel en el mismo formato:
+
+```text
+Chile:cl; Región Metropolitana:rm; Providencia:prov
+Chile:cl; Región Metropolitana:rm; Las Condes:lcd
+Perú:pe; Lima:lim; Miraflores:mir
+```
+
+Si una sola línea está mal formada, **no se importa ninguna alternativa**: la carga se rechaza completa y el mensaje indica la línea y el texto que causaron el problema. Se rechaza una línea sin `:`, una sin identificador, una sin etiqueta, y una con un identificador que no cumple el formato. También se rechaza que una misma etiqueta llegue con dos identificadores distintos.
+
+:::warning Atención
+En los data sets anidados el ejemplo de ayuda menciona solo el punto y coma como separador de niveles, pero la tabulación también funciona, igual que en la carga masiva sin identificadores.
+:::
+
+##### Cómo se consumen
+
+Una vez configurados, los identificadores externos quedan disponibles donde los integradores los necesitan:
+
+- Al consultar el data set por la **API de administración**, cada alternativa incluye su `external_id`, y el data set informa si tiene la opción activada mediante `use_external_ids`.
+- Al consultar la respuesta de un usuario por la **API de administración**, se incluye el `external_id` de la alternativa elegida.
+- En **plantillas Liquid**, la respuesta expone `answer.external_id`.
+
+En un data set anidado, el identificador que se entrega es el de la **hoja** seleccionada, no el de la rama completa: la respuesta apunta a una sola alternativa, la del último nivel.
+
+:::tip Data sets sin identificadores externos
+Leer `external_id` de un data set que no tiene la opción activada nunca produce un error. En Liquid devuelve una cadena vacía, y lo mismo ocurre al leerlo desde una respuesta que no es de data set. Puedes agregar la lectura a tus plantillas antes de terminar de configurar los data sets sin romper nada.
+:::
+
+Activar los identificadores externos no cambia cómo se elige ni cómo se guarda una respuesta, ni afecta la lógica condicional de las originaciones. Los data sets que ya tenías siguen funcionando igual mientras no marques la casilla.
+
 ### Seguridad
 
 #### Política de Contraseña


### PR DESCRIPTION
## Cambios propuestos

Documenta los **data sets del reino**, que hasta ahora no tenían una sola línea en la documentación, y sobre esa base los **identificadores externos** que agrega la issue. Todo verificado contra el código de `modyo/modyo#20232`.

### `docs/{es,en}/platform/customers/settings.md`

Sección nueva **Data Sets**, entre Custom fields y Seguridad:

- **Qué son y dónde viven**: Configuración de reino → Data Set, con el permiso agrupado **Administrar Data Sets**, y los tres lugares donde se usan: formularios, originaciones y campos personalizados de usuario.
- **Tipos**: simple y anidado, qué campo alimenta cada uno, el tope de 5 niveles, y la regla de unicidad de etiquetas —global en simples, entre hermanas en anidados—.
- **Usar un data set en un campo**: la casilla **Usar data set**, disponible solo mientras el campo es nuevo, y el panel **Uso del data set** que bloquea el borrado.
- **Carga masiva**: los formatos preexistentes de simples y anidados, la fusión de ramas que comparten niveles, y la limitación de que la casilla solo está disponible mientras el data set no tenga alternativas.
- **Identificadores externos**: para qué sirven, cómo se activan, las cuatro reglas del valor, el borrado al desactivar con su confirmación, el formato de carga masiva `etiqueta:identificador` con ejemplos, y cómo se consumen desde la API y desde Liquid.

## Por qué la sección es más grande que la issue

Los data sets no estaban documentados en ninguna parte: un `grep` sobre `docs/es` y `docs/en` completos solo devuelve la lista de herramientas del MCP. Documentar únicamente el campo nuevo habría dejado una sección huérfana, ininteligible para quien no sabe qué es un data set — y el destinatario del identificador externo es justamente el integrador, que hoy no encuentra nada.

## Detalles verificados que conviene destacar

- **La unicidad del identificador externo es global en todo el data set**, no entre alternativas hermanas. Es lo contrario de lo que ocurre con las etiquetas en los data sets anidados, donde dos ramas sí pueden repetir un nombre. Sin decirlo explícitamente, un administrador no puede anticipar el error.
- **En anidados, el identificador que llega en la respuesta es el de la hoja**, no el de la rama completa.
- **Leerlo cuando no está configurado nunca falla**: en Liquid devuelve cadena vacía, igual que al leerlo desde una respuesta que no es de data set. Verificado en `answer_drop.rb`, donde el método hace `alternative.respond_to?(:external_id) ? alternative.external_id.to_s : ""`. Eso permite preparar las plantillas antes de terminar de configurar los data sets.
- **El valor se guarda siempre en minúsculas y recortado**, y el editor normaliza lo que se teclea, así que no se pueden ingresar caracteres inválidos a mano.

## Un cabo suelto que no resuelve este PR

El botón de ayuda de la pantalla de data sets apunta hoy a `platform/customers/origination.html`, donde no hay nada sobre data sets. Con esta sección publicada, ese enlace del producto debería apuntar a `platform/customers/settings.html#data-sets`. Es un cambio en el repositorio de la plataforma, no en la documentación.

## Validación

Build local con Docker: `success`. La página la tocan también los PRs abiertos #1024, #1027 y #1035; la sección es autocontenida y se inserta antes de `Seguridad`, así que un conflicto sería trivial.

Referencia: `modyo/modyo#20232`

🤖 Generated with [Claude Code](https://claude.com/claude-code)