### PR TITLE
activity-logs.md: catálogo de eventos auditados, marca de sistema y detalle del listado

### DIFF
--- a/docs/en/platform/core/activity-logs.md
+++ b/docs/en/platform/core/activity-logs.md
@@ -4,18 +4,94 @@ search: true
 
 # Activity Logs
 
-This section shows a detailed chronological record of the activities carried out by account administrators and is useful for auditing and monitoring tasks, as they provide you with a detailed history of the actions of the account administrators.
+This section shows a detailed chronological record of the activities carried out in the account and is useful for auditing and monitoring tasks, as it provides you with a detailed history of those actions. Most of them correspond to administrators, but since version 10.2 the actions the platform runs on its own, with no person behind them, are also recorded.
+
+To enter this section you need the **View Activity Logs** grouped permission. What you can see inside it also depends on your roles, following the same scope rules described in [What logs you see](/en/platform/core/api.html#what-logs-you-see).
 
 The auditability offered by Modyo in this space guarantees the possibility of examining all actions carried out by any administrator. This is essential to accurately determine the responsibilities that correspond to each operation.
 
 
 ## About the Interface
 
-In the activity logs interface, you can see a list of the administrators who performed tasks, what types of tasks, and when they carried them out.
+In the activity logs interface, you can see who performed each action, what type it was, on which object, and in what context it happened.
 
 You can filter events by:
- - **Date**: Filter by a specific period or select a start and end date.
-- **Type**: Filter by type of events, such as creating, updating or deleting a campaign, creating or updating a post, updating or deleting a site, user enablement, and others.
-- **Administrator**: Select a specific administrator to see only their activities or choose all to see all the activities carried out by the administrators.
 
-Check the box next to one or more users and click on the **Export** button, located below the list to download a file in Excel or CSV format with the selected activities.
+- **Date**: Filter by a specific period or select a start and end date.
+- **Type**: Filter by type of events, such as creating, updating or deleting a campaign, creating or updating a post, updating or deleting a site, user enablement, and others. The dropdown does not list the full catalog: it only offers the types that already have at least one record in your account, up to a maximum of 100.
+- **Admin**: Select a specific administrator to see only their activities, choose **System** to isolate the platform's automated actions, or leave the filter unselected to see every activity. This filter only appears if your role includes the **Admin Team** grouped permission.
+
+:::tip Tip
+Records are added to the list and to the **Type** filter dropdown a few seconds after the action happens. If you just did something and still don't see it, reload the screen.
+:::
+
+### List columns
+
+| Column | What it shows |
+| --- | --- |
+| **User** | The administrator who performed the action, with their avatar and email. If the action was automated, it shows **System** with a gear icon and no email. If the record has neither an administrator nor an automated mark, it shows **Unregistered User**. |
+| **Type** | The visible name of the event type, for example *Entry published* or *App created*. |
+| **Description** | The sentence summarizing the event, with links to the author, the affected object, and the context. |
+| **Origin** | The type of object that was acted upon: *Entry*, *Form*, *Widget*, *Category*, *Team member*, *Origination submission*, and so on. It shows a dash when the event does not point to any object. |
+| **Context** | Where the action happened: **Space**, **Realm**, or **App** followed by the corresponding name, or **Account** when the action belongs to none of the three. |
+| **Created at** | Date and time of the event. |
+
+### Event detail
+
+Click a record's row to open the **Log details** window, which shows the complete information stored for the event, including what the list cannot display:
+
+- The record identifier and its type identifier, which is the same value used by the API and by webhooks.
+- The affected object (`loggeable_type` and `loggeable_id`) and the context (`site_id`, `space_id`, `realm_id`, and their names).
+- The IP address and the user agent the action was performed from.
+- The `automated` mark, which indicates whether the action was automated.
+- The `options` block with the event's own data. When the action modified an object, `options` carries the changes field by field, with the previous value (`before`) and the new one (`after`).
+
+## Automated platform actions
+
+A record has either an administrator or an automated mark, never both at the same time: either a person performed the action, or the platform did. When the platform did, the **User** column shows **System** with a gear icon, and to review only those actions you can choose **System** in the **Admin** filter.
+
+Among the actions the platform records on its own are:
+
+- Disabling administrators for inactivity, with one record per disabled administrator and a summary record with the total.
+- The scheduled generation of the account activity reports.
+- Disabling expired trial accounts.
+- Cancelling Origination submissions that went past their deadline.
+
+## What gets audited
+
+The catalog of event types is closed: the platform defines 291 types, and you cannot create new types or edit the existing ones. Each type has a visible name, the one shown in the **Type** filter and in the **Type** column, and a stable identifier, which is the value of the `type` field in the [Logs API](/en/platform/core/api.html#logs) and the one that arrives as `trigger_uid` in [Webhooks](/en/platform/core/webhooks.html). To find the identifier of a specific event, open its detail.
+
+These are the domains that get audited:
+
+| Domain | What is recorded |
+| --- | --- |
+| Account and settings | Creation, update, and deletion of the account; global snippets; global variables; language; plan changes; payment settings; restoration of the default roles and log types. |
+| Team, roles, and access | Roles and their assignments; groups; team members, with their creation, update, enabling, disabling, and impersonation; sign-ins and sign-outs, failed attempts, temporary password login, and password reset; updates to your own profile; identity providers; API OAuth applications. |
+| Apps | Creation, cloning, update, enabling, disabling, and deletion of apps; switching to draft state; synchronization of the app and of its elements; templates; reviewers and approvers; review stages; releases and scheduled publications; version rollbacks. |
+| Pages, layouts, and navigation | Layouts and layout pages, with their creation, editing, cloning, forking, publication, unpublication, rollback, submission for review, and approval; remote layouts and their deployments; navigations. |
+| Widgets | Creation, editing, cloning, publication, unpublication, restoration, and deletion; associated assets; users with access. |
+| Content | Spaces, with their languages, security, review team, and cache; content types and their reindexing; entries, with their publication, cloning, approval, submission for review, and bulk actions; categories and their synchronizations; library assets. |
+| Customers and end users | Realms; end users, with their creation through a form, invitation, identity provider, SCIM, signup, or purchase, and with their verification, enabling, disabling, tags, impersonation, and bulk updates; member notes; user custom fields and their options; segments. |
+| Messaging | Campaigns and their locks; deliveries started and stopped; mail templates; mail delivery events, with sent, delivered, opened, click, bounce, spam report, and unsubscribe; opened notifications. |
+| Forms | Creation, editing, enabling, disabling, and deletion of forms; their locks; responses created, updated, deleted, and bulk deleted. |
+| Origination | Originations, with their creation, update, publication, and deletion; invitations sent, resent, and cancelled; submissions, with their start, assignment, update, cancellation, completion, impersonation, and deletion; task responses, with their start, completion, review, reopening, and validation. |
+| Payments | Orders, with their creation, confirmation, payment, rejection, and tracking, plus the errors of each of those steps; tokenized cards, with their enrollment, activation, removal, and failures. |
+| Integrations and automation | Integrations and their synchronizations, both successful and failed; webhooks; process tasks; app uninstallation. |
+
+## Events that do not appear in this list
+
+Review workflow events are deliberately left out of this screen: creation, editing, comments, submission for review, approval, rejection, back to editing, completion, archiving, restoration, and adding or removing reviewers. To review them, use the **Activity** panel in the **Overview** of the app, space, or realm where they happened, which does not apply that exclusion.
+
+## Export the list
+
+Check the box next to one or more records and click on the **Export** button, located below the list, to choose the format (Excel or CSV) and generate the file. If instead of checking individual records you select all results, the export uses the filters you have applied.
+
+The file carries one row per record with five columns: **Type**, **Origin**, **App**, **Created at**, and **User**. Records of automated actions come out with **System** in the **User** column.
+
+:::tip Tip
+In the file, **Type** and **Origin** carry the record's internal values, for example `Entry published log` and `Content::Entry`, and not the translated labels you see in the list.
+:::
+
+## End user activity
+
+This screen records administration activity. The activity of a realm's end users is reviewed in [Events](/en/platform/customers/events.html), which uses the same list, the same detail, and the same export, but with a **User** filter instead of the **Admin** filter.

--- a/docs/en/platform/core/security.md
+++ b/docs/en/platform/core/security.md
@@ -195,7 +195,7 @@ Traffic between the load balancer and the platform instances can use ports 443 o
 
 ### Activity logs
 
-The platform keeps a record of all actions performed by administrator users within it. You can review these logs in the “Activity Logs” section.
+The platform keeps a record of all actions performed by administrator users within it, and also of those it runs on its own, with no person behind them: the latter are recorded with **System** as the author. You can review these logs in the [Activity logs](/en/platform/core/activity-logs.html) section.
 
 We recommend that you review these logs periodically to verify the correct behavior of users within the system. Activity logs are also available through Modyo's administrative API.
 

--- a/docs/es/platform/core/activity-logs.md
+++ b/docs/es/platform/core/activity-logs.md
@@ -4,18 +4,94 @@ search: true
 
 # Logs de Actividad
 
-Esta sección muestra un registro cronológico detallado de las actividades realizadas por los administradores de la cuenta, útil para tareas de seguimiento y monitoreo, ya que proporciona un historial detallado de sus acciones.
+Esta sección muestra un registro cronológico detallado de las actividades realizadas en la cuenta, útil para tareas de seguimiento y monitoreo, ya que proporciona un historial detallado de esas acciones. La mayor parte corresponde a los administradores, pero desde la versión 10.2 también quedan registradas las acciones que la plataforma ejecuta por su cuenta, sin una persona detrás.
+
+Para entrar a esta sección necesitas el permiso agrupado **Ver Logs de Actividad**. Lo que alcanzas a ver dentro de ella depende además de tus roles, con las mismas reglas de alcance que describe [Qué registros ves](/es/platform/core/api.html#que-registros-ves).
 
 La auditabilidad que te ofrece Modyo en este espacio, garantiza la posibilidad de examinar todas las acciones realizadas por cualquier administrador. Esto es fundamental para determinar de manera precisa las responsabilidades que corresponden en cada operación.
 
 
 ## Sobre la Interfaz
 
-En la interfaz de logs de actividad puedes ver una lista de los administradores que han realizado tareas, qué tipos de tareas y cuándo las llevaron a cabo.
+En la interfaz de logs de actividad puedes ver quién realizó cada acción, de qué tipo fue, sobre qué objeto y en qué contexto ocurrió.
 
 Puedes filtrar los eventos por:
- - **Fecha**: Filtra por un período específico o selecciona una fecha de inicio y finalización.
-- **Tipo**: Filtra por tipo de eventos, como creación, actualización o eliminación de una campaña, creación o actualización de una entrada, actualización o borrado de un sitio, habilitación de usuario, entre otros.
-- **Administrador**: Selecciona un administrador en específico para ver solo sus actividades o elige todos para ver todas las actividades realizadas por los  administradores.
 
-Marca la casilla al lado de uno o varios usuarios y haz click en el botón **Exportar**,  ubicado debajo del listado para descargar un archivo en formato Excel o CSV con las actividades seleccionadas.
+- **Fecha**: Filtra por un período específico o selecciona una fecha de inicio y finalización.
+- **Tipo**: Filtra por tipo de eventos, como creación, actualización o eliminación de una campaña, creación o actualización de una entrada, actualización o borrado de un sitio, habilitación de usuario, entre otros. El desplegable no lista el catálogo completo: solo ofrece los tipos de los que ya existe al menos un registro en tu cuenta, hasta un máximo de 100.
+- **Administrador**: Selecciona un administrador en específico para ver solo sus actividades, elige **Sistema** para aislar las acciones automáticas de la plataforma, o deja el filtro sin selección para ver todas las actividades. Este filtro aparece solo si tu rol incluye el permiso agrupado **Administrar Equipo**.
+
+:::tip Tip
+Los registros se incorporan al listado y al desplegable del filtro **Tipo** unos segundos después de que ocurre la acción. Si acabas de ejecutar algo y todavía no lo ves, recarga la pantalla.
+:::
+
+### Columnas del listado
+
+| Columna | Qué muestra |
+| --- | --- |
+| **Usuario** | El administrador que ejecutó la acción, con su avatar y su correo. Si la acción fue automática, muestra **Sistema** con un ícono de engranaje y sin correo. Si el registro no tiene administrador ni marca de acción automática, muestra **Usuario no registrado**. |
+| **Tipo** | El nombre visible del tipo de evento, por ejemplo *Entrada publicada* o *Aplicación creada*. |
+| **Descripción** | La frase que resume el evento, con enlaces al autor, al objeto afectado y al contexto. |
+| **Origen** | El tipo de objeto sobre el que se actuó: *Entrada*, *Formulario*, *Widget*, *Categoría*, *Miembro del equipo*, *Respuesta de originación*, y así con el resto. Muestra un guion cuando el evento no apunta a ningún objeto. |
+| **Contexto** | Dónde ocurrió la acción: **Espacio**, **Reino** o **Aplicación** seguido del nombre respectivo, o **Cuenta** cuando la acción no pertenece a ninguno de los tres. |
+| **Creado el** | Fecha y hora del evento. |
+
+### Detalle del evento
+
+Haz click en la fila de un registro para abrir la ventana **Detalles del log**, que muestra la información completa del evento tal como quedó guardada, incluida la que el listado no alcanza a mostrar:
+
+- El identificador del registro y el identificador de su tipo, que es el mismo valor que usan el API y los webhooks.
+- El objeto afectado (`loggeable_type` y `loggeable_id`) y el contexto (`site_id`, `space_id`, `realm_id` y sus nombres).
+- La dirección IP y el agente de usuario desde donde se ejecutó la acción.
+- La marca `automated`, que indica si la acción fue automática.
+- El bloque `options` con los datos propios del evento. Cuando la acción modificó un objeto, `options` trae los cambios campo por campo, con el valor anterior (`before`) y el nuevo (`after`).
+
+## Acciones automáticas de la plataforma
+
+Un registro tiene un administrador o una marca de acción automática, nunca las dos cosas a la vez: o la acción la hizo una persona, o la hizo la plataforma. Cuando la hizo la plataforma, la columna **Usuario** muestra **Sistema** con un ícono de engranaje, y para revisar solo esas acciones puedes elegir **Sistema** en el filtro **Administrador**.
+
+Entre las acciones que la plataforma registra por su cuenta están:
+
+- La deshabilitación de administradores por inactividad, con un registro por cada administrador deshabilitado y un registro resumen con el total.
+- La generación programada de los reportes de actividad de la cuenta.
+- La deshabilitación de las cuentas de prueba vencidas.
+- La cancelación de las respuestas de Origination que superaron su plazo.
+
+## Qué queda auditado
+
+El catálogo de tipos de evento es cerrado: la plataforma define 291 tipos y no puedes crear tipos nuevos ni editar los existentes. Cada tipo tiene un nombre visible, que es el que aparece en el filtro **Tipo** y en la columna **Tipo**, y un identificador estable, que es el valor del campo `type` en el [API de Logs](/es/platform/core/api.html#registros-logs) y el que llega como `trigger_uid` en los [Webhooks](/es/platform/core/webhooks.html). Para conocer el identificador de un evento concreto, abre su detalle.
+
+Estos son los dominios que quedan auditados:
+
+| Dominio | Qué queda registrado |
+| --- | --- |
+| Cuenta y configuración | Creación, actualización y borrado de la cuenta; snippets globales; variables globales; idioma; cambios de plan; configuración de pagos; restauración de los roles y de los tipos de log por omisión. |
+| Equipo, roles y accesos | Roles y sus asignaciones; grupos; miembros del equipo, con su creación, actualización, habilitación, deshabilitación y suplantación; inicios y cierres de sesión, intentos fallidos, ingreso con contraseña temporal y restablecimiento de contraseña; actualización del propio perfil; proveedores de identidad; aplicaciones OAuth del API. |
+| Aplicaciones | Creación, clonado, actualización, habilitación, deshabilitación y borrado de aplicaciones; paso a estado editable; sincronizaciones de la aplicación y de sus elementos; plantillas; revisores y aprobadores; etapas de revisión; releases y publicaciones programadas; rollback de versiones. |
+| Páginas, layouts y navegación | Layouts y layout pages, con su creación, edición, clonado, fork, publicación, despublicación, rollback, envío a revisión y aprobación; layouts remotos y sus despliegues; navegaciones. |
+| Widgets | Creación, edición, clonado, publicación, despublicación, restauración y borrado; archivos asociados; usuarios con acceso. |
+| Contenido | Espacios, con sus idiomas, seguridad, equipo de revisión y caché; tipos de contenido y sus reindexaciones; entradas, con su publicación, clonado, aprobación, envío a revisión y acciones masivas; categorías y sus sincronizaciones; archivos de la biblioteca. |
+| Clientes y usuarios finales | Reinos; usuarios finales, con su alta por formulario, invitación, proveedor de identidad, SCIM, registro o compra, y con su verificación, habilitación, deshabilitación, etiquetas, suplantación y actualizaciones masivas; notas de miembro; campos personalizados de usuario y sus opciones; segmentos. |
+| Mensajería | Campañas y sus bloqueos; envíos iniciados y detenidos; plantillas de correo; eventos de entrega de correo, con envío, entrega, apertura, click, rebote, reporte de spam y baja; notificaciones abiertas. |
+| Formularios | Creación, edición, habilitación, deshabilitación y borrado de formularios; sus bloqueos; respuestas creadas, actualizadas, eliminadas y borradas en lote. |
+| Origination | Originaciones, con su creación, actualización, publicación y borrado; invitaciones enviadas, reenviadas y canceladas; respuestas, con su inicio, asignación, actualización, cancelación, término, suplantación y borrado; respuestas a tareas, con su inicio, término, revisión, reapertura y validación. |
+| Pagos | Órdenes, con su creación, confirmación, pago, rechazo y seguimiento, y los errores de cada uno de esos pasos; tarjetas tokenizadas, con su inscripción, activación, baja y fallos. |
+| Integraciones y automatización | Integraciones y sus sincronizaciones, exitosas y fallidas; webhooks; tareas de proceso; desinstalación de aplicaciones. |
+
+## Eventos que no aparecen en este listado
+
+Los eventos del flujo de revisión quedan fuera de esta pantalla a propósito: creación, edición, comentarios, envío a revisión, aprobación, rechazo, vuelta a edición, término, archivado, restauración y alta o baja de revisores. Para revisarlos, usa el panel **Actividad** del **Resumen** de la aplicación, el espacio o el reino donde ocurrieron, que no aplica esa exclusión.
+
+## Exportar el listado
+
+Marca la casilla al lado de uno o varios registros y haz click en el botón **Exportar**, ubicado debajo del listado, para elegir el formato (Excel o CSV) y generar el archivo. Si en lugar de marcar registros sueltos seleccionas todos los resultados, la exportación toma los filtros que tengas aplicados.
+
+El archivo trae una fila por registro con cinco columnas: **Tipo**, **Origen**, **Aplicación**, **Creado el** y **Usuario**. Los registros de acciones automáticas salen con **Sistema** en la columna **Usuario**.
+
+:::tip Tip
+En el archivo, **Tipo** y **Origen** traen los valores internos del registro, por ejemplo `Entry published log` y `Content::Entry`, y no las etiquetas traducidas que ves en el listado.
+:::
+
+## Actividad de los usuarios finales
+
+Esta pantalla registra la actividad de la administración. La actividad de los usuarios finales de un reino se revisa en [Eventos](/es/platform/customers/events.html), que usa el mismo listado, el mismo detalle y la misma exportación, pero con un filtro por **Usuario** en lugar del filtro por **Administrador**.

--- a/docs/es/platform/core/security.md
+++ b/docs/es/platform/core/security.md
@@ -195,7 +195,7 @@ El tráfico entre el balanceador de carga y las instancias de la plataforma pued
 
 ### Registros de actividad
 
-La plataforma guarda un registro de todas las acciones realizadas por los usuarios administradores dentro de ella. Puedes revisar estos registros en la sección "Registros de actividad".
+La plataforma guarda un registro de todas las acciones realizadas por los usuarios administradores dentro de ella y también de las que ejecuta por su cuenta, sin una persona detrás: estas últimas quedan registradas con **Sistema** como autor. Puedes revisar estos registros en la sección [Logs de actividad](/es/platform/core/activity-logs.html).
 
 Te recomendamos revisar estos registros de forma periódica para verificar el correcto comportamiento de los usuarios dentro del sistema. Los registros de actividad también están disponibles a través del API administrativo de Modyo.
 


### PR DESCRIPTION
## Cambios propuestos

La página de registros de actividad tenía 20 líneas para una funcionalidad que en clientes financieros es requisito de cumplimiento. Se reescribe con lo que el auditor necesita saber.

### `docs/{es,en}/platform/core/activity-logs.md` y `docs/{es,en}/platform/core/security.md`

- **El catálogo de eventos auditados**, agrupado por dominio, con la explicación de que cada tipo tiene un nombre visible y un identificador estable, que es el mismo que usan el `type` de la API y el disparador de los webhooks.
- **Las acciones automáticas de la plataforma**, nuevas en 10.2: cómo se marcan, el autor **Sistema** y cómo filtrarlas.
- **Las columnas del listado, los filtros y el detalle del evento**, con sus labels reales.

## Diferencias con la ficha del plan, verificadas en master

- **Son 291 tipos, no 291 líneas**: el catálogo tiene 292 entradas pero un identificador está repetido.
- **Los labels de las columnas no eran los de la ficha**: la columna de tipo se rotula **Tipo**, no «Tipo de actividad».
- **En inglés el filtro por administrador es «Admin», no «Administrator»**. El espejo inglés decía lo segundo y quedó corregido.
- **El filtro de administrador, y con él la opción Sistema, solo aparece si el usuario tiene permiso sobre los administradores de la cuenta.** Sin eso no se ve, lo que explica reportes de «a mí no me aparece».
- **La exportación tiene cinco columnas**, y dos de ellas salen con el identificador técnico y no con el nombre visible.
- **Los eventos de tipo `application_*` son de aplicaciones OAuth del API**, no de aplicaciones web. Es una confusión fácil que quedó advertida.
- **El filtro por tipo se arma con lo realmente ocurrido y está topado**, así que no lista el catálogo completo.

`api.md` ya documentaba el endpoint de tipos, el valor `system` y las reglas de alcance, así que esta página enlaza en vez de duplicar.

Closes #1060

Gaps: `ROLES-SEGURIDAD-14`, `ROLES-SEGURIDAD-15`, `ROLES-SEGURIDAD-16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)