### PR TITLE
cli.md: los widgets publicados con el CLI quedan de solo lectura en el panel

### DIFF
--- a/docs/en/platform/channels/widgets.md
+++ b/docs/en/platform/channels/widgets.md
@@ -160,7 +160,7 @@ ES Modules have strict CORS requirements and are always loaded in strict mode. E
 
 ## CLI widgets
 
-Widgets that reach the site through `modyo-cli push` are marked as read-only widgets, because their source code lives in your repository and not in Modyo. In the site's widget list you recognize them by the **CLI** badge next to their name.
+Widgets **created** in the site through `modyo-cli push` are marked as read-only widgets, because their source code lives in your repository and not in Modyo. In the site's widget list you recognize them by the **CLI** badge next to their name.
 
 When you open one of these widgets you won't see the code tabs, but the **Widget summary** screen, with its **Name**, **Type**, **Size**, **Chunks**, **Last updated at**, and **Last updated by**, headed by the notice "CLI Widgets can't be edited in Modyo. Download it to review its content." and the **Download** button.
 

--- a/docs/en/platform/channels/widgets.md
+++ b/docs/en/platform/channels/widgets.md
@@ -158,6 +158,18 @@ ES Module loading is especially useful for widgets built with modern frameworks 
 ES Modules have strict CORS requirements and are always loaded in strict mode. Ensure your widget code is compatible with ES module semantics before enabling this option.
 :::
 
