### PR TITLE
filters.md: familias de filtros ausentes de la referencia

### DIFF
--- a/docs/en/platform/channels/liquid-markup/filters.md
+++ b/docs/en/platform/channels/liquid-markup/filters.md
@@ -204,6 +204,43 @@ If the site doesn't have an associated realm and you don't specify parameters, t
 - precision - number of decimal digits.
 
 
+## Common
+
+These Liquid filters are available in any template and don't depend on a module.
+
+### Handle
+
+Turns a text into a URL-friendly identifier, *e.g.*
+<span v-pre>`{{ ' A s.?%$!' | handle }} #=> 'a-s'`</span>
+
+**Parameters**
+
+- `string` (String) — text to convert (object before the pipe).
+- `separator` (String) (default: '-') — character that replaces whitespace and special characters.
+- `preserve_case` (Boolean) (default: false) — with `true` it keeps the original text's casing.
+
+The rules it applies are:
+
+- It lowercases everything, unless `preserve_case` is `true`.
+- It replaces whitespace and special characters with the separator.
+- It collapses a sequence of consecutive whitespace or special characters into a single separator.
+- It removes the separators at the beginning and at the end.
+- With an empty text it returns an empty text.
+
+*e.g.*
+
+<span v-pre>`{{ 'Hello   World!!!' | handle }} #=> 'hello-world'`</span>
+
+<span v-pre>`{{ '---Hello---World---' | handle }} #=> 'hello-world'`</span>
+
+<span v-pre>`{{ 'CamelCase Words' | handle: '-', true }} #=> 'CamelCase-Words'`</span>
+
+<span v-pre>`{{ ' A s.?%$!' | handle: '.', true }} #=> 'A.s'`</span>
+
+### Handleize
+
+Alias of `handle`, with the same signature and the same result (e.g. <span v-pre>`{{ ' A s.?%$!' | handleize }} #=> 'a-s'`</span>). It exists for templates coming from Shopify; in new templates use `handle`.
+
 ## Content
 
 These are the liquid filters that alter values related to the Content module in Modyo Platform.
@@ -218,8 +255,38 @@ If the UUID doesn't match any file in the account, none of the four fails or ret
 
 ### Asset image
 
-Returns the tags of an image using its uuid from the File Manager. If using Cloudflare for image optimization, you can use these additional parameters: width, height, blur, quality, format and fit. *e.g.*
+Returns the tags of an image using its uuid from the File Manager. If using Cloudflare for image optimization, you can use these additional parameters: width, height, blur, quality, format, fit, widths, sizes and style. *e.g.*
 <span v-pre>`{{ uuid | asset_image: width: 40, format: 'auto', fit: 'cover' }}`</span>
