### PR TITLE
tags.md: bloques de layout y tags de CSRF

### DIFF
--- a/docs/en/platform/channels/liquid-markup/objects.md
+++ b/docs/en/platform/channels/liquid-markup/objects.md
@@ -497,7 +497,6 @@ Site objects are used to get all the information about a site. The available att
 | **site.account_url**            | A string with the URL of the account associated with the site.                                         |                        |
 | **site.breadcrumb**             | A string with the CSS class of the breadcrumb div.                                                     |                        |
 | **site.cache_version**          | A string with the cache key for this version of the site.                                              |                        |
-| **site.csrf_meta_tag**          | A string with the CSRF meta tag.                                                                       |                        |
 | **site.css_path**               | A string with the location of the site's CSS file.                                                     |                        |
 | **site.current_year**           | A string with the current year of the site.                                                            |                        |
 | **site.js_path**                | A string with the location of the site's JS file.                                                      |                        |
@@ -794,3 +793,4 @@ When a template calls an attribute that no longer exists, Liquid resolves it as 
 | request.comments_url                             | (remove)                      | Removed in 10.2; now resolves as empty.         |
 | request.interact_url                             | (remove)                      | Removed in 10.2; now resolves as empty.         |
 | request.refresh_url                              | (remove)                      | Removed in 10.2; now resolves as empty.         |
+| site.csrf_meta_tag                               | `{% csrf_meta %}`             | Always resolves as empty; use the tag instead.  |

--- a/docs/en/platform/channels/liquid-markup/tags.md
+++ b/docs/en/platform/channels/liquid-markup/tags.md
@@ -19,6 +19,8 @@ Tags are used for template logic. Here is a list of currently supported tags:
 - **raw**: Temporarily disables tag processing to avoid syntax conflicts.
 - **unless**: Mirror of the `if` statement.
 
