### PR TITLE
api.md: contrato transversal de paginación, only, orden y rangos de fecha

### DIFF
--- a/docs/en/platform/core/api.md
+++ b/docs/en/platform/core/api.md
@@ -536,6 +536,88 @@ Which returns a response like the following:
 
 Finally, the API will always return the first page (`current_page: 1`) of resources grouped by pages of 10 elements (`per_page: 10`) by default.
 
+### Records per page limit
+
+`per_page` has a cap of 100 records. If you ask for a larger value, the API trims it silently: it responds `HTTP 200 OK` with 100 records, with no error and no warning in the body. The only place where you see how many records each page actually carries is `meta.per_page`, so read it instead of assuming the value you sent.
+
+Out-of-range values do not fail either, they silently fall back to a default:
+
+- `per_page=0`, a negative value, or a non-numeric value do not bring "everything": the page stays at the default 10 records.
+- `page=0`, a negative value, or a non-numeric value return the first page.
+- There is a third parameter, `paginate`, which does not disable pagination either. With `paginate=false` or `paginate=0` the page moves to 100 records, exactly the same as `per_page=100`.
+
+There is no combination of parameters that returns a complete collection in a single call. To take all the records of a resource, walk the pages up to `meta.total_pages`.
+
+:::warning Attention
+The Swagger catalog for `GET /api/admin/sites` declares `per_page` with the description "Number of items per page (0 for all)", a maximum of 1000, and a default value of 25. All three are false: that list paginates like the rest of the API, with a cap of 100, a default of 10 records, and `per_page=0` returning 10. A site synchronization written with `per_page=0` trusting that description receives 10 sites and `HTTP 200 OK`, with no sign that the rest are missing.
+:::
+
+## Common collection parameters
+
+The lists of the administration API share a group of query parameters that behave the same across every resource, even though the Swagger catalog does not declare them in every operation. They also share the same failure mode: a value the platform does not understand does not return an error, it is ignored and the query responds with its default behavior.
+
+### Selecting attributes with only
+
+`only` trims the attributes the response carries and is available in most lists and detail calls of the administration API. It is sent as an array, repeating the parameter once per attribute:
+
+```shell script
+curl -X GET "https://test.modyo.com/api/admin/messaging/campaigns?only[]=id&only[]=name" -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+An attribute that does not exist in the resource simply does not appear in the response and does not raise an error.
+
+:::warning Attention
+Do not use `only` as a comma-separated list. Some operations in the Swagger catalog declare it that way, with examples such as `id,name,admin_users_count` (this is the case of `/api/admin/groups` and `/api/admin/customers/{realm_uid}/forms`), but the platform does not split the value by commas: it takes `id,name` as the name of a single attribute, finds none with that name, and returns the collection with all of its objects empty, with `HTTP 200 OK`.
+:::
+
+:::tip Tip
+In `GET /api/admin/versions`, `only` means something else: it does not trim attributes, it filters versions by type with a comma-separated list of `editable`, `current`, `backup`, and `scheduled`, for example `only=editable,current`. It is the only resource where `only` is interpreted this way.
+:::
+
+### Sorting with sort_by and order
+
+`sort_by` chooses the attribute the collection is sorted by and `order` chooses the direction, with the values `ASC` and `DESC`. `order` is case-insensitive, so `asc` and `desc` work as well.
+
+Unless the resource states otherwise, the default sorting is `updated_at` in `DESC`, from the most recently modified record to the oldest one.
+
+Both parameters silently fall back to that default sorting when the value is not usable:
+
+- `order` with any value other than `ASC` or `DESC` is ignored entirely.
+- `sort_by` is only honored if it names a real attribute of the resource and, when the resource publishes a list of sortable attributes in the Swagger catalog, if it belongs to that list. A misspelled attribute or one outside the list is ignored.
+
+A list sorted by an invalid `sort_by` looks exactly like a correctly sorted one, so check the order of the records in the response before considering the query good.
+
+These resources accept `sort_by` and `order` even though the Swagger catalog does not declare them among their parameters:
+
+- `GET /api/admin/customers/{realm_uid}/forms`
+- `GET /api/admin/customers/{realm_uid}/originations`
+- `GET /api/admin/customers/{realm_uid}/users/{user_id}/submissions`, which does not appear in the catalog at all
+- The lists under `/api/admin/team_members`, which declare `order` in some operations but never `sort_by`
+
+### Date ranges
+
+`date_range` narrows a collection by the creation date of its records and `updated_date_range` by the last modification date. Both take the two dates as an array:
+
+```shell script
+curl -X GET "https://test.modyo.com/api/admin/logs?date_range[]=2026-07-01&date_range[]=2026-07-15" -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+The platform expands each date to the whole day: the first value moves to the beginning of that day and the second one to its end. The time you send changes nothing, `date_range[]=2026-07-15T18:00:00` still covers the whole of July 15, and a range with the same date in both values covers that entire day. Internally the range is translated into the `from_date` and `to_date` parameters (or `updated_from_date` and `updated_to_date`), and it takes precedence over them when you send both in the same call.
+
+:::warning Attention
+If either of the two dates cannot be parsed, or if you send the array with a single value, the platform drops the whole range and responds with the collection without any date filter, with `HTTP 200 OK` and no error message. In that same call, any `from_date` and `to_date` you sent separately are dropped as well. Instead of a `4xx` you receive many more records than you asked for, so validate the dates before building the call and compare `meta.total_entries` against what you expected.
+:::
+
+The resources that accept `date_range` are:
+
+- `GET /api/admin/logs`
+- `GET /api/admin/business_events`, which accepts it without declaring it in the Swagger catalog
+- `GET /api/admin/customers/{realm_uid}/payments/orders`
+- `GET /api/admin/customers/{realm_uid}/originations/{id}/submissions`, the only one that also accepts `updated_date_range`
+- `GET /api/admin/customers/{realm_uid}/originations/{id}/assignees`
+
+In the submissions of an origination and in its assignees, the filter is only applied when the range arrives with both dates; in any other case the collection is returned unfiltered.
+
 ## Logs
 
 With the Logs API you get the activity records that happen within Modyo Platform. Each record stores the type of action (`type`), the administrator who performed it (`user`, empty when the action is automated), the affected object (`loggeable_type` and `loggeable_id`), and the context where it happened (`site_id`, `space_id`). End user activity arrives with its own record types, such as `user_login_log` or `form_response_created_log`.

