### PR TITLE
sites.md: estados de una aplicación, selección de tema, clonado y pantalla Resumen

### DIFF
--- a/docs/en/platform/channels/sites.md
+++ b/docs/en/platform/channels/sites.md
@@ -6,11 +6,15 @@ search: true
 
 A web application or web app displays the content created in Content and Channels to create your personalized digital channel. All the development, design, and navigation flow is carried out in the web application.
 
-A web app can be in one of these three states:
+A web application can be in one of these three states, which you choose in **Application settings** > [General](/en/platform/channels/sites.html#general) > **Change status**:
 
-- **Enabled**: Default status of newly created web applications and those that are enabled for use.
-- **Pending changes**: There are pending changes in the web application. An administrator can verify the changes and publish the web application.
-- **Disabled**: The web application cannot be accessed.
+- **Enabled**: The web application is editable and visible to the public.
+- **Draft**: The web application is modifiable but not visible to the public: it requires logging in to access. This is the state in which every newly created web application starts.
+- **Disabled**: The web application is neither editable nor accessible.
+
+:::tip Transient states
+In addition to these three, the platform uses two states that it assigns on its own and that you cannot choose in the selector: one for a copy while it is being cloned, and another for an application while it is being deleted. In both cases, the application does not appear in the applications list while the process lasts.
+:::
 
 ## Create a Web Application
 
@@ -19,14 +23,104 @@ To create a new web app, follow these steps:
 1. In the side menu, click on **channels**.
 1. Click on **+ new application**.
 1. Type the name and host (main path of the web application).
+1. In **Theme**, select the theme the web application starts from.
 1. If necessary, select which realm it belongs to.
 1. Click **create**.
 
-Once created, the web application is automatically enabled and the system takes you to the summary screen.
+Once created, the web application is in **Draft** status and the system takes you to the [Overview](/en/platform/channels/sites.html#application-overview) screen. To make it visible to the public, change its status to **Enabled** in **Application settings** > [General](/en/platform/channels/sites.html#general) > **Change status**.
 
 :::warning Attention
 In the web apps index, you will only see those apps in which you have a role and are part of the team.
 :::
+
+### Theme
+
+The theme is the set of templates, snippets, CSS, and JavaScript the web application is born with. It determines its starting point and nothing else: it is an initial mold, not a permanent dependency.
+
+- The list of available themes depends on the plan contracted for the account.
+- If only one theme is available, the selector is disabled and the application is created with the default theme.
+- Once the application is created, its [templates](/en/platform/channels/templates.html) can be edited freely, and there is no option to change the theme.
+
+## Clone a Web Application
+
+Cloning creates an independent copy of a web application within the same account. It is useful for starting from an application that is already built, with its pages, templates, and widgets, without redoing it from scratch.
+
+To clone a web application, follow these steps:
+
+1. In the side menu, click on **channels**.
+1. In the applications list, find the one you want to copy and, in the **Actions** column, click **Clone**.
+1. In the **Clone app** window, click the **Clone app** button.
+1. Wait for the process to finish. When it does, the list refreshes with the copy already created.
+
+The copy takes the name and host of the original, preceded by **Copy of**. If that name or host already exists in the account, Modyo appends a number.
+
+**What is copied**:
+
+- Templates and snippets.
+- Widgets and pages, with their hierarchy.
+- Navigation.
+- App variables.
+- Custom meta tags, custom redirects, and forced reviewers.
+- Team members with their roles.
+- The logo, the favicon, and the Apple icon.
+
+**What is not copied**:
+
+- The custom domain and the alternative domains: the copy is reachable only through its host.
+- The Google Tag Manager ID.
+- Origination pages.
+- The stages of the original application.
+- The status: the copy always starts in **Draft**, even if the original is **Enabled**.
+
+All the content of the copy starts unpublished, so you must publish it before it becomes visible.
+
+:::tip Tip
+Cloning takes some time and runs in the background. While it lasts, the window shows the message "This will take some time, the app is being cloned" and the copy does not appear in the applications list yet.
+:::
+
+:::warning Attention
+Cloning is subject to your plan's maximum number of applications. If you have already reached that maximum, the operation fails with the message "You've reached the maximum number of apps for your current plan".
+:::
+
+:::tip Cloning is not the same as creating a stage
+[Adding a stage](/en/platform/channels/sites.html#add-a-new-stage) also copies a web application, but the result is another stage of the same application, meant for developing and then synchronizing the changes back. Cloning, on the other hand, produces an independent application that does not synchronize with the original.
+:::
+
+## Application Overview
+
+**Overview** is the entry screen of every web application: it is where you land when you select it in the applications list, and where you return with the **Overview** option in the side menu.
+
+In the main column you find:
+
+- Direct access to **Pages**, **Navigation**, **Widgets**, and **Templates**, each with the number of elements in the application.
+- **Activity**: the log of the actions administrators have performed on the application.
+
+In the side column you find the application's identification data:
+
+- **Stage**: the stage you are working on, next to the access to the synchronization view.
+- **Status**: **Pending changes** if there are unpublished elements, or **Published** if there are none.
+- **Realm**: the realm the application is linked to, or **None**.
+- **Privacy**: **Public** or **Private**.
+- **Time zone**, **Language**, **Description**, and **ID** of the application.
+
+In the header you see the date of the last release, the access to the application's **Preview**, and the **Publish** button, which opens the [Review and Joint Publication](/en/platform/channels/sites.html#review-and-joint-publication) screen. **Publish** is only available to those with the **Admin Synchronizations** or **Manage Channels** permission, and it is disabled when there are no pending changes.
+
+### Pending changes to publish
+
+When the application has [team review](/en/platform/channels/sites.html#team-review) enabled, one of these three messages appears under the **Pending changes** status:
+
+- **All changes are approved**: the review conditions are met and you can publish.
+- **Changes need review**: there are no approvals yet, and the **Publish** button remains disabled.
+- **Some changes are not approved and need review**: there are partial approvals.
+
+### Access to synchronization
+
+The **Stage** block only appears if your role has one of the synchronization permissions, and the button changes depending on which one:
+
+- With **Admin Synchronizations** you see **Synchronize** and you can [synchronize the stage](/en/platform/channels/sites.html#synchronize-a-stage).
+- With **View Synchronizations** you see **Synchronize (read only)**: you enter the synchronization view and review the differences, but you cannot apply them.
+
+If the application has unpublished changes, a warning icon appears next to the stage name with the message "Before sync you have to publish all your changes", and when you click **Synchronize**, Modyo asks for confirmation before continuing.
 
 ## Review and Joint Publication
 
@@ -221,8 +315,8 @@ Proceed with caution when modifying these options, as they can affect access to 
 - **Change host**: This action modifies the visibility and accessibility of the application. Changing the host can impact the visibility and availability of the web application.
 - **Change realm**: Displays the application's realm. When you change the realm, you lose all privacy settings in your web apps, pages, and navigation, and the site's origination pages lose the reference to their current origination.
 - **Change status**: Changes the application's status. Options are:
-	* Enabled: Editable and visible to the public. This is the default state of a web app.
-	* Editable: Modifiable but not visible to the public. Requires login to access. Robots.txt, PWAs, and the manifest are disabled in this state.
+	* Enabled: Editable and visible to the public.
+	* Draft: Modifiable but not visible to the public. Requires login to access. This is the state in which every newly created web application starts. Robots.txt, PWAs, and the manifest are disabled in this state.
 	* Disabled: Not editable or visible. In this state, it is not accessible or visible to users.
 - **Delete application**: Initiates the asynchronous deletion of the application and all its elements, such as pages and widgets.
 

--- a/docs/es/platform/channels/sites.md
+++ b/docs/es/platform/channels/sites.md
@@ -6,11 +6,15 @@ search: true
 
 Una aplicación web (web app) despliega el contenido creado en Content y Channels para crear tu canal digital personalizado. En la aplicación web se lleva a cabo todo el desarrollo, diseño y flujo de navegación.
 
-Una web app puede estar en uno de estos tres estados:
+Una aplicación web puede estar en uno de estos tres estados, que eliges en **Configuración de la aplicación** > [General](/es/platform/channels/sites.html#general) > **Cambiar estado**:
 
-- **Habilitado**: Estado por defecto de las aplicaciones web recién creadas y aquellas que están habilitadas para uso.
-- **Cambios pendientes**: Existen modificaciones pendientes en la aplicación web. Un administrador puede verificar los cambios y publicar la aplicación web.
-- **Deshabilitado**: No es posible acceder a la aplicación web.
+- **Habilitado**: La aplicación web es editable y visible para el público.
+- **Editable**: La aplicación web es modificable, pero no visible para el público: requiere iniciar sesión para acceder. Es el estado con el que nace toda aplicación web recién creada.
+- **Deshabilitado**: La aplicación web no es editable ni accesible.
+
+:::tip Estados transitorios
+Además de estos tres, la plataforma usa dos estados que asigna por su cuenta y que no puedes elegir en el selector: el de una copia mientras se está clonando y el de una aplicación mientras se está eliminando. En ambos casos la aplicación no aparece en el listado de aplicaciones mientras dura el proceso.
+:::
 
 ## Crear una Aplicación Web
 
@@ -19,14 +23,104 @@ Para crear una nueva web app, sigue estos pasos:
 1. En el menú lateral, haz click en **channels**.
 1. Haz click en **nueva aplicación**.
 1. Escribe el nombre y el host (ruta principal de la aplicación web).
+1. En **Tema**, selecciona el tema con el que parte la aplicación web.
 1. Si es necesario, selecciona a qué reino pertenece.
 1. Haz click en **crear**.
 
-Una vez creada, la aplicación web se habilita automáticamente y el sistema te lleva a la pantalla de resumen.
+Una vez creada, la aplicación web queda en estado **Editable** y el sistema te lleva a la pantalla de [Resumen](/es/platform/channels/sites.html#resumen-de-la-aplicacion). Para que sea visible al público, cambia su estado a **Habilitado** en **Configuración de la aplicación** > [General](/es/platform/channels/sites.html#general) > **Cambiar estado**.
 
 :::warning Atención
 En el índice de web apps, solo verás aquellas apps en las cuales tienes algún rol y eres parte del equipo de trabajo.
 :::
+
+### Tema
+
+El tema es el conjunto de plantillas, snippets, CSS y JavaScript con el que nace la aplicación web. Determina su punto de partida y nada más: es un molde inicial, no una dependencia permanente.
+
+- La lista de temas disponibles depende del plan contratado en la cuenta.
+- Si solo hay un tema disponible, el selector queda deshabilitado y la aplicación se crea con el tema por defecto.
+- Una vez creada la aplicación, sus [plantillas](/es/platform/channels/templates.html) se editan libremente y no existe una opción para cambiar de tema.
+
+## Clonar una aplicación web
+
+Clonar crea una copia independiente de una aplicación web dentro de la misma cuenta. Es útil para partir de una aplicación ya construida, con sus páginas, plantillas y widgets, sin rehacerla desde cero.
+
+Para clonar una aplicación web, sigue estos pasos:
+
+1. En el menú lateral, haz click en **channels**.
+1. En el listado de aplicaciones, ubica la que quieres copiar y, en la columna **Acciones**, haz click en **Clonar**.
+1. En la ventana **Clonar aplicación**, haz click en el botón **Clonar aplicación**.
+1. Espera a que el proceso termine. Al finalizar, el listado se actualiza con la copia ya creada.
+
+La copia toma el nombre y el host de la original precedidos de **Copia de**. Si ese nombre o ese host ya existen en la cuenta, Modyo agrega un número al final.
+
+**Qué se copia**:
+
+- Las plantillas y los snippets.
+- Los widgets y las páginas, con su jerarquía.
+- La navegación.
+- Las variables de la aplicación.
+- Los meta tags personalizados, las redirecciones personalizadas y los revisores forzados.
+- Los miembros del equipo con sus roles.
+- El logo, el favicon y el icono de Apple.
+
+**Qué no se copia**:
+
+- El dominio personalizado y los dominios alternativos: la copia queda accesible solo por su host.
+- El ID de Google Tag Manager.
+- Las páginas de originación.
+- Los stages de la aplicación original.
+- El estado: la copia siempre nace en estado **Editable**, aunque la original esté **Habilitado**.
+
+Todo el contenido de la copia nace sin publicar, así que debes publicarlo antes de que sea visible.
+
+:::tip Tip
+El clonado toma un tiempo y ocurre en segundo plano. Mientras dura, la ventana muestra el mensaje "Esto demorará un tiempo, la aplicación está siendo clonada" y la copia todavía no aparece en el listado de aplicaciones.
+:::
+
+:::warning Atención
+El clonado está sujeto al máximo de aplicaciones de tu plan. Si ya alcanzaste ese máximo, la operación falla con el mensaje "Has alcanzado el número máximo de aplicaciones para el plan actual".
+:::
+
+:::tip Clonar no es lo mismo que crear un stage
+[Agregar un stage](/es/platform/channels/sites.html#agregar-un-nuevo-stage) también copia una aplicación web, pero el resultado es otra etapa de la misma aplicación, pensada para desarrollar y luego sincronizar los cambios de vuelta. Clonar, en cambio, produce una aplicación independiente que no se sincroniza con la original.
+:::
+
+## Resumen de la aplicación
+
+**Resumen** es la pantalla de entrada de toda aplicación web: es a donde llegas al seleccionarla en el listado de aplicaciones, y a donde vuelves con la opción **Resumen** del menú lateral.
+
+En la columna principal encuentras:
+
+- Accesos directos a **Páginas**, **Navegación**, **Widgets** y **Plantillas**, cada uno con la cantidad de elementos de la aplicación.
+- **Actividad**: la bitácora de las acciones que los administradores han realizado sobre la aplicación.
+
+En la columna lateral encuentras los datos de identificación de la aplicación:
+
+- **Etapa**: el stage en el que estás trabajando, junto al acceso a la vista de sincronización.
+- **Estado**: **Cambios pendientes** si hay elementos sin publicar, o **Publicado** si no los hay.
+- **Reino**: el reino al que está vinculada la aplicación, o **Ninguno**.
+- **Privacidad**: **Público** o **Privado**.
+- **Zona horaria**, **Lenguaje**, **Descripción** e **ID** de la aplicación.
+
+En el encabezado ves la fecha del último release, el acceso a la **Vista previa** de la aplicación y el botón **Publicar**, que abre la pantalla de [Revisión y publicación conjunta](/es/platform/channels/sites.html#revision-y-publicacion-conjunta). **Publicar** solo está disponible para quienes tienen el permiso **Administrar Sincronizaciones** o **Gestionar Canales**, y se deshabilita cuando no hay cambios pendientes.
+
+### Cambios pendientes por publicar
+
+Cuando la aplicación tiene la [revisión en equipo](/es/platform/channels/sites.html#revision-en-equipo) activada, bajo el estado **Cambios pendientes** aparece uno de estos tres mensajes:
+
+- **Todos los cambios están aprobados**: se cumplen las condiciones de revisión y puedes publicar.
+- **Los cambios requieren revisión**: todavía no hay ninguna aprobación, y el botón **Publicar** permanece deshabilitado.
+- **Algunos cambios no se han aprobado y necesitan revisión**: hay aprobaciones parciales.
+
+### Acceso a la sincronización
+
+El bloque **Etapa** solo aparece si tu rol tiene alguno de los permisos de sincronización, y el botón cambia según cuál sea:
+
+- Con **Administrar Sincronizaciones** ves **Sincronizar** y puedes [sincronizar el stage](/es/platform/channels/sites.html#sincronizar-un-stage).
+- Con **Ver Sincronizaciones** ves **Sincronizar (solo lectura)**: entras a la vista de sincronización y revisas las diferencias, pero no puedes aplicarlas.
+
+Si la aplicación tiene cambios sin publicar, junto al nombre del stage aparece un ícono de advertencia con el mensaje "Tienes que publicar todos los cambios antes de sincronizar", y al hacer click en **Sincronizar** Modyo te pide confirmación antes de continuar.
 
 ## Revisión y publicación conjunta
 
@@ -221,8 +315,8 @@ Procede con cautela al modificar estas opciones, ya que pueden afectar el acceso
 - **Cambiar host**: Esta acción modifica la visibilidad y accesibilidad de la aplicación. Realizar un cambio de host puede impactar la visibilidad y disponibilidad de la aplicación web.
 - **Cambiar reino**: Despliega el reino de la aplicación. Al cambiar de reino pierdes toda la configuración de privacidad en tus web apps, páginas y navegación, y las páginas de originación del sitio pierden la referencia a su originación actual.
 - **Cambiar estado**: Cambia el estado de la aplicación, las opciones son:
-	* Habilitado: Editable y visible al público. Este es el estado por defecto de una web app.
-	* Editable: Modificable pero no visible al público. Requiere inicio de sesión para acceder. Robots.txt, PWAs y el manifiesto están deshabilitados en este estado.
+	* Habilitado: Editable y visible al público.
+	* Editable: Modificable pero no visible al público. Requiere inicio de sesión para acceder. Es el estado con el que nace toda aplicación web recién creada. Robots.txt, PWAs y el manifiesto están deshabilitados en este estado.
 	* Deshabilitado: No editable ni visible. En este estado, no es accesible ni visible para los usuarios.
 - **Eliminar aplicación**: Inicia la eliminación asíncrona de la aplicación y de todos sus elementos, como páginas y widgets.
 


### PR DESCRIPTION
## Cambios propuestos

Cuatro correcciones y adiciones a la página de aplicaciones web, todas verificadas contra `master` de la plataforma.

### `docs/{es,en}/platform/channels/sites.md`

- **Estados de una aplicación**: la lista de apertura usaba «Cambios pendientes», que es un estado de publicación de elementos y no de la aplicación. El label real del selector es **Editable**. Además se elimina la contradicción con la lista de «Zona peligrosa» que aparecía 200 líneas más abajo diciendo otra cosa.
- **Selección de tema**: el asistente de creación tiene un paso de Tema que el procedimiento numerado se saltaba.
- **Clonar una aplicación**: qué se copia y qué no, que no estaba documentado en ninguna parte.
- **Pantalla Resumen**: ficha nueva, con el bloque de etapa y la acción de sincronizar.

## Diferencias con la ficha del plan, verificadas en master

Varias afirmaciones de la ficha no resistieron la verificación y se documentó lo que hace el código:

- **Una aplicación no nace habilitada.** La columna `status` tiene `default: 3`, que es el estado **Editable**. La ficha daba por hecho lo contrario.
- **El asistente solo ofrece los temas del plan de la cuenta**, no el catálogo completo de temas.
- **Los stages no excluyen las redirecciones**, como decía la ficha: sí se clonan. Lo que sí se excluye al clonar una aplicación son las páginas de originación.
- **La pantalla Resumen no tiene selector de etapa.** Muestra el nombre de la etapa y el botón de sincronizar.
- **La acción de la columna se llama «Clonar»**, no «Clonar aplicación»; ese último es el título del modal.
- **El estado «Editable» es solo del español**: en inglés el label es **Draft**. El espejo inglés decía «Editable» y quedó corregido.

Se omitió deliberadamente que durante la clonación no se invalida la caché de CDN: es interno de infraestructura.

Closes #1056

Gaps: `CHANNELS-EX-02`, `CHANNELS-11`, `CHANNELS-18`, `CHANNELS-22`

🤖 Generated with [Claude Code](https://claude.com/claude-code)