+Beyond these, Modyo registers platform-specific tags that do not exist in standard Liquid: see [Modyo-specific tags](/en/platform/channels/liquid-markup/tags.html#modyo-specific-tags).
+
 ### Comments
 
 Any content written between `{% comment %}` and `{% endcomment %}` tags will become a comment.
@@ -370,3 +372,69 @@ If you want to combine several strings into one and save it in a variable, you c
     <option value="blue">Blue</option>
   </select>
 ```
+
+## Modyo-specific tags
+
+Beyond the standard Liquid tags, the platform registers its own. The following ones ship with the default layouts and templates of every new site, so it is worth knowing what they emit before changing them.
+
+### The html5 block
+
+<code v-pre>{% html5 %}</code> is a block, not a simple tag: it needs its closing <code v-pre>{% endhtml5 %}</code>, and everything you write between them is rendered inside the document it generates.
+
+The block emits the `<!DOCTYPE html>` declaration and the `<html>` element with the `no-js` class and a `lang` attribute taken from the site's configured language, then the block's content, and the closing `</html>`:
+
+```html
+<!DOCTYPE html>
+<html class="no-js" lang='en'>
+  <!-- block content -->
+</html>
+```
+
+If the site has no configured language, the `lang` attribute is omitted entirely. That is why a Modyo layout does not write the `<!DOCTYPE html>` and `<html>` tags by hand: this block writes them, and the **Base** layout of every new site already comes wrapped in it. See [Layouts](/en/platform/channels/templates.html#layouts).
+
+### The body block
+
+<code v-pre>{% body %}</code> is also a block and needs its closing <code v-pre>{% endbody %}</code>. It generates the full `<body>` element, with an `id` and three classes the platform derives from the context the page was resolved in:
+
+```html
+<body id="<context id>" class="<page_context> <page_name> <page_id>">
+  <!-- block content -->
+</body>
+```
+
+Those classes are the hook for writing CSS or JavaScript per page type without printing anything in the template. These are the values the platform assigns:
+
+| `page_context` | Where it resolves | body `id` | `page_name` | `page_id` |
+|----------------|-------------------|-----------|-------------|-----------|
+| `context-home` | Site home page | `home` | `context-home-show` | `context-home-show` |
+| `context-custom` | Custom pages | `custom` | `context-custom-show` | `context-custom-show-<page path>` |
+| `context-content` | Content pages | `content` | `context-content-show` | `context-content-show-<page path>` |
+| `context-search` | Search results view | `search` | `context-search-show` | (empty) |
+| `context-origination` | Origination pages | `base` | `context-origination-show` | `context-origination-show-<page path>` |
+| `context-support` | Support pages | `base` | `context-support-show` | `context-support-show-<page path>` |
+| `context-forms` | Forms, form view | `base` | `context-forms-form_response` | `context-forms-show-<form slug>` |
+| `context-forms` | Forms, thank you page | `base` | `context-forms-thank_you` | `context-forms-thank_you-<form slug>` |
+| `context-people` | Preview from the admin | `base` | (empty) | (empty) |
+
+:::tip Tip
+The `id` only distinguishes the home page, custom pages, content pages and search. Every other context shares `id="base"`, so to style those use the `page_context` class.
+:::
+
+See [Context Variables](/en/platform/channels/liquid-markup/variables.html#context-variables) for what each of these variables holds.
+
+### CSRF tags
+
+Modyo registers two tags that emit the session's CSRF token:
+
+| Tag | What it emits |
+|-----|---------------|
+| `{% csrf_meta %}` | The `<meta name="csrf-param">` and `<meta name="csrf-token">` elements, so the token can be read from JavaScript. |
+| `{% csrf_param %}` | An `<input type="hidden">` with the parameter name and the token, to send it inside a form. |
+
+Both come included in the default templates: <code v-pre>{% csrf_meta %}</code> in the theme's `shared/general/head` snippet, and <code v-pre>{% csrf_param %}</code> inside the forms of the default origination templates.
+
+:::warning Warning
+Both tags render an empty string when the visitor has no session on the site. A form of your own that relies on them is submitted without a token for anonymous visitors, and the HTML leaves no trace that the tag was ever there. Use them in views that already require a session.
+:::
+
+The `site.csrf_meta_tag` attribute is not an equivalent of <code v-pre>{% csrf_meta %}</code>: it always resolves as empty. See [Deprecated Attributes](/en/platform/channels/liquid-markup/objects.html#deprecated-attributes).

--- a/docs/en/platform/channels/liquid-markup/variables.md
+++ b/docs/en/platform/channels/liquid-markup/variables.md
@@ -187,8 +187,8 @@ These four collections are injected on every render, no matter the page type and
 |----------|---------------|-----------------|
 | `content_for_layout` | The already rendered HTML of the view. Marks the spot in the layout where the page is inserted. | Layouts only |
 | `page` | The current page. See [page](/en/platform/channels/liquid-markup/objects.html#page). | All but the search results page |
-| `page_context` | The page type that was resolved: `context-home`, `context-custom`, `context-content`, `context-origination` or `context-search`. | All |
-| `page_name` | The same identifier with the `-show` suffix, for example `context-content-show`. | All |
+| `page_context` | The page type that was resolved, for example `context-home`, `context-custom` or `context-content`. See the full list in [The body block](/en/platform/channels/liquid-markup/tags.html#the-body-block). | All |
+| `page_name` | The context identifier with a suffix that indicates the view, almost always `-show`, for example `context-content-show`. | All |
 | `page_title` | The page name. On the home page and on search it is the platform's translated text. | All |
 | `page_id` | `page_name` followed by the page path, for example `context-custom-show-contact`. On the home page it is just `context-home-show`. | All but the search results page |
 | `url` | The URL being resolved, including the category path or the entry slug when applicable. | All but the search results page |

--- a/docs/es/platform/channels/liquid-markup/objects.md
+++ b/docs/es/platform/channels/liquid-markup/objects.md
@@ -504,7 +504,6 @@ Los objetos de Sitio se utilizan para obtener toda la información de un sitio. 
 | **site.account_url**            | String con la URL de la cuenta asociada al sitio.                                                                           |                        |
 | **site.breadcrumb**             | String con la clase CSS del div de breadcrumb.                                                                              |                        |
 | **site.cache_version**          | String con la clave de caché de esta versión del sitio.                                                                     |                        |
-| **site.csrf_meta_tag**          | String con la meta etiqueta CSRF.                                                                                           |                        |
 | **site.css_path**               | String con la ubicación del archivo CSS del sitio.                                                                          |                        |
 | **site.current_year**           | String con el año actual del sitio.                                                                                         |                        |
 | **site.js_path**                | String con la ubicación del archivo JS del sitio.                                                                           |                        |
@@ -810,4 +809,5 @@ Cuando una plantilla invoca un atributo que ya no existe, Liquid lo resuelve com
 | request.comments_url                             | (eliminar)                    | Eliminado en 10.2; hoy se resuelve como vacío.      |
 | request.interact_url                             | (eliminar)                    | Eliminado en 10.2; hoy se resuelve como vacío.      |
 | request.refresh_url                              | (eliminar)                    | Eliminado en 10.2; hoy se resuelve como vacío.      |
+| site.csrf_meta_tag                               | `{% csrf_meta %}`             | Siempre se resuelve como vacío; usa el tag.         |
 

--- a/docs/es/platform/channels/liquid-markup/tags.md
+++ b/docs/es/platform/channels/liquid-markup/tags.md
@@ -19,6 +19,8 @@ Los tags (etiquetas) se utilizan para la lógica de la plantilla. Aquí hay una 
 - **raw**: Desactiva temporalmente el procesamiento de tags para evitar conflictos de sintaxis.
 - **unless**: Copia de la sentencia `if`.
 
+Además de estos, Modyo registra tags propios de la plataforma que no existen en Liquid estándar: consulta [Tags propios de Modyo](/es/platform/channels/liquid-markup/tags.html#tags-propios-de-modyo).
+
 ### Comentarios
 
 Cualquier contenido escrito entre los tags `{% comment %}` y `{% endcomment %}` se convertirá en un comentario.
@@ -370,3 +372,69 @@ Si quieres combinar varios strings en uno solo y guardarlo en una variable, pued
     <option value="blue">Blue</option>
   </select>
 ```
+
+## Tags propios de Modyo
+
+Además de los tags estándar de Liquid, la plataforma registra tags propios. Los siguientes vienen en los layouts y plantillas por defecto de todo sitio nuevo, así que conviene saber qué emiten antes de modificarlos.
+
+### Bloque html5
+
+<code v-pre>{% html5 %}</code> es un bloque, no un tag simple: necesita su cierre <code v-pre>{% endhtml5 %}</code> y todo lo que escribas entre ambos se renderiza dentro del documento que genera.
+
+El bloque emite la declaración `<!DOCTYPE html>` y la etiqueta `<html>` con la clase `no-js` y el atributo `lang` tomado del idioma configurado del sitio, luego el contenido del bloque, y el cierre `</html>`:
+
+```html
+<!DOCTYPE html>
+<html class="no-js" lang='es'>
+  <!-- contenido del bloque -->
+</html>
+```
+
+Si el sitio no tiene idioma configurado, el atributo `lang` se omite por completo. Por eso un layout de Modyo no lleva escritas a mano las etiquetas `<!DOCTYPE html>` ni `<html>`: las escribe este bloque, y el layout **Base** de todo sitio nuevo ya viene envuelto en él. Consulta [Layouts](/es/platform/channels/templates.html#layouts).
+
+### Bloque body
+
+<code v-pre>{% body %}</code> también es un bloque y necesita su cierre <code v-pre>{% endbody %}</code>. Genera la etiqueta `<body>` completa, con un `id` y tres clases que la plataforma deriva del contexto en el que se resolvió la página:
+
+```html
+<body id="<id del contexto>" class="<page_context> <page_name> <page_id>">
+  <!-- contenido del bloque -->
+</body>
+```
+
+Esas clases son el gancho para escribir CSS o JavaScript por tipo de página sin imprimir nada en la plantilla. Estos son los valores que asigna la plataforma:
+
+| `page_context` | Dónde se resuelve | `id` del body | `page_name` | `page_id` |
+|----------------|-------------------|---------------|-------------|-----------|
+| `context-home` | Portada del sitio | `home` | `context-home-show` | `context-home-show` |
+| `context-custom` | Páginas personalizadas | `custom` | `context-custom-show` | `context-custom-show-<ruta de la página>` |
+| `context-content` | Páginas de contenido | `content` | `context-content-show` | `context-content-show-<ruta de la página>` |
+| `context-search` | Vista de resultados de búsqueda | `search` | `context-search-show` | (vacío) |
+| `context-origination` | Páginas de originación | `base` | `context-origination-show` | `context-origination-show-<ruta de la página>` |
+| `context-support` | Páginas de soporte | `base` | `context-support-show` | `context-support-show-<ruta de la página>` |
+| `context-forms` | Formularios, vista del formulario | `base` | `context-forms-form_response` | `context-forms-show-<slug del formulario>` |
+| `context-forms` | Formularios, página de agradecimiento | `base` | `context-forms-thank_you` | `context-forms-thank_you-<slug del formulario>` |
+| `context-people` | Vista previa desde el administrador | `base` | (vacío) | (vacío) |
+
+:::tip Tip
+El `id` solo distingue portada, páginas personalizadas, páginas de contenido y búsqueda. Todos los demás contextos comparten `id="base"`, así que para estilarlos usa la clase de `page_context`.
+:::
+
+Consulta [Variables de Contexto](/es/platform/channels/liquid-markup/variables.html#variables-de-contexto) para ver qué contiene cada una de estas variables.
+
+### Tags de CSRF
+
+Modyo registra dos tags que emiten el token CSRF de la sesión:
+
+| Tag | Qué emite |
+|-----|-----------|
+| `{% csrf_meta %}` | Las etiquetas `<meta name="csrf-param">` y `<meta name="csrf-token">`, para leer el token desde JavaScript. |
+| `{% csrf_param %}` | Un `<input type="hidden">` con el nombre del parámetro y el token, para enviarlo dentro de un formulario. |
+
+Ambos vienen incluidos en las plantillas por defecto: <code v-pre>{% csrf_meta %}</code> en el snippet `shared/general/head` del tema, y <code v-pre>{% csrf_param %}</code> dentro de los formularios de las plantillas de originación.
+
+:::warning Atención
+Los dos tags rinden una cadena vacía cuando el visitante no tiene sesión iniciada en el sitio. Un formulario propio que dependa de ellos se envía sin token para visitantes anónimos, y en el HTML no queda ninguna marca de que el tag estuvo ahí. Úsalos en vistas que ya requieren sesión.
+:::
+
+El atributo `site.csrf_meta_tag` no es un equivalente de <code v-pre>{% csrf_meta %}</code>: siempre se resuelve como vacío. Consulta [Deprecated Attributes](/es/platform/channels/liquid-markup/objects.html#deprecated-attributes).

--- a/docs/es/platform/channels/liquid-markup/variables.md
+++ b/docs/es/platform/channels/liquid-markup/variables.md
@@ -187,8 +187,8 @@ Estas cuatro colecciones se inyectan en todos los renderizados, sin importar el 
 |----------|--------------|--------------|
 | `content_for_layout` | El HTML ya renderizado de la vista. Marca el punto del layout donde se inserta la página. | Solo en los layouts |
 | `page` | La página actual. Consulta [page](/es/platform/channels/liquid-markup/objects.html#page). | Todas menos la de resultados de búsqueda |
-| `page_context` | El tipo de página que se resolvió: `context-home`, `context-custom`, `context-content`, `context-origination` o `context-search`. | Todas |
-| `page_name` | El mismo identificador con el sufijo `-show`, por ejemplo `context-content-show`. | Todas |
+| `page_context` | El tipo de página que se resolvió, por ejemplo `context-home`, `context-custom` o `context-content`. Consulta la lista completa en [Bloque body](/es/platform/channels/liquid-markup/tags.html#bloque-body). | Todas |
+| `page_name` | El identificador del contexto con un sufijo que indica la vista, casi siempre `-show`, por ejemplo `context-content-show`. | Todas |
 | `page_title` | El nombre de la página. En la portada y en la búsqueda es el texto traducido de la plataforma. | Todas |
 | `page_id` | `page_name` seguido de la ruta de la página, por ejemplo `context-custom-show-contacto`. En la portada es solo `context-home-show`. | Todas menos la de resultados de búsqueda |
 | `url` | La URL que se está resolviendo, incluida la ruta de la categoría o el slug de la entrada cuando corresponde. | Todas menos la de resultados de búsqueda |


### PR DESCRIPTION
## Cambios propuestos

Documenta los tres tags propios de Modyo que vienen en todos los layouts predeterminados y que hasta ahora aparecían como código sin explicación. Es la clase de contenido que alguien borra por parecer decorativo y rompe el sitio.

### `docs/{es,en}/platform/channels/liquid-markup/tags.md`

Sección nueva de tags propios con el bloque de documento HTML, el bloque de cuerpo —con la tabla completa del identificador y las clases que inyecta según el contexto de página, que es lo que permite estilar por página— y los dos tags de CSRF, con su render condicional.

### `docs/{es,en}/platform/channels/liquid-markup/objects.md` y `variables.md`

Corrección de un atributo que la referencia de objetos declaraba y no existe, y enlaces desde las notas que ya hablaban de las clases del cuerpo sin explicar de dónde salen.

## Diferencias con la ficha del plan, verificadas en master

- **El identificador del cuerpo solo distingue cuatro casos**, no todos los contextos: el resto cae en el genérico.
- **En la búsqueda no existe identificador de página**, así que esa clase sale vacía.
- **En formularios el identificador difiere entre las dos vistas.**
- **Un contexto asigna solo el contexto de página**, sin nombre ni identificador, y quedó reflejado con sus celdas vacías.
- **El error de la referencia de objetos está confirmado**: el atributo declarado no existe en el objeto.
- Se omitieron los sufijos de `sitemap.xml` y `llms.txt` porque esas respuestas no pasan por un layout.

Closes #1066

Gaps: `LIQUID-TAGS-04`, `LIQUID-TAGS-05`, `LIQUID-TAGS-07`

🤖 Generated with [Claude Code](https://claude.com/claude-code)