### PR TITLE
filters.md: filtros de colección, orden y paginación con su letra chica

### DIFF
--- a/docs/en/platform/channels/liquid-markup/filters.md
+++ b/docs/en/platform/channels/liquid-markup/filters.md
@@ -291,7 +291,7 @@ Returns a list of Entries that belong to a selected tag. *e.g.*
 
 **Parameters**:
 - entries (ArrayEntry) — array with entries
-- locale (String) (default: '') — String with comma-separated tags.
+- list (String) (default: '') — String with comma-separated tags.
 
 ### By type
 
@@ -300,7 +300,7 @@ Returns a list of Entries that belong to a selected Content Type. *e.g.*
 
 **Parameters**:
 - entries (ArrayEntry) — array with entries
-- locale (String) (default: '') — String with comma-separated content types.
+- list (String) (default: '') — String with comma-separated content types.
 
 ### By UUID
 
@@ -325,12 +325,20 @@ Applies multiple entry filters in one call. Supported option keys (all optional)
 - locale: a single locale code (applies `by_lang`; a comma-separated list is not supported)
 - from_published_date: date string (>= `published_at`)
 - to_published_date: date string (<= `published_at`)
-- sort_by: field name (`name`, `slug`, `created_at`, `updated_at`, `published_at`, or a field path)
+- sort_by: field name (default: `created_at`). Accepts `name`, `slug`, `created_at`, `updated_at` and `published_at`, or a field with its prefix (`fields.<name>` or `meta.<attribute>`); see [Sort By](/en/platform/channels/liquid-markup/filters.html#sort-by)
 - order: `asc` | `desc` (default: `desc`)
 - per_page: integer results per page (enables pagination if provided; default: 10)
-- page: integer page number (default: 1)
+- page: integer page number (enables pagination if provided; default: 1)
 
 *e.g.* <span v-pre>`{% assign entries = spaces['testing'].entries | by: types: 'promo,basic', locale: 'es', categories: 'starred,favorites', tags: 'test,test2', slugs: 'slug2,slug1', uuids: 'uuid2,uuid1', sort_by: 'name', order: 'asc', per_page: 10, page: 2 %}`</span>
+
+`sort_by` and `order` are optional in the call, but not in effect: `by` always applies `sort_by`, using `created_at` and `desc` as defaults. A collection that already came sorted by another criterion, such as a widget with its own order, comes out re-sorted by creation date descending even if the template requests no ordering at all, and there is no way to tell `by` not to sort. If you need to preserve the original order, chain the simple filters (`by_type`, `by_category`, `by_tag`, `by_slug`…) instead of using `by`.
+
+Pagination, on the other hand, is optional: it is applied only if you pass `per_page` or `page`. The defaults of those two keys are what the filter uses when you set one and omit the other, and they are subject to the URL parameter precedence described in [Paginated](/en/platform/channels/liquid-markup/filters.html#paginated).
+
+:::warning Attention
+Keys that `by` does not recognize are ignored silently, with no error or warning: a singular `type:` or a misspelled `tag:` filters nothing and the listing comes out complete. Check the key names against the list above before giving up on a filter that seems to do nothing.
+:::
 
 ### Filter By
 
@@ -432,9 +440,17 @@ Separates the results into pages. *e.g.*
 <span v-pre>`{{ objects | paginated: 10, 2 }}`</span>
 
 **Parameters**:
-- object(Array) — array
+- object(Array) — entry collection (object before the pipe)
 - per_page (Integer) (default: 10) — objects per page
 - page (Integer) (default: 1) — page number to display
+
+The `page` and `per_page` URL parameters take precedence over the arguments written in the template. With the example above, a visit to `my-page.com/landing?page=5` shows page 5 and not page 2: the arguments act as initial values, for the first visit without parameters in the URL. And because those parameters are global to the page, they reach every paginated listing on it at once.
+
+The filter clamps both values, whether they come from the argument or from the URL: `per_page` is limited to a minimum of 1 and a maximum of 100, and `page` to a minimum of 1. A `per_page` of 500 returns 100 results per page.
+
+:::warning Attention
+Applied to something that is not an entry collection, for example an array already materialized by `sort`, by `map` or defined in the template itself, the filter returns the input untouched: it does not paginate and it does not fail either. The listing looks complete, the pagination links do not appear and no clue is left as to why. Chain `paginated` directly onto the entry collection.
+:::
 
 ### Sort By
 
@@ -442,9 +458,24 @@ Returns an array with entries sorted by a field *e.g.*
 <span v-pre>`{% assign entries = widgets.entries | sort_by: 'name', 'asc' %}`</span>
 
 **Parameters**:
-- entries (ArrayEntry) — array with entries
-- attribute (String) — field by which you want to sort
-- order (String) - asc (ascending) or desc (descending)
+- collection (ArrayEntry | ArrayCategory) — collection to sort (object before the pipe)
+- field (String) — field by which you want to sort
+- order (String) (default: 'desc') — `asc` or `desc`
+
+The default order is descending and any value that is not exactly `asc` is treated as `desc`: an `'ascending'` or an `'asc '` with an extra space sort the opposite way from what you asked, with no warning at all.
+
+The accepted fields depend on the collection the filter receives:
+
+- **Category collection**: only `name`, `slug` and `uuid`.
+- **Entry collection**: the five meta attributes `name`, `slug`, `created_at`, `updated_at` and `published_at` are sorted directly. Any other name is resolved by the search layer, which requires the container prefix, just like [Filter By](/en/platform/channels/liquid-markup/filters.html#filter-by): `fields.<name>` for a content type field and `meta.<attribute>` for the remaining metadata.
+
+:::warning Attention
+On a category collection, a field outside `name`, `slug` and `uuid` returns an empty collection with no error at all: the listing looks blank and seems to have no data.
+
+On an entry collection, a name without a prefix, such as `'price'` instead of `'fields.price'`, does not sort by the field you expect. Also, sorting by `fields.<name>` requires, just like `filter_by`, a collection scoped to a content type: on something like <span v-pre>`spaces['blog'].entries`</span> the filter aborts and the published HTML keeps the `<!-- Liquid Error -->` comment in place of the block. Start from <span v-pre>`spaces['blog'].types['post'].entries`</span> or from <span v-pre>`widget.entries`</span>.
+
+The filter also aborts, with the same comment in the output, if the field or the order do not arrive as strings, for example <span v-pre>`| sort_by: 'name', 1`</span>.
+:::
 
 ### To Published Date
 
@@ -529,28 +560,32 @@ These Liquid filters alter values related to Geolocation in Modyo Platform.
 
 ### Dynamic Map
 
-Returns a dynamic Google Maps map (e.g. <span v-pre>`{{ locations | dynamic_map: '600x300', 'true', 'roadmap', true}}`</span>).
+Returns a dynamic Google Maps map (e.g. <span v-pre>`{{ locations | dynamic_map: '600x300', 10, 'roadmap', '', true }}`</span>).
 
 **Parameters**
 
 - `locations` (ArrayHash) — Array of hashes with latitude and longitude points.
 - `size` (String) (default: '600x300') — Map size in pixels.
-- `zoom` (String) (default: 10) — Zoom level for the map.
+- `zoom` (Integer) (default: 10) — Zoom level for the map.
 - `type` (String) (default: 'roadmap') — Map type.
 - `icon` (String) (default: '') — Map icon.
-- `controls` (String) (default: true) — Navigation controls for the map.
+- `controls` (Boolean) (default: true) — Navigation controls for the map.
 
 ### Static Map
 
-Returns a static Google Maps map (e.g. <span v-pre>`{{ locations | static_map: '600x300', 'true', 'roadmap'}}`</span>).
+Returns a static Google Maps map (e.g. <span v-pre>`{{ locations | static_map: '600x300', 15, 'roadmap' }}`</span>).
 
 **Parameters**
 
 - `locations` (ArrayHash) — Array of hashes with latitude and longitude points.
 - `size` (String) (default: '600x300') — Map size in pixels.
-- `zoom` (String) (default: 10) — Zoom level for the map.
+- `zoom` (String) (default: '') — Zoom level for the map. With no value, the Google Maps URL is built with an empty `zoom=` and the framing is left to Google; always pass it when you need a fixed framing.
 - `type` (String) (default: 'roadmap') — Map type.
 - `icon` (String) (default: '') — Map icon.
+
+:::warning Attention
+In both filters the argument that follows `size` is `zoom`, not `controls`. An example such as <span v-pre>`{{ locations | static_map: '600x300', 'true', 'roadmap' }}`</span> builds the Google Maps URL with `zoom=true` and the map is not framed as you expect. In `dynamic_map` the order is `size`, `zoom`, `type`, `icon`, `controls`, so reaching `controls` means passing the four preceding arguments.
+:::
 
 
 ## Menu Items
@@ -579,12 +614,31 @@ These are the liquid filters that alter values related to originations in Modyo 
 
 ### By UID
 
-Returns the Origination with the selected UID. *e.g.*
-<span v-pre>`{% assign my_origination = site.originations | by_uid: 'my-origination' %}`</span>
+Returns the object with the given UID inside an Origination module collection. It is a single filter, `by_uid`, that accepts four collection classes:
+
+- `site.originations` — the originations of the site.
+- `origination.steps` — the steps of an origination.
+- `step.tasks` — the tasks of a step.
+- `task.fields` — the questions of a user input task. This is the only way to take a specific question by its UID; the objects it returns are [question](/en/platform/channels/liquid-markup/objects.html#question).
 
 **Parameters:**
-- originations (ArrayOrigination) - array with originations
-- uid (String) - Origination UID
+- collection (ArrayOrigination | ArrayStep | ArrayTask | ArrayQuestion) - collection to search in
+- uid (String) - UID of the object to find
+
+The filter returns a single object, not a collection: its result is used directly and is not traversed with a loop. If no element in the collection has that UID, it returns nothing.
+
+*e.g.*
+
+```liquid
+{% assign my_origination = site.originations | by_uid: 'my-origination' %}
+{% assign my_step = my_origination.steps | by_uid: 'step-01' %}
+{% assign my_task = my_step.tasks | by_uid: 'task-01' %}
+{% assign my_question = my_task.fields | by_uid: 'question-01' %}
+```
+
+:::warning Attention
+In two cases the filter aborts and the published HTML keeps the `<!-- Liquid Error -->` comment in place of the block: when it is applied to something that is not a collection, and when it is applied to a collection of an unsupported class. In the second case the message includes the name of the class received, which makes it possible to identify what was passed by mistake.
+:::
 
 ## Site
 
@@ -732,6 +786,15 @@ Converts a date in String to words (e.g. <span v-pre>`{{ '01-02-2019' | time_ago
 
 Resolves the translation text for Site keys. Custom values will be returned if they exist (e.g. <span v-pre>`{{ 'admin.logs.errors.no_logs_yet' | translate }}`</span>).
 
+**Parameters**
+
+- `value` (String) — translation key (object before the pipe).
+- `count` (Integer) (default: nil) — count used to pluralize the key.
+
+`t` is the short alias of the filter and does exactly the same: <span v-pre>`{{ 'admin.logs.errors.no_logs_yet' | t }}`</span>.
+
+The second parameter pluralizes the key and is applied only when it arrives as an integer (e.g. <span v-pre>`{{ 'site.results.count' | t: total }}`</span>). If it arrives as a string, for example `'3'`, the filter discards it without warning and resolves the key without pluralizing.
+
 ### Truncate HTML
 
 Returns a String after truncating it (e.g. <span v-pre>`{{ html | truncate_html: 10 }}`</span>).
@@ -748,6 +811,8 @@ Returns the Step with the selected UID. *e.g.*
 **Parameters:**
 - steps (ArrayStep) - array with steps
 - uid (String) - Step UID
+
+This is the same `by_uid` filter from the Origination module. The full reference, with the four supported collection classes and the errors it aborts with, is in [By UID](/en/platform/channels/liquid-markup/filters.html#by-uid).
 
 ## Submission
 
@@ -853,6 +918,8 @@ Returns the Task with the selected UID. *e.g.*
 **Parameters:**
 - tasks (ArrayTask) - array with tasks
 - uid (String) - Task UID
+
+This is the same `by_uid` filter from the Origination module, which also accepts the `fields` collection of a user input task to take one of its questions by UID: <span v-pre>`{% assign my_question = my_task.fields | by_uid: 'question-01' %}`</span>. The full reference is in [By UID](/en/platform/channels/liquid-markup/filters.html#by-uid).
 
 ### Navigation / Completion Helpers
 

--- a/docs/es/platform/channels/liquid-markup/filters.md
+++ b/docs/es/platform/channels/liquid-markup/filters.md
@@ -291,7 +291,7 @@ Retorna una lista de Entradas que pertenecen a un tag seleccionado. *e.g.*
 
 **Parametros**:
 - entries (ArrayEntry) — array con entradas
-- list (String) (default: '') — String con tags separadas por coma.
+- list (String) (default: '') — String con tags separados por coma.
 
 ### By type
 
@@ -789,7 +789,7 @@ Convierte una fecha en String a palabras (ej. <span v-pre>`{{ '01-02-2019' | tim
 
 Resuelve el texto de traducción para claves de Sitios. Se devolverán valores personalizados si existen (ej. <span v-pre>`{{ 'admin.logs.errors.no_logs_yet' | translate }}`</span>).
 
-**Parametros**
+**Parámetros**
 
 - `value` (String) — clave de la traducción (objeto antes de la barra).
 - `count` (Integer) (default: nil) — cantidad con la que se pluraliza la clave.

--- a/docs/es/platform/channels/liquid-markup/filters.md
+++ b/docs/es/platform/channels/liquid-markup/filters.md
@@ -291,7 +291,7 @@ Retorna una lista de Entradas que pertenecen a un tag seleccionado. *e.g.*
 
 **Parametros**:
 - entries (ArrayEntry) — array con entradas
-- locale (String) (default: '') — String con tags separadas por coma.
+- list (String) (default: '') — String con tags separadas por coma.
 
 ### By type
 
@@ -300,7 +300,7 @@ Retorna una lista de Entradas que pertenecen a un Tipo de Contenido seleccionado
 
 **Parametros**:
 - entries (ArrayEntry) — array con entradas
-- locale (String) (default: '') — String con tipos de contenido separados por coma.
+- list (String) (default: '') — String con tipos de contenido separados por coma.
 
 ### By UUID
 
@@ -325,12 +325,20 @@ Aplica múltiples filtros de entradas en una sola llamada. Claves soportadas (to
 - locale: un único código de idioma (aplica `by_lang`; no acepta lista separada por comas)
 - from_published_date: fecha límite inicial (>= `published_at`)
 - to_published_date: fecha límite final (<= `published_at`)
-- sort_by: nombre de campo (`name`, `slug`, `created_at`, `updated_at`, `published_at` u otro path de campo)
+- sort_by: nombre de campo (default: `created_at`). Admite `name`, `slug`, `created_at`, `updated_at` y `published_at`, o un campo con su prefijo (`fields.<nombre>` o `meta.<atributo>`); ver [Sort By](/es/platform/channels/liquid-markup/filters.html#sort-by)
 - order: `asc` | `desc` (default: `desc`)
 - per_page: cantidad de resultados por página (habilita paginación; default: 10)
-- page: número de página (default: 1)
+- page: número de página (habilita paginación; default: 1)
 
 *ej.* <span v-pre>`{% assign entries = spaces['testing'].entries | by: types: 'promo,basic', locale: 'es', categories: 'destacadas,favoritas', tags: 'test,test2', slugs: 'slug2,slug1', uuids: 'uuid2,uuid1', sort_by: 'name', order: 'asc', per_page: 10, page: 2 %}`</span>
+
+`sort_by` y `order` son opcionales en la invocación, pero no en el efecto: `by` aplica siempre `sort_by`, con `created_at` y `desc` como valores por defecto. Una colección que ya venía ordenada por otro criterio, como la de un widget con su propio orden, sale reordenada por fecha de creación descendente aunque la plantilla no pida ningún ordenamiento, y no hay forma de pedirle a `by` que no ordene. Si necesitas conservar el orden de origen, encadena los filtros simples (`by_type`, `by_category`, `by_tag`, `by_slug`…) en lugar de usar `by`.
+
+La paginación, en cambio, sí es opcional: solo se aplica si pasas `per_page` o `page`. Los valores por defecto de esas dos claves son los que toma el filtro cuando indicas una y omites la otra, y quedan sujetos a la precedencia de los parámetros de la URL descrita en [Paginated](/es/platform/channels/liquid-markup/filters.html#paginated).
+
+:::warning Atención
+Las claves que `by` no reconoce se ignoran en silencio, sin error ni aviso: un `type:` en singular o un `tag:` mal escrito no filtran nada y el listado sale completo. Revisa los nombres contra la lista de arriba antes de dar por perdido un filtro que no parece hacer nada.
+:::
 
 ### Filter By (Operadores Extendidos)
 
@@ -432,9 +440,17 @@ Separa los resultados en páginas. *e.g.*
 <span v-pre>`{{ objects | paginated: 10, 2 }}`</span>
 
 **Parametros**:
-- objeto(Array) — array
+- objeto(Array) — colección de entradas (objeto antes de la barra)
 - per_page (Integer) (default: 10) — objetos por página
 - page (Integer) (default: 1) — número de página a mostrar
+
+Los parámetros `page` y `per_page` de la URL tienen precedencia sobre los argumentos escritos en la plantilla. Con el ejemplo de arriba, una visita a `mi-pagina.com/landing?page=5` muestra la página 5 y no la 2: los argumentos actúan como valores iniciales, para la primera visita sin parámetros en la URL. Y como esos parámetros son globales para la página, alcanzan a la vez a todos los listados paginados que haya en ella.
+
+El filtro acota los dos valores, vengan del argumento o de la URL: `per_page` se limita a un mínimo de 1 y a un máximo de 100, y `page` a un mínimo de 1. Un `per_page` de 500 entrega 100 resultados por página.
+
+:::warning Atención
+Aplicado sobre algo que no sea una colección de entradas, por ejemplo un array ya materializado por `sort`, por `map` o definido en la propia plantilla, el filtro devuelve la entrada intacta: no pagina y tampoco falla. El listado se ve completo, los enlaces de paginación no aparecen y no queda ninguna pista del motivo. Encadena `paginated` directamente sobre la colección de entradas.
+:::
 
 ### Sort By
 
@@ -442,9 +458,24 @@ Retorna un array con las entradas ordenadas por un campo *e.g.*
 <span v-pre>`{% assign entries = widgets.entries | sort_by: 'name', 'asc' %}`</span>
 
 **Parametros**:
-- entries (ArrayEntry) — array con entradas
-- atributo (String) — campo por el cual se quiere ordenar
-- orden (String) - asc (asecendente) o desc (desciendiente)
+- coleccion (ArrayEntry | ArrayCategory) — colección a ordenar (objeto antes de la barra)
+- field (String) — campo por el cual se quiere ordenar
+- order (String) (default: 'desc') — `asc` o `desc`
+
+El orden por defecto es descendente y cualquier valor que no sea exactamente `asc` se trata como `desc`: un `'ascending'` o un `'asc '` con un espacio de más ordenan al revés de lo pedido, sin ningún aviso.
+
+Los campos admitidos dependen de la colección que recibe el filtro:
+
+- **Colección de categorías**: solo `name`, `slug` y `uuid`.
+- **Colección de entradas**: los cinco atributos meta `name`, `slug`, `created_at`, `updated_at` y `published_at` se ordenan de forma directa. Cualquier otro nombre lo resuelve la capa de búsqueda, que exige el prefijo del contenedor, igual que [Filter By](/es/platform/channels/liquid-markup/filters.html#filter-by-operadores-extendidos): `fields.<nombre>` para un campo del tipo de contenido y `meta.<atributo>` para el resto de los metadatos.
+
+:::warning Atención
+Sobre una colección de categorías, un campo fuera de `name`, `slug` y `uuid` devuelve una colección vacía sin ningún error: el listado se ve en blanco y parece que no hay datos.
+
+Sobre una colección de entradas, un nombre sin prefijo, como `'precio'` en lugar de `'fields.precio'`, no ordena por el campo que esperas. Además, ordenar por `fields.<nombre>` necesita, igual que `filter_by`, una colección acotada a un tipo de contenido: sobre algo como <span v-pre>`spaces['blog'].entries`</span> el filtro aborta y en el HTML publicado queda el comentario `<!-- Liquid Error -->` en lugar del bloque. Parte de <span v-pre>`spaces['blog'].types['post'].entries`</span> o de <span v-pre>`widget.entries`</span>.
+
+El filtro aborta también, con el mismo comentario en la salida, si el campo o el orden no llegan como cadena, por ejemplo <span v-pre>`| sort_by: 'name', 1`</span>.
+:::
 
 
 ### To Published Date
@@ -532,28 +563,32 @@ Estos filtros Liquid alteran valores relacionados con la Geolocalización en Mod
 
 ### Dynamic Map
 
-Devuelve un mapa dinámico de Google Maps (ej. <span v-pre>`{{ locations | dynamic_map: '600x300', 'true', 'roadmap', true}}`</span>).
+Devuelve un mapa dinámico de Google Maps (ej. <span v-pre>`{{ locations | dynamic_map: '600x300', 10, 'roadmap', '', true }}`</span>).
 
 **Parametros**
 
 - `locations` (ArrayHash) — Array de hashes con los puntos de latitud y longitud.
 - `size` (String) (default: '600x300') — Tamaño en píxeles del mapa.
-- `zoom` (String) (default: 10) — Nivel de zoom para el mapa.
+- `zoom` (Integer) (default: 10) — Nivel de zoom para el mapa.
 - `type` (String) (default: 'roadmap') — Tipo de mapa.
 - `icon` (String) (default: '') — Icono para el mapa.
-- `controls` (String) (default: true) — Controles de navegación para el mapa.
+- `controls` (Boolean) (default: true) — Controles de navegación para el mapa.
 
 ### Static Map
 
-Devuelve un mapa estático de Google Maps (ej. <span v-pre>`{{ locations | static_map: '600x300', 'true', 'roadmap'}}`</span>).
+Devuelve un mapa estático de Google Maps (ej. <span v-pre>`{{ locations | static_map: '600x300', 15, 'roadmap' }}`</span>).
 
 **Parametros**
 
 - `locations` (ArrayHash) — Array de hashes con los puntos de latitud y longitud.
 - `size` (String) (default: '600x300') — Tamaño en píxeles del mapa.
-- `zoom` (String) (default: 10) — Nivel de zoom para el mapa.
+- `zoom` (String) (default: '') — Nivel de zoom para el mapa. Sin valor, la URL de Google Maps se arma con `zoom=` vacío y el encuadre queda a criterio de Google; pásalo siempre que necesites un encuadre fijo.
 - `type` (String) (default: 'roadmap') — Tipo de mapa.
 - `icon` (String) (default: '') — Icono para el mapa.
+
+:::warning Atención
+En los dos filtros el argumento que sigue a `size` es `zoom`, no `controls`. Un ejemplo del tipo <span v-pre>`{{ locations | static_map: '600x300', 'true', 'roadmap' }}`</span> arma la URL de Google Maps con `zoom=true` y el mapa no se encuadra como esperas. En `dynamic_map` el orden es `size`, `zoom`, `type`, `icon`, `controls`, así que para llegar a `controls` hay que pasar los cuatro argumentos anteriores.
+:::
 
 
 ## Menu Items
@@ -582,12 +617,31 @@ Estos son los filtros liquid que alteran valores relacionados con originations e
 
 ### By UID
 
-Devuelve el Origination con el UID seleccionado. *ej.*
-<span v-pre>`{% assign my_origination = site.originations | by_uid: 'my-origination' %}`</span>
+Devuelve el objeto con el UID indicado dentro de una colección del módulo Origination. Es un único filtro, `by_uid`, que admite cuatro clases de colección:
+
+- `site.originations` — los originations del sitio.
+- `origination.steps` — los steps de un origination.
+- `step.tasks` — las tareas de un step.
+- `task.fields` — las preguntas de una tarea de entrada de usuario. Es la única forma de tomar una pregunta concreta por su UID; los objetos que devuelve son [question](/es/platform/channels/liquid-markup/objects.html#question).
 
 **Parámetros:**
-- originations (ArrayOrigination) - array con originations
-- uid (String) - UID del Origination
+- coleccion (ArrayOrigination | ArrayStep | ArrayTask | ArrayQuestion) - colección sobre la que se busca
+- uid (String) - UID del objeto buscado
+
+El filtro devuelve un único objeto, no una colección: su resultado se usa directamente y no se recorre con un ciclo. Si ningún elemento de la colección tiene ese UID, no devuelve nada.
+
+*ej.*
+
+```liquid
+{% assign my_origination = site.originations | by_uid: 'my-origination' %}
+{% assign my_step = my_origination.steps | by_uid: 'step-01' %}
+{% assign my_task = my_step.tasks | by_uid: 'task-01' %}
+{% assign my_question = my_task.fields | by_uid: 'question-01' %}
+```
+
+:::warning Atención
+En dos casos el filtro aborta y en el HTML publicado queda el comentario `<!-- Liquid Error -->` en lugar del bloque: cuando se aplica sobre algo que no es una colección y cuando se aplica sobre una colección de una clase no admitida. En el segundo caso el mensaje incluye el nombre de la clase recibida, lo que permite identificar qué se pasó por error.
+:::
 
 ## Site
 
@@ -735,6 +789,15 @@ Convierte una fecha en String a palabras (ej. <span v-pre>`{{ '01-02-2019' | tim
 
 Resuelve el texto de traducción para claves de Sitios. Se devolverán valores personalizados si existen (ej. <span v-pre>`{{ 'admin.logs.errors.no_logs_yet' | translate }}`</span>).
 
+**Parametros**
+
+- `value` (String) — clave de la traducción (objeto antes de la barra).
+- `count` (Integer) (default: nil) — cantidad con la que se pluraliza la clave.
+
+`t` es el alias corto del filtro y hace exactamente lo mismo: <span v-pre>`{{ 'admin.logs.errors.no_logs_yet' | t }}`</span>.
+
+El segundo parámetro pluraliza la clave y solo se aplica cuando llega como entero (ej. <span v-pre>`{{ 'site.results.count' | t: total }}`</span>). Si llega como cadena, por ejemplo `'3'`, el filtro lo descarta sin avisar y resuelve la clave sin pluralizar.
+
 ### Truncate HTML
 
 Devuelve un String después de truncarlo (ej. <span v-pre>`{{ html | truncate_html: 10 }}`</span>).
@@ -751,6 +814,8 @@ Devuelve el Step con el UID seleccionado. *ej.*
 **Parámetros:**
 - steps (ArrayStep) - array con steps
 - uid (String) - UID del Step
+
+Es el mismo filtro `by_uid` del módulo Origination. La referencia completa, con las cuatro clases de colección admitidas y los errores que aborta, está en [By UID](/es/platform/channels/liquid-markup/filters.html#by-uid).
 
 ## Submission
 
@@ -856,6 +921,8 @@ Devuelve el Task con el UID seleccionado. *ej.*
 **Parámetros:**
 - tasks (ArrayTask) - array con tasks
 - uid (String) - UID del Task
+
+Es el mismo filtro `by_uid` del módulo Origination, que también acepta la colección `fields` de una tarea de entrada de usuario para tomar una de sus preguntas por UID: <span v-pre>`{% assign my_question = my_task.fields | by_uid: 'question-01' %}`</span>. La referencia completa está en [By UID](/es/platform/channels/liquid-markup/filters.html#by-uid).
 
 ## User
 


### PR DESCRIPTION
## Cambios propuestos

Completa las fichas de los filtros de colección con lo que hoy obliga a depurar a ciegas: por qué un listado sale vacío, en qué orden sale realmente y qué parámetro gana cuando hay conflicto.

### `docs/{es,en}/platform/channels/liquid-markup/filters.md`

- **`sort_by`**: los tres caminos que toma según la colección, los prefijos aceptados, el orden predeterminado y los dos casos en que aborta.
- **`by_uid`**: su alcance real, que incluye preguntas de formulario, y el error fuera de él.
- **El filtro compuesto**: reordena siempre por fecha de creación descendente, aunque hayas pedido otro orden antes.
- **`paginated`**: qué tiene precedencia.
- **`dynamic_map`**: la firma real y los tipos correctos de sus parámetros.

## Diferencias con la ficha del plan, verificadas en master

- **`sort_by` acepta dos prefijos, no uno.** La ficha solo mencionaba uno.
- **Hay un tercer modo de fallo** que la ficha no traía: la ordenación aborta cuando falta el tipo de contenido.
- **El ordenamiento del filtro compuesto es incondicional, pero la paginación no lo es.** La ficha las trataba igual.
- **El ejemplo de `dynamic_map` tenía un defecto más** que el señalado, y un parámetro estaba tipado como texto cuando es booleano.
- **No borré las fichas duplicadas** que la ficha sugería eliminar: dejé la canónica donde corresponde por dónde vive el filtro, y eso resuelve la duplicación sin perder contenido.

Closes #1064

Gaps: `LIQUID-FILTROS-15`, `LIQUID-FILTROS-18`, `LIQUID-FILTROS-19`, `LIQUID-FILTROS-21`, `LIQUID-FILTROS-22`

🤖 Generated with [Claude Code](https://claude.com/claude-code)