+## CLI widgets
+
+Widgets that reach the site through `modyo-cli push` are marked as read-only widgets, because their source code lives in your repository and not in Modyo. In the site's widget list you recognize them by the **CLI** badge next to their name.
+
+When you open one of these widgets you won't see the code tabs, but the **Widget summary** screen, with its **Name**, **Type**, **Size**, **Chunks**, **Last updated at**, and **Last updated by**, headed by the notice "CLI Widgets can't be edited in Modyo. Download it to review its content." and the **Download** button.
+
+The rest of the lifecycle is that of any widget: it keeps an editable and a published version, supports [variables](#widget-variables), goes through [team review](/en/platform/core/#team-review), and is instantiated on pages from the [Page Builder](/en/platform/channels/pages.html). Code changes, however, are never shown as differences: in the **Differences** view, in [review and joint publication](/en/platform/channels/sites.html#review-and-joint-publication), and in [synchronization between stages](/en/platform/channels/sites.html#stages), the message "The file has differences but CLI Widgets can not be displayed" is shown. You also can't use **Reset to this version** to take the widget back to a previous version: rolling back is done by deploying again from your repository.
+
+:::warning Attention
+The ZIP delivered by **Download** is built from the templates stored in the platform and is not the bundle you uploaded: entry files are renamed and chunks are flattened. It's meant to inspect the published code, not as a backup. See [CLI widgets in the admin](/en/platform/tools/cli.html#cli-widgets-in-the-admin) for full details.
+:::
+
 ## Code splitting
 
 Widgets deployed through the [Modyo CLI](/en/platform/tools/cli.html) can be split into multiple files (*chunks*) in addition to their entry files. The platform stores and serves each chunk individually, and the widget loads them dynamically only when needed, making the initial load of large widgets lighter.

--- a/docs/en/platform/tools/cli.md
+++ b/docs/en/platform/tools/cli.md
@@ -569,7 +569,9 @@ If you have defined [variables](/en/platform/channels/global-variables.html), th
 
 ## CLI widgets in the admin
 
-A widget created or updated with `modyo-cli push` is marked in the platform as a read-only widget, because its source code lives in your repository and not in Modyo. This is a direct consequence of deploying with the CLI, and it's worth knowing before adopting it.
+A widget **created** with `modyo-cli push` is marked in the platform as a read-only widget, because its source code lives in your repository and not in Modyo. This is a direct consequence of deploying with the CLI, and it's worth knowing before adopting it.
+
+The mark is decided at that moment and is never re-evaluated: a widget that already existed in the panel and later receives a CLI deploy keeps its editing and does not become read-only.
 
 In the site's widget list, these widgets are identified by the **CLI** badge next to their name. When you open one you won't find the code tabs, but the **Widget summary** screen, with:
 

--- a/docs/en/platform/tools/cli.md
+++ b/docs/en/platform/tools/cli.md
@@ -566,3 +566,50 @@ The token owner user must have a role of [site reviewer or admin](/en/platform/c
 Once a widget is deployed and published in Modyo, it's available to be used on the pages of the site it belongs to.
 
 If you have defined [variables](/en/platform/channels/global-variables.html), their values can be specified at a global level or particular to each widget instance.
+
+## CLI widgets in the admin
+
+A widget created or updated with `modyo-cli push` is marked in the platform as a read-only widget, because its source code lives in your repository and not in Modyo. This is a direct consequence of deploying with the CLI, and it's worth knowing before adopting it.
+
+In the site's widget list, these widgets are identified by the **CLI** badge next to their name. When you open one you won't find the code tabs, but the **Widget summary** screen, with:
+
+- **Name**: the widget's name in Modyo.
+- **Type**: the CLI badge.
+- **Size**: the total weight of the widget's files.
+- **Chunks**: the number of files beyond the entry points, not counting source maps.
+- **Last updated at**: the date and time of the last deployment.
+- **Last updated by**: the user who performed the last deployment.
+
+Above the summary, the notice "CLI Widgets can't be edited in Modyo. Download it to review its content." is displayed next to the **Download** button.
+
+The rest of the lifecycle is that of any widget: it keeps an editable and a published version, supports [variables](/en/platform/channels/widgets.html#widget-variables), goes through [team review](/en/platform/core/#team-review), and is instantiated on pages from the [Page Builder](/en/platform/channels/pages.html). The properties column still shows the name, the tags, and the list of pages using the widget.
+
+### Code differences
+
+When comparing versions of a CLI widget, whether in the widget's **Differences** view, in [review and joint publication](/en/platform/channels/sites.html#review-and-joint-publication), or in [synchronization between stages](/en/platform/channels/sites.html#stages), the platform detects that there are changes but does not show the line-by-line diff. Instead, the message "The file has differences but CLI Widgets can not be displayed" is shown.
+
+The same behavior applies to any template that exceeds the allowed size limit, with the message "The file has differences but the size of the file surpass the limit permitted and can not be displayed".
+
+You also can't use **Reset to this version** to take a CLI widget back to a previous version. To review or revert changes between deployments, use your repository history and run `modyo-cli push` again with the version you need.
+
+### The ZIP from the Download button
+
+The **Download** button calls `GET /api/admin/sites/{site_id}/widget_definitions/{id}/download` and builds a ZIP on the fly from the templates stored in the platform. It is not the file you uploaded, and its content does not match your build:
+
+- Entry files are renamed with the widget identifier: `<uuid>.js`, `<uuid>.css`, and `<uuid>.html`, instead of `main.js` and `main.css`.
+- Chunks lose their path: only the last segment is kept, so a build organized in subdirectories is flattened and two files with the same name in different folders collide.
+- `.wasm` files are delivered decoded.
+
+:::warning Attention
+The ZIP from **Download** is meant to inspect what code is running on the platform, not as a backup: it can't be redeployed as is. The source of truth for a CLI widget is always your repository.
+:::
+
+### Permissions and deployments from your own pipeline
+
+To deploy with `push`, the user who owns the token needs the **Create Widgets CLI** permission, included in the [Site Developer CLI](/en/platform/core/roles.html#roles) role and above. To use the **Download** button, the **View Widgets** permission is enough.
+
+The read-only mark is decided by the platform when the widget is created, based on how the request identifies itself: it is only applied when the `User-Agent` header corresponds to the Modyo CLI.
+
+:::warning Attention
+If you integrate the deployment from your own pipeline that calls the same endpoint without identifying itself as the Modyo CLI, the widget is created as editable, the regular widget editing permission is required instead of **Create Widgets CLI**, and it stays open to changes from the admin that your next deployment will overwrite. If the widget was already marked as a CLI widget, a request that doesn't identify itself as the CLI responds successfully but does not update its code.
+:::

--- a/docs/en/platform/tools/cli.md
+++ b/docs/en/platform/tools/cli.md
@@ -599,8 +599,9 @@ You also can't use **Reset to this version** to take a CLI widget back to a prev
 The **Download** button calls `GET /api/admin/sites/{site_id}/widget_definitions/{id}/download` and builds a ZIP on the fly from the templates stored in the platform. It is not the file you uploaded, and its content does not match your build:
 
 - Entry files are renamed with the widget identifier: `<uuid>.js`, `<uuid>.css`, and `<uuid>.html`, instead of `main.js` and `main.css`.
-- Chunks lose their path: only the last segment is kept, so a build organized in subdirectories is flattened and two files with the same name in different folders collide.
+- Chunks lose their path: only the last segment of the name is kept, so the folder structure is not rebuilt.
 - `.wasm` files are delivered decoded.
+- The ZIP includes the source maps, unlike the **Chunks** counter in the Summary screen, which leaves them out. That is why the ZIP usually carries more files than that number announces.
 
 :::warning Attention
 The ZIP from **Download** is meant to inspect what code is running on the platform, not as a backup: it can't be redeployed as is. The source of truth for a CLI widget is always your repository.
@@ -610,8 +611,8 @@ The ZIP from **Download** is meant to inspect what code is running on the platfo
 
 To deploy with `push`, the user who owns the token needs the **Create Widgets CLI** permission, included in the [Site Developer CLI](/en/platform/core/roles.html#roles) role and above. To use the **Download** button, the **View Widgets** permission is enough.
 
-The read-only mark is decided by the platform when the widget is created, based on how the request identifies itself: it is only applied when the `User-Agent` header corresponds to the Modyo CLI.
+The read-only mark is decided by the platform when the widget is created, based on how the request identifies itself: it is only applied when the `User-Agent` header corresponds to one of the CLIs the platform recognizes. Those are the Modyo and Dynamic ones, and the list is configurable per installation, so check with whoever administers yours if you are unsure.
 
 :::warning Attention
-If you integrate the deployment from your own pipeline that calls the same endpoint without identifying itself as the Modyo CLI, the widget is created as editable, the regular widget editing permission is required instead of **Create Widgets CLI**, and it stays open to changes from the admin that your next deployment will overwrite. If the widget was already marked as a CLI widget, a request that doesn't identify itself as the CLI responds successfully but does not update its code.
+If you integrate the deployment from your own pipeline that calls the same endpoint without identifying itself as one of those CLIs, the widget is created as editable, the regular widget editing permission is required instead of **Create Widgets CLI**, and it stays open to changes from the admin that your next deployment will overwrite. If the widget was already marked as a CLI widget, a request that doesn't identify itself as the CLI responds successfully but does not update its code.
 :::

--- a/docs/en/platform/tools/cli.md
+++ b/docs/en/platform/tools/cli.md
@@ -601,7 +601,7 @@ The **Download** button calls `GET /api/admin/sites/{site_id}/widget_definitions
 - Entry files are renamed with the widget identifier: `<uuid>.js`, `<uuid>.css`, and `<uuid>.html`, instead of `main.js` and `main.css`.
 - Chunks lose their path: only the last segment of the name is kept, so the folder structure is not rebuilt.
 - `.wasm` files are delivered decoded.
-- The ZIP includes the source maps, unlike the **Chunks** counter in the Summary screen, which leaves them out. That is why the ZIP usually carries more files than that number announces.
+- The ZIP always carries three more files than the **Chunks** counter shows: that counter only counts chunks, while the ZIP also includes the three entry files.
 
 :::warning Attention
 The ZIP from **Download** is meant to inspect what code is running on the platform, not as a backup: it can't be redeployed as is. The source of truth for a CLI widget is always your repository.

--- a/docs/es/platform/channels/widgets.md
+++ b/docs/es/platform/channels/widgets.md
@@ -158,6 +158,18 @@ La carga como ES Module es especialmente útil para widgets construidos con fram
 Los ES Modules tienen requisitos estrictos de CORS y siempre se cargan en modo estricto. Asegúrate de que el código de tu widget sea compatible con la semántica de ES modules antes de habilitar esta opción.
 :::
 
+## Widgets CLI
+
+Los widgets que llegan al sitio con `modyo-cli push` quedan marcados como widgets de solo lectura, porque su código fuente vive en tu repositorio y no en Modyo. En el listado de widgets del sitio los reconoces por la etiqueta **CLI** junto a su nombre.
+
+Al abrir uno de estos widgets no verás las pestañas de código, sino la pantalla **Resumen del widget**, con su **Nombre**, **Tipo**, **Tamaño**, **Chunks**, **Actualizado por última vez en** y **Actualizado por última vez por**, encabezada por el aviso "Los widgets CLI no se pueden editar en Modyo. Descárgalo para revisar su contenido." y el botón **Descargar**.
+
+El resto del ciclo de vida es el de cualquier widget: conserva versión editable y publicada, admite [variables](#variables-del-widget), pasa por [revisión en equipo](/es/platform/core/#revision-en-equipo) y se instancia en las páginas desde el [Page Builder](/es/platform/channels/pages.html). Los cambios de código, en cambio, nunca se muestran como diferencias: en la vista de **Diferencias**, en la [revisión y publicación conjunta](/es/platform/channels/sites.html#revision-y-publicacion-conjunta) y en la [sincronización entre stages](/es/platform/channels/sites.html#stages) aparece el mensaje "El archivo tiene diferencias, pero los widgets CLI no se pueden mostrar". Tampoco puedes usar **Resetear a esta versión** para devolver el widget a una versión anterior: la vuelta atrás se hace volviendo a desplegar desde tu repositorio.
+
+:::warning Atención
+El ZIP que entrega **Descargar** se arma desde las plantillas guardadas en la plataforma y no es el bundle que subiste: los archivos de entrada salen renombrados y los chunks aplanados. Sirve para inspeccionar el código publicado, no como respaldo. Revisa [Widgets CLI en el panel](/es/platform/tools/cli.html#widgets-cli-en-el-panel) para el detalle completo.
+:::
+
 ## Code splitting
 
 Los widgets que despliegas mediante el [CLI de Modyo](/es/platform/tools/cli.html) pueden dividirse en múltiples archivos (*chunks*) además de sus archivos de entrada. La plataforma almacena y sirve cada chunk individualmente, y el widget los carga de forma dinámica solo cuando los necesita, con lo que la carga inicial de widgets grandes es más liviana.

--- a/docs/es/platform/channels/widgets.md
+++ b/docs/es/platform/channels/widgets.md
@@ -160,7 +160,7 @@ Los ES Modules tienen requisitos estrictos de CORS y siempre se cargan en modo e
 
 ## Widgets CLI
 
-Los widgets que llegan al sitio con `modyo-cli push` quedan marcados como widgets de solo lectura, porque su código fuente vive en tu repositorio y no en Modyo. En el listado de widgets del sitio los reconoces por la etiqueta **CLI** junto a su nombre.
+Los widgets **creados** en el sitio con `modyo-cli push` quedan marcados como widgets de solo lectura, porque su código fuente vive en tu repositorio y no en Modyo. En el listado de widgets del sitio los reconoces por la etiqueta **CLI** junto a su nombre.
 
 Al abrir uno de estos widgets no verás las pestañas de código, sino la pantalla **Resumen del widget**, con su **Nombre**, **Tipo**, **Tamaño**, **Chunks**, **Actualizado por última vez en** y **Actualizado por última vez por**, encabezada por el aviso "Los widgets CLI no se pueden editar en Modyo. Descárgalo para revisar su contenido." y el botón **Descargar**.
 

--- a/docs/es/platform/tools/cli.md
+++ b/docs/es/platform/tools/cli.md
@@ -569,7 +569,9 @@ Si has definido [variables](/es/platform/channels/global-variables.html) sus val
 
 ## Widgets CLI en el panel
 
-Un widget creado o actualizado con `modyo-cli push` queda marcado en la plataforma como widget de solo lectura, porque su código fuente vive en tu repositorio y no en Modyo. Es una consecuencia directa de desplegar con el CLI y conviene conocerla antes de adoptarlo.
+Un widget **creado** con `modyo-cli push` queda marcado en la plataforma como widget de solo lectura, porque su código fuente vive en tu repositorio y no en Modyo. Es una consecuencia directa de desplegar con el CLI y conviene conocerla antes de adoptarlo.
+
+La marca se decide en ese momento y no vuelve a evaluarse: un widget que ya existía en el panel y que después recibe un despliegue del CLI conserva su edición y no queda de solo lectura.
 
 En el listado de widgets del sitio, estos widgets se reconocen por la etiqueta **CLI** junto a su nombre. Al abrir uno no encontrarás las pestañas de código, sino la pantalla **Resumen del widget**, con:
 

--- a/docs/es/platform/tools/cli.md
+++ b/docs/es/platform/tools/cli.md
@@ -601,7 +601,7 @@ El botón **Descargar** llama a `GET /api/admin/sites/{site_id}/widget_definitio
 - Los archivos de entrada salen renombrados con el identificador del widget: `<uuid>.js`, `<uuid>.css` y `<uuid>.html`, en lugar de `main.js` y `main.css`.
 - Los chunks pierden su ruta: solo se conserva el último segmento del nombre, así que la estructura de carpetas no se reconstruye.
 - Los archivos `.wasm` se entregan decodificados.
-- El ZIP incluye los source maps, a diferencia del contador **Chunks** de la pantalla Resumen, que los deja fuera. Por eso el ZIP suele traer más archivos de los que anuncia ese número.
+- El ZIP trae siempre tres archivos más que el número del contador **Chunks**: ese contador cuenta solo los chunks, mientras que el ZIP incluye además los tres archivos de entrada.
 
 :::warning Atención
 El ZIP de **Descargar** sirve para inspeccionar qué código está corriendo en la plataforma, no como respaldo: no se puede volver a desplegar tal cual. La fuente de verdad de un widget CLI es siempre tu repositorio.

--- a/docs/es/platform/tools/cli.md
+++ b/docs/es/platform/tools/cli.md
@@ -599,8 +599,9 @@ Tampoco puedes usar **Resetear a esta versión** para devolver un widget CLI a u
 El botón **Descargar** llama a `GET /api/admin/sites/{site_id}/widget_definitions/{id}/download` y arma un ZIP al vuelo a partir de las plantillas guardadas en la plataforma. No es el archivo que subiste, y su contenido no coincide con tu build:
 
 - Los archivos de entrada salen renombrados con el identificador del widget: `<uuid>.js`, `<uuid>.css` y `<uuid>.html`, en lugar de `main.js` y `main.css`.
-- Los chunks pierden su ruta: solo se conserva el último segmento, así que un build organizado en subdirectorios queda aplanado y dos archivos con el mismo nombre en carpetas distintas colisionan.
+- Los chunks pierden su ruta: solo se conserva el último segmento del nombre, así que la estructura de carpetas no se reconstruye.
 - Los archivos `.wasm` se entregan decodificados.
+- El ZIP incluye los source maps, a diferencia del contador **Chunks** de la pantalla Resumen, que los deja fuera. Por eso el ZIP suele traer más archivos de los que anuncia ese número.
 
 :::warning Atención
 El ZIP de **Descargar** sirve para inspeccionar qué código está corriendo en la plataforma, no como respaldo: no se puede volver a desplegar tal cual. La fuente de verdad de un widget CLI es siempre tu repositorio.
@@ -610,8 +611,8 @@ El ZIP de **Descargar** sirve para inspeccionar qué código está corriendo en 
 
 Para desplegar con `push`, el usuario dueño del token necesita el permiso **Crear Widgets CLI**, incluido en el rol [Site Developer CLI](/es/platform/core/roles.html#roles) y superiores. Para usar el botón **Descargar** basta con el permiso **Ver Widgets**.
 
-La marca de solo lectura la decide la plataforma al crear el widget, según cómo se identifica la petición: solo se aplica cuando la cabecera `User-Agent` corresponde al CLI de Modyo.
+La marca de solo lectura la decide la plataforma al crear el widget, según cómo se identifica la petición: solo se aplica cuando la cabecera `User-Agent` corresponde a uno de los CLI reconocidos por la plataforma. Son los de Modyo y los de Dynamic, y la lista es configurable por instalación, así que si tienes dudas confírmala con quien administre la tuya.
 
 :::warning Atención
-Si integras el despliegue desde un pipeline propio que llama al mismo endpoint sin identificarse como el CLI de Modyo, el widget se crea editable, se le exige el permiso normal de edición de widgets en lugar de **Crear Widgets CLI**, y queda abierto a cambios desde el panel que tu siguiente despliegue sobrescribirá. Si el widget ya estaba marcado como widget CLI, una petición que no se identifica como el CLI responde con éxito pero no actualiza su código.
+Si integras el despliegue desde un pipeline propio que llama al mismo endpoint sin identificarse como uno de esos CLI, el widget se crea editable, se le exige el permiso normal de edición de widgets en lugar de **Crear Widgets CLI**, y queda abierto a cambios desde el panel que tu siguiente despliegue sobrescribirá. Si el widget ya estaba marcado como widget CLI, una petición que no se identifica como el CLI responde con éxito pero no actualiza su código.
 :::

--- a/docs/es/platform/tools/cli.md
+++ b/docs/es/platform/tools/cli.md
@@ -566,3 +566,50 @@ El usuario dueño del token debe tener un rol de [site reviewer o admin](/es/pla
 Una vez que un widget está desplegado y publicado en Modyo, está disponible para ser utilizado en las páginas del sitio al que pertenece.
 
 Si has definido [variables](/es/platform/channels/global-variables.html) sus valores pueden ser especificados a nivel global o particular a cada instancia del widget.
+
+## Widgets CLI en el panel
+
+Un widget creado o actualizado con `modyo-cli push` queda marcado en la plataforma como widget de solo lectura, porque su código fuente vive en tu repositorio y no en Modyo. Es una consecuencia directa de desplegar con el CLI y conviene conocerla antes de adoptarlo.
+
+En el listado de widgets del sitio, estos widgets se reconocen por la etiqueta **CLI** junto a su nombre. Al abrir uno no encontrarás las pestañas de código, sino la pantalla **Resumen del widget**, con:
+
+- **Nombre**: el nombre del widget en Modyo.
+- **Tipo**: la etiqueta CLI.
+- **Tamaño**: el peso total de los archivos del widget.
+- **Chunks**: la cantidad de archivos adicionales a los de entrada, sin contar los source maps.
+- **Actualizado por última vez en**: la fecha y hora del último despliegue.
+- **Actualizado por última vez por**: el usuario que hizo el último despliegue.
+
+Sobre el resumen aparece el aviso "Los widgets CLI no se pueden editar en Modyo. Descárgalo para revisar su contenido." junto al botón **Descargar**.
+
+El resto del ciclo de vida es el de cualquier widget: conserva versión editable y publicada, admite [variables](/es/platform/channels/widgets.html#variables-del-widget), pasa por [revisión en equipo](/es/platform/core/#revision-en-equipo) y se instancia en las páginas desde el [Page Builder](/es/platform/channels/pages.html). En la columna de propiedades siguen visibles el nombre, los tags y el listado de páginas que usan el widget.
+
+### Diferencias de código
+
+Al comparar versiones de un widget CLI, ya sea en la vista de **Diferencias** del widget, en la [revisión y publicación conjunta](/es/platform/channels/sites.html#revision-y-publicacion-conjunta) o en la [sincronización entre stages](/es/platform/channels/sites.html#stages), la plataforma detecta que hay cambios pero no muestra el diff línea a línea. En su lugar aparece el mensaje "El archivo tiene diferencias, pero los widgets CLI no se pueden mostrar".
+
+El mismo comportamiento aplica a cualquier plantilla que supere el límite de tamaño permitido, con el mensaje "El archivo tiene diferencias, pero su tamaño supera el límite permitido y no se puede mostrar".
+
+Tampoco puedes usar **Resetear a esta versión** para devolver un widget CLI a una versión anterior. Para revisar o revertir cambios entre despliegues, usa el historial de tu repositorio y vuelve a ejecutar `modyo-cli push` con la versión que necesites.
+
+### El ZIP del botón Descargar
+
+El botón **Descargar** llama a `GET /api/admin/sites/{site_id}/widget_definitions/{id}/download` y arma un ZIP al vuelo a partir de las plantillas guardadas en la plataforma. No es el archivo que subiste, y su contenido no coincide con tu build:
+
+- Los archivos de entrada salen renombrados con el identificador del widget: `<uuid>.js`, `<uuid>.css` y `<uuid>.html`, en lugar de `main.js` y `main.css`.
+- Los chunks pierden su ruta: solo se conserva el último segmento, así que un build organizado en subdirectorios queda aplanado y dos archivos con el mismo nombre en carpetas distintas colisionan.
+- Los archivos `.wasm` se entregan decodificados.
+
+:::warning Atención
+El ZIP de **Descargar** sirve para inspeccionar qué código está corriendo en la plataforma, no como respaldo: no se puede volver a desplegar tal cual. La fuente de verdad de un widget CLI es siempre tu repositorio.
+:::
+
+### Permisos y despliegues desde un pipeline propio
+
+Para desplegar con `push`, el usuario dueño del token necesita el permiso **Crear Widgets CLI**, incluido en el rol [Site Developer CLI](/es/platform/core/roles.html#roles) y superiores. Para usar el botón **Descargar** basta con el permiso **Ver Widgets**.
+
+La marca de solo lectura la decide la plataforma al crear el widget, según cómo se identifica la petición: solo se aplica cuando la cabecera `User-Agent` corresponde al CLI de Modyo.
+
+:::warning Atención
+Si integras el despliegue desde un pipeline propio que llama al mismo endpoint sin identificarse como el CLI de Modyo, el widget se crea editable, se le exige el permiso normal de edición de widgets en lugar de **Crear Widgets CLI**, y queda abierto a cambios desde el panel que tu siguiente despliegue sobrescribirá. Si el widget ya estaba marcado como widget CLI, una petición que no se identifica como el CLI responde con éxito pero no actualiza su código.
+:::


### PR DESCRIPTION
## Cambios propuestos

Documenta la consecuencia más importante de adoptar el CLI, que hasta ahora no estaba escrita: un widget desplegado con `modyo-cli push` **deja de ser editable desde el panel**.

### `docs/{es,en}/platform/tools/cli.md` y `docs/{es,en}/platform/channels/widgets.md`

Qué cambia en el panel para un widget publicado por CLI: distintivo **CLI** en el listado, pantalla **Resumen** en lugar del editor de código, botón **Descargar** para revisar el contenido, y comparación de cambios no disponible ni en Diferencias, ni en la revisión y publicación conjunta, ni en la sincronización entre etapas.

## Diferencias con la ficha del plan, verificadas en master

- **La marca de solo lectura no la dispara solo `MODYO-CLI`.** El valor predeterminado es una lista de identificadores de cliente, no uno solo.
- **`read_only` solo se asigna al crear el widget, nunca al actualizarlo.** Un widget que ya existía en el panel y después se publica por CLI no queda marcado. Es un matiz que la ficha no recogía y que cambia qué esperar al migrar.
- **El botón Descargar solo exige el permiso de ver el widget**, no uno propio.
- Los labels reales de la pantalla Resumen no coinciden con los que listaba la ficha; se citan los del producto.
- El límite de tamaño del aviso «archivo demasiado grande» es configurable por instalación, así que se redactó sin fijar el número como si fuera inmutable.

## Gap parcialmente saltado

`HERRAMIENTAS-13`, en su parte de Swagger: es cierto que el endpoint de descarga no tiene ficha en el catálogo a diferencia de sus vecinos, pero eso es un defecto del catálogo de la plataforma, no algo que se corrija desde la documentación.

Closes #1058

Gaps: `HERRAMIENTAS-02`

🤖 Generated with [Claude Code](https://claude.com/claude-code)