--- a/docs/en/platform/core/api.md
+++ b/docs/en/platform/core/api.md
@@ -540,7 +540,7 @@ Finally, the API will always return the first page (`current_page: 1`) of resour
 
 `per_page` has a cap of 100 records. If you ask for a larger value, the API trims it silently: it responds `HTTP 200 OK` with 100 records, with no error and no warning in the body. The only place where you see how many records each page actually carries is `meta.per_page`, so read it instead of assuming the value you sent.
 
-Out-of-range values do not fail either, they silently fall back to a default:
+Out-of-range values do not fail either; they silently fall back to a default:
 
 - `per_page=0`, a negative value, or a non-numeric value do not bring "everything": the page stays at the default 10 records.
 - `page=0`, a negative value, or a non-numeric value return the first page.

--- a/docs/es/platform/core/api.md
+++ b/docs/es/platform/core/api.md
@@ -532,6 +532,88 @@ Lo que entrega un response como el siguiente:
 
 Finalmente, la API siempre retornará la primera página (`current_page: 1`) de recursos agrupados por páginas de 10 elementos (`per_page: 10`) de manera predeterminada.
 
+### Límite de registros por página
+
+`per_page` tiene un tope de 100 registros. Si pides un valor mayor, la API lo recorta en silencio: responde `HTTP 200 OK` con 100 registros, sin error y sin ninguna advertencia en el cuerpo. El único lugar donde ves cuántos registros trae realmente cada página es `meta.per_page`, así que conviene leerlo en vez de dar por hecho el valor que enviaste.
+
+Los valores fuera de rango tampoco fallan, caen a un valor predeterminado sin avisar:
+
+- `per_page=0`, un valor negativo o un valor que no es un número no traen "todo": la página queda en los 10 registros predeterminados.
+- `page=0`, un valor negativo o un valor que no es un número devuelven la primera página.
+- Existe un tercer parámetro, `paginate`, que tampoco desactiva la paginación. Con `paginate=false` o `paginate=0` la página pasa a 100 registros, exactamente lo mismo que `per_page=100`.
+
+No hay ninguna combinación de parámetros que devuelva una colección completa en una sola llamada. Para llevarte todos los registros de un recurso, recorre las páginas hasta `meta.total_pages`.
+
+:::warning Atención
+El catálogo Swagger de `GET /api/admin/sites` declara `per_page` con la descripción "Number of items per page (0 for all)", un máximo de 1000 y un valor predeterminado de 25. Las tres cosas son falsas: ese listado pagina como el resto de la API, con tope 100, 10 registros predeterminados y `per_page=0` devolviendo 10. Una sincronización de sitios escrita con `per_page=0` confiando en esa descripción recibe 10 sitios y `HTTP 200 OK`, sin ninguna señal de que faltan los demás.
+:::
+
+## Parámetros comunes de las colecciones
+
+Los listados de la API de administración comparten un grupo de parámetros de query que se comportan igual en todos los recursos, aunque el catálogo Swagger no los declare en todas las operaciones. Comparten también la misma forma de fallar: un valor que la plataforma no entiende no devuelve un error, se ignora y la consulta responde con su comportamiento predeterminado.
+
+### Selección de atributos con only
+
+`only` recorta los atributos que trae la respuesta y está disponible en la mayoría de los listados y detalles de la API de administración. Se envía como arreglo, repitiendo el parámetro una vez por atributo:
+
+```shell script
+curl -X GET "https://test.modyo.com/api/admin/messaging/campaigns?only[]=id&only[]=name" -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+Un atributo que no existe en el recurso simplemente no aparece en la respuesta y no genera error.
+
+:::warning Atención
+No uses `only` como lista separada por comas. Algunas operaciones del catálogo Swagger lo declaran así, con ejemplos del estilo `id,name,admin_users_count` (es el caso de `/api/admin/groups` y de `/api/admin/customers/{realm_uid}/forms`), pero la plataforma no divide el valor por comas: toma `id,name` como el nombre de un único atributo, no encuentra ninguno que se llame así y devuelve la colección con todos sus objetos vacíos, con `HTTP 200 OK`.
+:::
+
+:::tip Tip
+En `GET /api/admin/versions`, `only` significa otra cosa: no recorta atributos, sino que filtra las versiones por tipo con una lista separada por comas de `editable`, `current`, `backup` y `scheduled`, por ejemplo `only=editable,current`. Es el único recurso donde `only` se interpreta de esta forma.
+:::
+
+### Orden con sort_by y order
+
+`sort_by` elige el atributo por el que se ordena la colección y `order` el sentido, con los valores `ASC` y `DESC`. `order` no distingue mayúsculas de minúsculas, así que `asc` y `desc` también sirven.
+
+Salvo que el recurso indique otra cosa, el orden predeterminado es `updated_at` en `DESC`, del registro modificado más recientemente al más antiguo.
+
+Ambos parámetros caen a ese orden predeterminado en silencio cuando el valor no sirve:
+
+- `order` con cualquier valor distinto de `ASC` o `DESC` se ignora por completo.
+- `sort_by` solo se respeta si nombra un atributo real del recurso y, cuando el recurso publica en el catálogo Swagger una lista de atributos ordenables, si pertenece a esa lista. Un atributo mal escrito o fuera de la lista se ignora.
+
+Un listado ordenado por un `sort_by` inválido se ve igual que uno ordenado correctamente, así que revisa el orden de los registros en la respuesta antes de dar la consulta por buena.
+
+Estos recursos aceptan `sort_by` y `order` aunque el catálogo Swagger no los declare entre sus parámetros:
+
+- `GET /api/admin/customers/{realm_uid}/forms`
+- `GET /api/admin/customers/{realm_uid}/originations`
+- `GET /api/admin/customers/{realm_uid}/users/{user_id}/submissions`, que además no aparece en el catálogo
+- Los listados de `/api/admin/team_members`, que declaran `order` en algunas operaciones pero nunca `sort_by`
+
+### Rangos de fecha
+
+`date_range` acota una colección por la fecha de creación de sus registros y `updated_date_range` por la fecha de la última modificación. Los dos reciben las dos fechas como arreglo:
+
+```shell script
+curl -X GET "https://test.modyo.com/api/admin/logs?date_range[]=2026-07-01&date_range[]=2026-07-15" -H 'Authorization: Bearer 8c280d601fc1b361aabb20836841b4b82faab23e990148c91406bbf5e452ab56'
+```
+
+La plataforma expande cada fecha al día completo: el primer valor pasa al inicio de ese día y el segundo al final. La hora que envíes no cambia nada, `date_range[]=2026-07-15T18:00:00` cubre igualmente el 15 de julio entero, y un rango con la misma fecha en los dos valores cubre ese día completo. Internamente el rango se traduce a los parámetros `from_date` y `to_date` (o `updated_from_date` y `updated_to_date`), y tiene prioridad sobre ellos cuando los envías en la misma llamada.
+
+:::warning Atención
+Si alguna de las dos fechas no se puede interpretar, o si envías el arreglo con un solo valor, la plataforma descarta el rango completo y responde la colección sin ningún filtro de fecha, con `HTTP 200 OK` y sin mensaje de error. En esa misma llamada también se descartan los `from_date` y `to_date` que hayas enviado por separado. En vez de un `4xx` recibes muchos más registros de los que pediste, así que valida las fechas antes de armar la llamada y compara `meta.total_entries` con lo que esperabas.
+:::
+
+Los recursos que aceptan `date_range` son:
+
+- `GET /api/admin/logs`
+- `GET /api/admin/business_events`, que lo acepta sin declararlo en el catálogo Swagger
+- `GET /api/admin/customers/{realm_uid}/payments/orders`
+- `GET /api/admin/customers/{realm_uid}/originations/{id}/submissions`, el único que acepta también `updated_date_range`
+- `GET /api/admin/customers/{realm_uid}/originations/{id}/assignees`
+
+En las respuestas de una originación y en sus asignados, el filtro solo se aplica cuando el rango llega con las dos fechas; en cualquier otro caso la colección se devuelve sin filtrar.
+
 ## Registros (Logs)
 
 Con la API de Logs obtienes los registros de actividad que suceden dentro de Modyo Platform. Cada registro guarda el tipo de acción (`type`), el administrador que la ejecutó (`user`, vacío cuando la acción es automática), el objeto afectado (`loggeable_type` y `loggeable_id`) y el contexto donde ocurrió (`site_id`, `space_id`). La actividad de los usuarios finales llega con tipos de registro propios, como `user_login_log` o `form_response_created_log`.

--- a/docs/es/platform/core/api.md
+++ b/docs/es/platform/core/api.md
@@ -536,7 +536,7 @@ Finalmente, la API siempre retornará la primera página (`current_page: 1`) de 
 
 `per_page` tiene un tope de 100 registros. Si pides un valor mayor, la API lo recorta en silencio: responde `HTTP 200 OK` con 100 registros, sin error y sin ninguna advertencia en el cuerpo. El único lugar donde ves cuántos registros trae realmente cada página es `meta.per_page`, así que conviene leerlo en vez de dar por hecho el valor que enviaste.
 
-Los valores fuera de rango tampoco fallan, caen a un valor predeterminado sin avisar:
+Los valores fuera de rango tampoco fallan, sino que caen a un valor predeterminado sin avisar:
 
 - `per_page=0`, un valor negativo o un valor que no es un número no traen "todo": la página queda en los 10 registros predeterminados.
 - `page=0`, un valor negativo o un valor que no es un número devuelven la primera página.


### PR DESCRIPTION
## Cambios propuestos

Documenta el contrato que comparten todas las colecciones de la API de administración y que hasta ahora no estaba escrito en ninguna parte. Verificado contra `master` de la plataforma, no contra `releases/10.2-stable`.

### `docs/{es,en}/platform/core/api.md`

- **Límite de registros por página**, dentro de Paginación: el tope real de 100, el recorte silencioso de `per_page`, y qué hacen de verdad `per_page=0`, `page=0` y `paginate=false` — ninguno devuelve la colección completa.
- **Parámetros comunes de las colecciones**, sección nueva con `only`, `sort_by` / `order` y los rangos de fecha.

## Lo que corrige del catálogo Swagger

- `GET /api/admin/sites` declara `per_page` con «0 for all», máximo 1000 y predeterminado 25. Las tres son falsas: pagina como el resto, con tope 100 y 10 predeterminados. Queda como advertencia explícita, porque es la que produce pérdida de datos silenciosa.
- Cuatro operaciones declaran `only` como lista separada por comas. La plataforma no divide por comas: toma `id,name` como un único nombre de atributo, no encuentra ninguno y devuelve la colección con **todos sus objetos vacíos y HTTP 200**.
- `only` en `GET /api/admin/versions` significa otra cosa: filtra versiones por tipo, no recorta atributos. Es el único recurso donde se interpreta así.

## Diferencias con la ficha del plan, verificadas en master

- El enum de `only` en `/versions` incluye `scheduled`, que la ficha no listaba.
- `team_members` sí declara `order` en algunas operaciones; la ficha decía que ninguno de los cuatro recursos lo declaraba.
- Al descartarse un rango de fecha inválido, la plataforma además borra `from_date` y `to_date`. La ficha no lo recogía y cambia el resultado de la consulta.
- La sección de Logs ya documentaba el descarte silencioso de `date_range` para ese recurso: no se tocó, para no duplicar.

Closes #1054

Gaps: `API-ADMIN-06`, `API-ADMIN-07`, `API-ADMIN-08`, `API-ADMIN-09`

🤖 Generated with [Claude Code](https://claude.com/claude-code)