+
+**Parameters**:
+- uuid (String) — asset uuid
+- width (Integer) — width in pixels
+- height (Integer) — height in pixels
+- quality (Integer) — quality percentage
+- blur (Integer) — blur level
+- fit (String) — how the image fits its box
+- format (String) — output format
+- widths (String) — comma-separated list of widths; emits a `srcset` attribute with an `Nw` descriptor for each width
+- sizes (String) — emitted as is, as the `sizes` attribute
+- style (String) — emitted as is, as the `style` attribute
+
+The image's `alt` comes from the file's **Alt text**, edited in [Media](/en/platform/content/asset-manager.html#edit-a-file).
+
+The filter has three possible outputs:
+
+- **Without options, or with CDN image processing disabled**: an `<img>` with the file's original URL. All the options are ignored.
+- **With options and processing enabled**: an `<img>` with the transformed URL.
+- **With `widths`**: on top of the transformed URL in `src`, a `srcset` with one variant per width in the list, plus the `sizes` and `style` attributes if you passed them.
+
+*e.g.* <span v-pre>`{{ uuid | asset_image: width: 800, quality: 80, widths: '300, 600, 900', sizes: '(min-width: 400px) 298px, 78.75vw' }}`</span>
+
+:::warning Attention
+`sizes` and `style` are only emitted when you also pass `widths`: without it, the filter returns an `<img>` with `src` and `alt` and nothing else. And only `width`, `quality`, `blur` and `height` are propagated to each `srcset` variant, not `fit` or `format`, so if you need the same crop or the same format at every resolution, build the `srcset` by hand with several calls to the filter.
+:::
+
+:::tip Tip
+CDN image processing is an account setting. While it isn't enabled, all nine options are ignored without an error and the page publishes the image at its original size.
+:::
 
 ### Asset link
 
@@ -639,6 +706,81 @@ The filter returns a single object, not a collection: its result is used directl
 :::warning Attention
 In two cases the filter aborts and the published HTML keeps the `<!-- Liquid Error -->` comment in place of the block: when it is applied to something that is not a collection, and when it is applied to a collection of an unsupported class. In the second case the message includes the name of the class received, which makes it possible to identify what was passed by mistake.
 :::
+
+## Pagination
+
+These Liquid filters build the navigation of a listing already paginated with [Paginated](/en/platform/channels/liquid-markup/filters.html#paginated). Apply them to the paginated collection, not to the original one.
+
+The `page` and `per_page` URL parameters are global to the page, so they reach every paginated listing on it at once.
+
+### Pagination links
+
+Returns the complete navigation bar of a paginated listing. *e.g.*
+<span v-pre>`{{ paginated_entries | pagination_links }}`</span>
+
+**Parameters**
+
+- `collection` (ArrayEntry) — collection already paginated (object before the pipe).
+
+The output is a `<nav aria-label="Pagination">` with a `<ul class="pagination">` inside, using Bootstrap's pagination classes:
+
+- The current page comes out as `<li class="page-item active" aria-current="page">`.
+- The other pages come out as `<li class="page-item">` with an `<a class="page-link">`.
+- The gap between blocks of pages comes out as `<li class="page-item disabled" aria-hidden="true">` with `&hellip;`.
+- The previous and next arrows come out as `<li class="page-item">` with `aria-label="Previous"` and `aria-label="Next"`. When there is no page to go to, the `<li>` also carries the `disabled` class.
+
+The arrow labels are fixed, `&laquo;` and `&raquo;`. The filter declares three more optional parameters, an anchor and the two labels, but none of them reaches the output: to change the symbols, the language or the structure of the bar you have to build your own markup with `?page=N` links.
+
+When the listing fits in a single page, the filter prints nothing.
+
+:::warning Attention
+The disabled arrow is still emitted as a link, with `href="false"`. Bootstrap's styles cancel the click with the `.page-item.disabled .page-link` rule; if you write your own pagination styles, replicate it or the user will be able to click an arrow that leads nowhere.
+:::
+
+:::warning Attention
+If the template is rendered outside the lifecycle of a site page, the filter can't build the page addresses and publishes a red error paragraph instead, starting with `(Will Paginate Liquidized) Error:`. If you find that text on a page, check where the template is being rendered from.
+:::
+
+### Pagination links remote
+
+Does the same as `pagination_links` and additionally adds `data-remote="true"` to every link in the bar. *e.g.*
+<span v-pre>`{{ paginated_entries | pagination_links_remote }}`</span>
+
+This is the version to use in custom widgets, which are loaded asynchronously. The conditions of that case are in [Examples](/en/platform/channels/liquid-markup/examples.html#filter-entries).
+
+### Total entries
+
+Returns the total number of items in the collection, not the ones on the current page. *e.g.*
+<span v-pre>`{{ paginated_entries | total_entries }}`</span>
+
+**Parameters**
+
+- `collection` (ArrayEntry) — collection (object before the pipe).
+
+It is the counterpart of `paginated`: on a collection that is already paginated, `size` returns the items on the page and `total_entries` the total of the listing. On an empty collection or on an array it returns its size, without an error.
+
+```liquid
+{% assign paginated_entries = entries | paginated: 10 %}
+<ul>
+  {% for entry in paginated_entries %}
+  <li>{{ entry.meta.name }}</li>
+  {% endfor %}
+</ul>
+<p>Showing {{ paginated_entries.size }} of {{ paginated_entries | total_entries }} results</p>
+{{ paginated_entries | pagination_links }}
+```
+
+### Page entries info liquid
+
+Returns a text legend with the range of results on the current page and the total of the collection. *e.g.*
+<span v-pre>`{{ paginated_entries | page_entries_info_liquid }}`</span>
+
+**Parameters**
+
+- `collection` (ArrayEntry) — collection already paginated (object before the pipe).
+- `model_name` (String) (default: null) — name of the entity being listed, to name it inside the legend.
+
+The legend is built in English and doesn't go through the site translations. If you need it in the site's language, or with another format, build it with `total_entries` as in the example above.
 
 ## Site
 

--- a/docs/en/platform/channels/liquid-markup/filters.md
+++ b/docs/en/platform/channels/liquid-markup/filters.md
@@ -255,7 +255,7 @@ If the UUID doesn't match any file in the account, none of the four fails or ret
 
 ### Asset image
 
-Returns the tags of an image using its uuid from the File Manager. If using Cloudflare for image optimization, you can use these additional parameters: width, height, blur, quality, format, fit, widths, sizes and style. *e.g.*
+Returns the tags of an image using its uuid from the File Manager. With CDN image processing active, you can use these additional parameters: width, height, blur, quality, format, fit, widths, sizes and style. *e.g.*
 <span v-pre>`{{ uuid | asset_image: width: 40, format: 'auto', fit: 'cover' }}`</span>
 
 **Parameters**:

--- a/docs/en/platform/content/asset-manager.md
+++ b/docs/en/platform/content/asset-manager.md
@@ -149,10 +149,10 @@ Once you have the Liquid code of the image, access the work area where you want 
 
 1. Paste the Liquid code. It should look something like this:
 <span v-pre>`{{ 'ec0a3e4-ccdb-48c5-87be-5e1eca560dee' | asset_image }}`</span>
-2. Add the Liquid filter, it can be height, width, or quality, following any of these formats:
+2. Add to the filter the parameters you need. The available ones are `width`, `height`, `quality`, `blur`, `fit` and `format`, plus `widths`, `sizes` and `style` for responsive images. You can follow any of these formats:
 - <span v-pre>`asset_image: width: XXX`</span> where XXX is the desired pixel size.
 - <span v-pre>`asset_image: quality: XX`</span> where XX is the desired percentage of quality.
-- <span v-pre>`asset_image: width: XXX, quality: XX, widths: 'XXX, XXX, XXX, sizes: (min-width: XXXpx) XXXpx`</span> adapting the values according to your needs to ensure that the image fits the different screens and resolutions of your user's devices, using the [srcset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset) attribute for responsive support.
+- <span v-pre>`asset_image: width: 800, quality: 80, widths: '300, 600, 900', sizes: '(min-width: 400px) 298px, 78.75vw'`</span> adapting the values according to your needs to ensure that the image fits the different screens and resolutions of your user's devices, using the [srcset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset) attribute for responsive support.
 3. Click **save**.
 4. Click on **publish**.
 
@@ -161,6 +161,13 @@ Once you have the Liquid code of the image, access the work area where you want 
 When resizing images, the original aspect ratio is preserved, so the image is adjusted proportionally, without distortion.
 
 If you only include the height or width of the image, the missing value is automatically calculated to maintain the correct aspect ratio of the image.
+:::
+
+
+:::warning Attention
+The `asset_image` options depend on your account's CDN image processing. If it isn't enabled, the filter publishes the original image and silently ignores all of them: there is no error or notice, just an image at its original size. If the size doesn't change no matter how you adjust the values, check with the team that administers your account.
+
+`sizes` and `style` are only emitted when you also pass `widths`, and only `width`, `quality`, `blur` and `height` are propagated to each `srcset` variant. The full filter reference is in [Asset image](/en/platform/channels/liquid-markup/filters.html#asset-image).
 :::
 
 

--- a/docs/es/platform/channels/liquid-markup/filters.md
+++ b/docs/es/platform/channels/liquid-markup/filters.md
@@ -255,7 +255,7 @@ Si el UUID no corresponde a ningún archivo de la cuenta, ninguno de los cuatro 
 
 ### Asset image
 
-Retorna los tags de una imagen usando su uuid del Gestor de Archivos. Al usar Cloudflare para la optimización de imágenes, puedes usar estos parámetros adicionales: width, height, blur, quality, format, fit, widths, sizes y style *e.g.*
+Retorna los tags de una imagen usando su uuid del Gestor de Archivos. Con el procesamiento de imágenes por CDN activo, puedes usar estos parámetros adicionales: width, height, blur, quality, format, fit, widths, sizes y style *e.g.*
 <span v-pre>`{{ uuid | asset_image: width: 40, format: 'auto', fit: 'cover' }}`</span>
 
 **Parámetros**:

--- a/docs/es/platform/channels/liquid-markup/filters.md
+++ b/docs/es/platform/channels/liquid-markup/filters.md
@@ -204,6 +204,43 @@ En caso de que el sitio no tenga un reino asociado y no especifiques parámetros
 - precision - cantidad de dígitos decimales.
 
 
+## Common
+
+Estos filtros Liquid están disponibles en cualquier plantilla y no dependen de un módulo.
+
+### Handle
+
+Convierte un texto en un identificador apto para una URL, *e.g.*
+<span v-pre>`{{ ' A s.?%$!' | handle }} #=> 'a-s'`</span>
+
+**Parámetros**
+
+- `string` (String) — texto a convertir (objeto antes de la barra).
+- `separator` (String) (default: '-') — carácter con el que se reemplazan los espacios y los caracteres especiales.
+- `preserve_case` (Boolean) (default: false) — con `true` conserva las mayúsculas y minúsculas del texto original.
+
+Las reglas que aplica son:
+
+- Pasa todo a minúsculas, salvo que `preserve_case` sea `true`.
+- Reemplaza los espacios y los caracteres especiales por el separador.
+- Colapsa una secuencia de espacios o caracteres especiales consecutivos en un solo separador.
+- Elimina los separadores del comienzo y del final.
+- Con un texto vacío devuelve un texto vacío.
+
+*ej.*
+
+<span v-pre>`{{ 'Hello   World!!!' | handle }} #=> 'hello-world'`</span>
+
+<span v-pre>`{{ '---Hello---World---' | handle }} #=> 'hello-world'`</span>
+
+<span v-pre>`{{ 'CamelCase Words' | handle: '-', true }} #=> 'CamelCase-Words'`</span>
+
+<span v-pre>`{{ ' A s.?%$!' | handle: '.', true }} #=> 'A.s'`</span>
+
+### Handleize
+
+Alias de `handle`, con la misma firma y el mismo resultado (ej. <span v-pre>`{{ ' A s.?%$!' | handleize }} #=> 'a-s'`</span>). Existe para las plantillas que vienen de Shopify; en plantillas nuevas usa `handle`.
+
 ## Content
 
 Estos son los filtros liquid que alteran valores relacionados al módulo de Content en Modyo Platform.
@@ -218,8 +255,38 @@ Si el UUID no corresponde a ningún archivo de la cuenta, ninguno de los cuatro 
 
 ### Asset image
 
-Retorna los tags de una imagen usando su uuid del Gestor de Archivos. Al usar Cloudflare para la optimización de imágenes, puedes usar estos parámetros adicionales: width, height, blur, quality, format y fit *e.g.*
+Retorna los tags de una imagen usando su uuid del Gestor de Archivos. Al usar Cloudflare para la optimización de imágenes, puedes usar estos parámetros adicionales: width, height, blur, quality, format, fit, widths, sizes y style *e.g.*
 <span v-pre>`{{ uuid | asset_image: width: 40, format: 'auto', fit: 'cover' }}`</span>
+
+**Parámetros**:
+- uuid (String) — asset uuid
+- width (Integer) — ancho en píxeles
+- height (Integer) — alto en píxeles
+- quality (Integer) — porcentaje de calidad
+- blur (Integer) — nivel de desenfoque
+- fit (String) — modo de ajuste al recuadro
+- format (String) — formato de salida
+- widths (String) — lista de anchos separados por coma; emite un atributo `srcset` con un descriptor `Nw` por cada ancho
+- sizes (String) — se emite tal cual como atributo `sizes`
+- style (String) — se emite tal cual como atributo `style`
+
+El `alt` de la imagen sale del **Texto alternativo** del archivo, el que se edita en [Media](/es/platform/content/asset-manager.html#editar-un-archivo).
+
+El filtro tiene tres salidas posibles:
+
+- **Sin opciones, o con el procesamiento de imágenes por CDN desactivado**: un `<img>` con la URL original del archivo. Las opciones se ignoran todas.
+- **Con opciones y el procesamiento activo**: un `<img>` con la URL transformada.
+- **Con `widths`**: además de la URL transformada en el `src`, un `srcset` con una variante por cada ancho de la lista, más los atributos `sizes` y `style` si los pasaste.
+
+*ej.* <span v-pre>`{{ uuid | asset_image: width: 800, quality: 80, widths: '300, 600, 900', sizes: '(min-width: 400px) 298px, 78.75vw' }}`</span>
+
+:::warning Atención
+`sizes` y `style` solo se emiten cuando pasas también `widths`: sin él, el filtro devuelve un `<img>` con `src` y `alt` y nada más. Y de cada variante del `srcset` solo se propagan `width`, `quality`, `blur` y `height`, no `fit` ni `format`, así que si necesitas el mismo recorte o el mismo formato en todas las resoluciones arma el `srcset` a mano con varias llamadas al filtro.
+:::
+
+:::tip Tip
+El procesamiento de imágenes por CDN es una configuración de la cuenta. Mientras no esté activo, las nueve opciones se ignoran sin error y la página publica la imagen en su tamaño original.
+:::
 
 ### Asset link
 
@@ -642,6 +709,81 @@ El filtro devuelve un único objeto, no una colección: su resultado se usa dire
 :::warning Atención
 En dos casos el filtro aborta y en el HTML publicado queda el comentario `<!-- Liquid Error -->` en lugar del bloque: cuando se aplica sobre algo que no es una colección y cuando se aplica sobre una colección de una clase no admitida. En el segundo caso el mensaje incluye el nombre de la clase recibida, lo que permite identificar qué se pasó por error.
 :::
+
+## Paginación
+
+Estos filtros Liquid arman la navegación de un listado ya paginado con [Paginated](/es/platform/channels/liquid-markup/filters.html#paginated). Aplícalos sobre la colección paginada, no sobre la colección original.
+
+Los parámetros `page` y `per_page` de la URL son globales de la página, así que alcanzan a la vez a todos los listados paginados que haya en ella.
+
+### Pagination links
+
+Devuelve la barra de navegación completa de un listado paginado. *ej.*
+<span v-pre>`{{ paginated_entries | pagination_links }}`</span>
+
+**Parámetros**
+
+- `coleccion` (ArrayEntry) — colección ya paginada (objeto antes de la barra).
+
+La salida es un `<nav aria-label="Pagination">` con un `<ul class="pagination">` dentro, con las clases de paginación de Bootstrap:
+
+- La página actual sale como `<li class="page-item active" aria-current="page">`.
+- Las demás páginas salen como `<li class="page-item">` con un `<a class="page-link">`.
+- El salto entre bloques de páginas sale como `<li class="page-item disabled" aria-hidden="true">` con `&hellip;`.
+- Las flechas de anterior y siguiente salen como `<li class="page-item">` con `aria-label="Previous"` y `aria-label="Next"`. Cuando no hay página a la que ir, el `<li>` lleva además la clase `disabled`.
+
+Las etiquetas de las flechas son fijas, `&laquo;` y `&raquo;`. El filtro declara tres parámetros opcionales más, un ancla y las dos etiquetas, pero ninguno llega a la salida: para cambiar los símbolos, el idioma o la estructura de la barra tienes que armar tu propio markup con enlaces `?page=N`.
+
+Cuando el listado cabe en una sola página, el filtro no imprime nada.
+
+:::warning Atención
+La flecha deshabilitada se emite igual como enlace, con `href="false"`. Los estilos de Bootstrap anulan el clic con la regla `.page-item.disabled .page-link`; si escribes tus propios estilos de paginación, replícala o el usuario podrá hacer clic en una flecha que no lleva a ninguna parte.
+:::
+
+:::warning Atención
+Si la plantilla se renderiza fuera del ciclo de una página del sitio, el filtro no puede armar las direcciones de las páginas y publica en su lugar un párrafo de error en rojo que empieza con `(Will Paginate Liquidized) Error:`. Si te encuentras con ese texto en una página, revisa desde dónde se está renderizando la plantilla.
+:::
+
+### Pagination links remote
+
+Hace lo mismo que `pagination_links` y además agrega `data-remote="true"` a cada enlace de la barra. *ej.*
+<span v-pre>`{{ paginated_entries | pagination_links_remote }}`</span>
+
+Es la versión que corresponde usar en los widgets personalizados, que se cargan de forma asíncrona. Las condiciones de ese caso están en [Ejemplos](/es/platform/channels/liquid-markup/examples.html#filtrar-entradas).
+
+### Total entries
+
+Devuelve la cantidad total de elementos de la colección, no los de la página actual. *ej.*
+<span v-pre>`{{ paginated_entries | total_entries }}`</span>
+
+**Parámetros**
+
+- `coleccion` (ArrayEntry) — colección (objeto antes de la barra).
+
+Es la contraparte de `paginated`: sobre una colección ya paginada, `size` devuelve los elementos de la página y `total_entries` el total del listado. Sobre una colección vacía o sobre un arreglo devuelve su tamaño, sin error.
+
+```liquid
+{% assign paginated_entries = entries | paginated: 10 %}
+<ul>
+  {% for entry in paginated_entries %}
+  <li>{{ entry.meta.name }}</li>
+  {% endfor %}
+</ul>
+<p>Mostrando {{ paginated_entries.size }} de {{ paginated_entries | total_entries }} resultados</p>
+{{ paginated_entries | pagination_links }}
+```
+
+### Page entries info liquid
+
+Devuelve una leyenda de texto con el rango de resultados de la página actual y el total de la colección. *ej.*
+<span v-pre>`{{ paginated_entries | page_entries_info_liquid }}`</span>
+
+**Parámetros**
+
+- `coleccion` (ArrayEntry) — colección ya paginada (objeto antes de la barra).
+- `model_name` (String) (default: nulo) — nombre de la entidad que se lista, para nombrarla dentro de la leyenda.
+
+La leyenda se arma en inglés y no pasa por las traducciones del sitio. Si la necesitas en el idioma del sitio, o con otro formato, ármala con `total_entries` como en el ejemplo de arriba.
 
 ## Site
 

--- a/docs/es/platform/content/asset-manager.md
+++ b/docs/es/platform/content/asset-manager.md
@@ -149,10 +149,10 @@ Una vez que tengas el código Liquid de la imagen, accede al área de trabajo do
 
 1. Pega el código Liquid. Debe verse similar a esto:
 <span v-pre>`{{ 'ec0a3e4-ccdb-48c5-87be-5e1eca560dee' | asset_image }}`</span>
-2. Agrega el filtro de Liquid, puede ser height, width o quality, siguiendo cualquiera de  estos  formatos:
+2. Agrega al filtro los parámetros que necesites. Los disponibles son `width`, `height`, `quality`, `blur`, `fit` y `format`, más `widths`, `sizes` y `style` para imágenes responsivas. Puedes seguir cualquiera de estos formatos:
 - <span v-pre>`asset_image: width: XXX`</span> donde XXX es el tamaño en píxeles deseado.
 - <span v-pre>`asset_image: quality: XX`</span> donde XX es el porcentaje de calidad deseado.
-- <span v-pre>`asset_image: width: XXX, quality: XX, widths: 'XXX, XXX, XXX, sizes: (min-width: XXXpx) XXXpx`</span> adaptando los valores según tus necesidades para asegurar que la imagen se ajuste a las diferentes pantallas y resoluciones de los dispositivos de tus usuarios, usando el atributo [srcset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset) para soporte responsivo.
+- <span v-pre>`asset_image: width: 800, quality: 80, widths: '300, 600, 900', sizes: '(min-width: 400px) 298px, 78.75vw'`</span> adaptando los valores según tus necesidades para asegurar que la imagen se ajuste a las diferentes pantallas y resoluciones de los dispositivos de tus usuarios, usando el atributo [srcset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset) para soporte responsivo.
 3. Da click en **guardar**.
 4. Da click en **publicar**.
 
@@ -161,6 +161,13 @@ Una vez que tengas el código Liquid de la imagen, accede al área de trabajo do
 Al redimensionar imágenes, se conserva la relación de aspecto original, por lo que la imagen se ajusta de manera proporcional, sin distorsionarse.
 
 Si incluyes solamente la altura o ancho de la imagen, automáticamente se calcula el valor faltante para mantener la relación de aspecto correcta de la imagen.
+:::
+
+
+:::warning Atención
+Las opciones de `asset_image` dependen del procesamiento de imágenes por CDN de tu cuenta. Si no está activo, el filtro publica la imagen original y las ignora todas en silencio: no hay error ni aviso, solo una imagen del tamaño original. Si el tamaño no cambia por más que ajustes los valores, consúltalo con el equipo que administra tu cuenta.
+
+`sizes` y `style` solo se emiten cuando pasas también `widths`, y de cada variante del `srcset` solo se propagan `width`, `quality`, `blur` y `height`. La ficha completa del filtro está en [Asset image](/es/platform/channels/liquid-markup/filters.html#asset-image).
 :::
 
 


### PR DESCRIPTION
## Cambios propuestos

Agrega a la referencia de Liquid familias completas de filtros que la plataforma ofrece y que no estaban documentadas: paginación, imágenes responsivas y assets.

### `docs/{es,en}/platform/channels/liquid-markup/filters.md` y `content/asset-manager.md`

## Un gap saltado, con su razón

**El filtro `json` sigue marcado como privado en master.** La ficha pedía documentarlo, pero la anotación `@private` continúa sobre su definición, lo que significa que la plataforma no lo considera parte de la interfaz pública. Documentarlo sería comprometernos con algo que el equipo de la plataforma se reserva el derecho de cambiar. Queda como decisión de producto, no de documentación.

Closes #1076

Gaps: `LIQUID-FILTROS-02`, `LIQUID-FILTROS-08`, `LIQUID-FILTROS-09`

🤖 Generated with [Claude Code](https://claude.com/claude-code)