### PR TITLE
types.md: propiedades comunes de los campos, límites y clonado

### DIFF
--- a/docs/en/platform/content/spaces.md
+++ b/docs/en/platform/content/spaces.md
@@ -37,6 +37,24 @@ Later, in the space configuration, you can define secondary languages for the en
 
 :::
 
+## Clone a space
+
+Cloning a space creates a full copy within the same account: its categories, its content types, its entries, the files in its media library, and the team members with their roles are all copied. To clone a space:
+
+1. In the side menu, select **Content**.
+1. In the **Actions** column of the space's row, click **Clone**.
+1. In the **Clone space** window, confirm by clicking **Clone space**.
+
+The clone takes the name of the original prefixed with "Copy of" and the identifier prefixed with "copy-of-". If a space with that name or identifier already exists, a number is appended so it isn't repeated.
+
+:::tip Tip
+Cloning runs in the background and may take a while: while it completes, the window shows "This will take some time, the space is being cloned.". When it finishes you'll see "Space cloned successfully" and the list is refreshed with the new space.
+:::
+
+:::warning Attention
+The number of spaces you can have is set by your account plan. If you've already reached that quota, cloning doesn't start and you'll see the message "You've reached the maximum number of spaces for your current plan". If you need a larger quota, talk to your Modyo account manager.
+:::
+
 ## Space Settings
 
 In this section, you can customize and adjust the options available for your space, according to your specific needs. To access the configuration of your space, follow these steps:

--- a/docs/en/platform/content/types.md
+++ b/docs/en/platform/content/types.md
@@ -68,7 +68,7 @@ For more information, go to the [API reference](/en/platform/content/public-api-
 
 Every field you can add to a type shares three properties, which you configure in the **Field** tab of the right-hand panel:
 
-- **Name**: Identifies the field and is the key you use to access its value from Liquid, the SDKs, and the API. It is required, accepts up to 255 characters, and cannot begin with an underscore (`_`), contain dots, or include the `<`, `>`, and `;` characters. If you type a character that isn't allowed, the panel discards what you typed and shows "Field names cannot begin with underscore nor contain dots".
+- **Name**: Identifies the field and is the key you use to access its value from Liquid, the SDKs, and the API. It is required, accepts up to 255 characters, and cannot begin with an underscore (`_`) or contain dots. If you type a character that isn't allowed, the panel discards what you typed and shows "Field names cannot begin with underscore nor contain dots".
 - **Hint**: Optional help text. It is displayed below the field when creating or modifying an entry, to guide whoever fills it in.
 - **Required**: When creating or modifying an entry, you must provide a value for that field. Otherwise, you will not be able to save the changes made.
 

--- a/docs/en/platform/content/types.md
+++ b/docs/en/platform/content/types.md
@@ -52,9 +52,9 @@ The number of content types you can create per space is set by your account plan
 
 In the creation interface, you'll find an empty template in the center of the screen and on the right side, a table with three tabs:
 
-- **Add fields**
-- **Field Configuration**
-- **Configuration**
+- **Add**
+- **Field**
+- **Settings**
 
 This interface allows you to create each of the types and format them as needed, according to your needs.
 
@@ -66,13 +66,25 @@ The name of the field is of utmost importance, as it will be used to access its 
 For more information, go to the [API reference](/en/platform/content/public-api-reference)
 :::
 
-All fields that can be added to a type have a name and can optionally be set as required.
+Every field you can add to a type shares three properties, which you configure in the **Field** tab of the right-hand panel:
 
-When a field is marked as required, when creating or modifying an entry, you must provide a value for that field. Otherwise, you will not be able to save the changes made.
+- **Name**: Identifies the field and is the key you use to access its value from Liquid, the SDKs, and the API. It is required, accepts up to 255 characters, and cannot begin with an underscore (`_`), contain dots, or include the `<`, `>`, and `;` characters. If you type a character that isn't allowed, the panel discards what you typed and shows "Field names cannot begin with underscore nor contain dots".
+- **Hint**: Optional help text. It is displayed below the field when creating or modifying an entry, to guide whoever fills it in.
+- **Required**: When creating or modifying an entry, you must provide a value for that field. Otherwise, you will not be able to save the changes made.
+
+Within the same type, two fields can't share a name: if you repeat one, the type isn't saved and you'll see the message "Cannot save this type because it has repeated field names".
+
+:::warning Attention
+Renaming a field changes the key you use to read its value from Liquid, the SDKs, and the API. Before renaming a field that is already in use, review the templates and integrations that consume it.
+:::
+
+:::danger Danger
+Deleting a field from a type erases that field's value in every entry of the type, and it can't be undone. When you remove it, the panel asks you to confirm with the message "Are you sure you want to delete this field? Once you save, this action will remove this field from all entries of this type, and cannot be undone." and warns you again when you save. As long as you don't save, the field and its values stay intact: if you made a mistake, leave the screen without saving.
+:::
 
 ### Single-line text
 
-This field allows you to enter single-line texts. It has the following restrictions:
+This field allows you to enter single-line texts, with a hard limit of 255 characters. If you need to store a longer text, use [Multiline text](#multiline-text). It has the following restrictions:
 
 - **Minimum length**: Allows you to require a minimum number of characters for the entered text.
 - **Maximum length**: Allows you to limit the maximum number of characters for the entered text.
@@ -221,9 +233,13 @@ This field allows you to link more than one existing Entry within the Space to a
 
 - **Allowed content type**: Limits the links to entries of one type. You select a single type, which applies to every entry you link, and the default value is **All**, which doesn't restrict anything. If any of the linked entries isn't of the chosen type, the entry isn't saved and the field shows "Does not match with allowed value", followed by the name of the required type.
 
+:::tip Tip
+Each entry can link up to 10 entries in a single Content list field. If you select more, the panel shows "Max reference items (10) reached, extra items will be excluded" and keeps only the first 10. That cap is defined per installation: if you need more references, talk to your Modyo account manager.
+:::
+
 ### Group
 
-Use the Group field to house another field within it. You can assign a name to the group according to your needs, as well as name the fields within the group. In the hint field, include the text you want to display to help your users complete the field correctly.
+Use the Group field to house another field within it. You can assign a name to the group according to your needs, as well as name the fields within the group and use each field's **Hint** to guide whoever fills in the entry.
 
 Once you have more than one type of field within a group, you can drag and order them as needed.
 
@@ -274,17 +290,48 @@ A group can host any type of field, except another group.
 :::
 
 
+## Saving changes to a type
+
+The changes you make to a type (adding, renaming, reordering, or deleting fields) are only applied when you click **Save**.
+
+:::warning Attention
+If the type already has entries, when you save the panel asks you to confirm with the message "Updating a type will result in the reindex and direct modification of any published entry of this type. Be aware that this process can take some time and in the meantime the entries of that type will not reflect the changes until the process is finished.". While that process is running, the button shows "Reindexing..." and you can't save the type again: hovering over it shows "This Content Type is currently being processed by a reindex process. Saving changes won't be available until it finishes.".
+:::
+
 ## Properties
 
-In this tab, you can see the name and UID of the type. The UID is important, as it is used to refer to the type from the Liquid SDKs, JavaScript, and the API. Next, you will see a button that can be in 2 states:
+In the **Settings** tab of the right-hand panel you can review and edit the general data of the type:
 
-- **Reindex**: Allows you to re-index the model in case of problems with the public API.
-- **Cancel reindexing**: If a reindexing is in progress, you can cancel the process by clicking this button.
+- **Name**: The name the type is listed under.
+- **Identifier**: The UID of the type. It is important, as it is used to refer to the type from the Liquid SDKs, JavaScript, and the API.
+- **Description**: Free text of up to 4,095 characters. Use it to document, for the rest of the team, what this type is for.
+- **Cardinality**: Switch between **Multiple** and **Single**. You can't switch to **Single** if the type already has more than one entry.
+
+In the actions menu of the type editor header you'll also find an option that can be in 2 states:
+
+- **Reindex type**: Allows you to re-index the model in case of problems with the public API.
+- **Cancel reindex**: If a reindexing is in progress, you can cancel the process by clicking this option.
 
 :::warning Attention
 When you reindex one of your types, the previously indexed model will remain available until the new indexing is complete. Once the reindexing is complete, the old index will be overwritten with the new index.
 :::
 
 :::warning Attention
-Note that depending on the [cache settings you have in your space](/en/platform/content/spaces#cache), you may not see the changes immediately after you have finished reindexing.
+Note that, depending on the cache settings between your browser and the platform, you may not see the changes immediately after you have finished reindexing.
+:::
+
+## Clone a type
+
+Cloning a type creates, within the same space, a copy with all its fields and validations. It's useful for starting from a proven structure without rebuilding it field by field. To clone a type:
+
+1. From the main menu, click **Content**.
+2. Select the space where the type lives.
+3. Click on **Types**.
+4. In the **Actions** column of the type's row, click **Clone**.
+5. In the **Clone type** window, confirm by clicking **Clone type**.
+
+The clone takes the name of the original prefixed with "Copy of" and the identifier prefixed with "copy-of-". If a type with that name or identifier already exists, a number is appended so it isn't repeated. Only the structure is copied: the entries of the original type aren't duplicated.
+
+:::tip Tip
+Cloning runs in the background and may take a while: while it completes, the window shows "This will take some time, the type is being cloned.". When it finishes you'll see "Type cloned successfully" and the new type will appear in the list.
 :::

--- a/docs/es/platform/content/spaces.md
+++ b/docs/es/platform/content/spaces.md
@@ -37,6 +37,24 @@ Posteriormente, en la configuración del espacio podrás definir idiomas secunda
 
 :::
 
+## Clonar un espacio
+
+Clonar un espacio crea una copia completa dentro de la misma cuenta: se copian sus categorías, sus tipos de contenido, sus entradas, los archivos de su biblioteca de multimedia y los miembros del equipo con sus roles. Para clonar un espacio:
+
+1. En el menú lateral selecciona **Content**.
+1. En la columna **Acciones** de la fila del espacio, haz click en **Clonar**.
+1. En la ventana **Clonar espacio**, confirma haciendo click en **Clonar espacio**.
+
+El clon toma el nombre del original precedido de "Copia de" y el identificador precedido de "copia-de-". Si ya existe un espacio con ese nombre o identificador, se le añade un número al final para no repetirlo.
+
+:::tip Tip
+El clonado se ejecuta en segundo plano y puede tardar: mientras se completa, la ventana muestra "Esto demorará un tiempo, el espacio está siendo clonado.". Al terminar verás "Espacio clonado correctamente" y el listado se actualiza con el nuevo espacio.
+:::
+
+:::warning Atención
+El número de espacios que puedes tener lo define el plan de tu cuenta. Si ya alcanzaste ese cupo, el clonado no se inicia y verás el mensaje "Has alcanzado el número máximo de espacios para el plan actual". Si necesitas un cupo mayor, conversa con tu ejecutivo de cuenta en Modyo.
+:::
+
 ## Configuración del espacio
 
 En esta sección puedes personalizar y ajustar las opciones disponibles para tu espacio, según tus necesidades específicas. Para acceder a la configuración de tu espacio sigue estos pasos:

--- a/docs/es/platform/content/types.md
+++ b/docs/es/platform/content/types.md
@@ -52,8 +52,8 @@ El número de tipos de contenido que puedes crear por espacio lo define el plan 
 
 En la interfaz de creación, encontrarás una plantilla vacía en el centro de la pantalla y al lado derecho, una tabla con tres pestañas: 
 
-- **Añadir campos**
-- **Configuración del campo**
+- **Añadir**
+- **Campo**
 - **Configuración**
 
 Esta interfaz te permite crear cada uno de los tipos y darles el formato necesario, según tus requisitos.
@@ -66,13 +66,25 @@ El nombre del campo es de suma importancia, ya que será utilizado para acceder 
 Para más información ve a la [referencia de la API](/es/platform/content/public-api-reference)
 :::
 
-Todos los campos que se pueden añadir en un tipo, tienen un nombre, y la posibilidad de ser requeridos.
+Todos los campos que puedes añadir a un tipo comparten tres propiedades, que se configuran en la pestaña **Campo** del panel derecho:
 
-Cuando un campo es marcado como requerido, al crear o modificar una entrada, se debes proporcionar un valor para ese campo. De lo contrario, no podrás guardar los cambios realizados.
+- **Nombre**: Identifica al campo y es la clave con la que accedes a su valor desde Liquid, los SDK y la API. Es obligatorio, admite hasta 255 caracteres, y no puede empezar con guion bajo (`_`), contener puntos, ni incluir los caracteres `<`, `>` y `;`. Si escribes un carácter no permitido, el panel descarta lo que escribiste y muestra "Los nombres de campos no pueden empezar con guión ni contener puntos".
+- **Indicación**: Texto de ayuda opcional. Se muestra bajo el campo al crear o modificar una entrada, para orientar a quien la completa.
+- **Requerido**: Al crear o modificar una entrada, se debe proporcionar un valor para ese campo. De lo contrario, no podrás guardar los cambios realizados.
+
+Dentro de un mismo tipo, dos campos no pueden llamarse igual: si repites un nombre, el tipo no se guarda y verás el mensaje "No se puede guardar el tipo porque hay nombres repetidos en sus campos".
+
+:::warning Atención
+Renombrar un campo cambia la clave con la que lees su valor desde Liquid, los SDK y la API. Antes de renombrar un campo que ya está en uso, revisa las plantillas y las integraciones que lo consumen.
+:::
+
+:::danger Peligro
+Eliminar un campo de un tipo borra el valor de ese campo en todas las entradas del tipo, y no se puede deshacer. Al quitarlo, el panel te pide confirmar con el mensaje "¿Estás seguro que quieres eliminar este campo? Una vez guardes, esta acción eliminará este campo de todas las entradas de este tipo y no se podrá deshacer." y vuelve a advertirte al guardar. Mientras no guardes, el campo y sus valores siguen intactos: si te equivocaste, sal de la pantalla sin guardar.
+:::
 
 ### Texto de una línea
 
-Este campo te permite ingresar textos de una sola linea. Cuenta con las siguientes restricciones:
+Este campo te permite ingresar textos de una sola linea, con un tope de 255 caracteres. Si necesitas guardar un texto más largo, usa [Texto de múltiples líneas](#texto-de-multiples-lineas). Cuenta con las siguientes restricciones:
 
 - **Largo mínimo**: Permite exigir un mínimo de caracteres para el texto ingresado.
 - **Largo máximo**: Permite  limitar la cantidad máxima de caracteres para el texto ingresado.
@@ -221,9 +233,13 @@ Este campo te permite vincular más de una Entrada existente dentro del Espacio 
 
 - **Tipos de contenido permitidos**: Limita los enlaces a las entradas de un tipo. Pese al plural del nombre, seleccionas un único tipo, que aplica a todas las entradas que enlaces; el valor por defecto es **Todos**, que no restringe nada. Si cualquiera de las entradas enlazadas no es del tipo elegido, la entrada no se guarda y el campo muestra "No calza con los valores permitidos", seguido del nombre del tipo exigido.
 
+:::tip Tip
+Cada entrada puede enlazar hasta 10 entradas en un mismo campo Listado de Contenido. Si seleccionas más, el panel muestra "Se ha alcanzado el máximo de referencias (10), se excluirán los elementos adicionales" y conserva solo las 10 primeras. Ese tope se define por instalación: si necesitas más referencias, conversa con tu ejecutivo de cuenta en Modyo.
+:::
+
 ### Grupo
 
-Utiliza el campo Grupo para albergar otro campo dentro él. Puedes asignar un nombre al grupo según tus necesidades, así como nombrar los campos dentro del grupo. En casilla pista, incluye el texto que deseas mostrar para ayudar a tus usuarios a completar correctamente el campo. 
+Utiliza el campo Grupo para albergar otro campo dentro él. Puedes asignar un nombre al grupo según tus necesidades, así como nombrar los campos dentro del grupo y usar la **Indicación** de cada uno para orientar a quien completa la entrada. 
 
 Una vez que tengas más de un tipo de campo dentro de un grupo, puedes arrastrarlos y ordenarlos según requieras. 
 
@@ -274,11 +290,26 @@ Un grupo puede albergar cualquier tipo de campo, menos otro grupo.
 :::
 
 
+## Guardar los cambios de un tipo
+
+Los cambios que haces en un tipo (añadir, renombrar, reordenar o eliminar campos) solo se aplican cuando haces click en **Guardar**.
+
+:::warning Atención
+Si el tipo ya tiene entradas, al guardar el panel te pide confirmar con el mensaje "Actualizar el tipo de contenido reindexará todas las entradas y afectará todo el contenido publicado de este tipo. Ten en cuenta que este proceso puede tomar un tiempo y mientras tanto, las entradas de este tipo no reflejarán los cambios hasta que el proceso de reindexación termine.". Mientras ese proceso está en curso, el botón muestra "Reindexando..." y no puedes volver a guardar el tipo: al pasar el cursor sobre él verás "Hay un proceso de reindexación activo para este tipo de contenido. Puedes guardar cuando termine.".
+:::
+
 ## Propiedades
 
-En esta pestaña, puedes ver el nombre y UID del tipo. El UID es importante, ya que se utiliza para referirse al tipo desde los SDK de Liquid, JavaScript y la API. A continuación, verás un botón que puede estar en 2 estados:
+En la pestaña **Configuración** del panel derecho puedes revisar y editar los datos generales del tipo:
 
-- **Reindexar**: Te permite volver a indexar el modelo en caso de problemas con la API pública.
+- **Nombre**: El nombre con el que aparece el tipo en el listado.
+- **Identificador**: El UID del tipo. Es importante, ya que se utiliza para referirse al tipo desde los SDK de Liquid, JavaScript y la API.
+- **Descripción**: Texto libre de hasta 4.095 caracteres. Úsalo para dejar documentado, para el resto del equipo, cuál es el propósito de este tipo.
+- **Cardinalidad**: Cambia entre **Múltiple** e **Individual**. No puedes cambiarla a **Individual** si el tipo ya tiene más de una entrada.
+
+En el menú de acciones del encabezado del editor del tipo encontrarás además una opción que puede estar en 2 estados:
+
+- **Reindexar este contenido**: Te permite volver a indexar el modelo en caso de problemas con la API pública.
 - **Cancelar reindexación**: Si hay una reindexación en curso, puedes cancelar el proceso haciendo click en este botón. 
 
 :::warning Atención
@@ -286,5 +317,21 @@ Al reindexar uno de tus tipos, el modelo previamente indexado seguirá disponibl
 :::
 
 :::warning Atención
-Ten en cuenta que dependiendo de la [configuración de caché que tengas en tu espacio](/es/platform/content/spaces#cache), es posible que no veas los cambios inmediatamente después de haber terminado la reindexación.
+Ten en cuenta que, según la configuración de caché entre tu navegador y la plataforma, es posible que no veas los cambios inmediatamente después de haber terminado la reindexación.
+:::
+
+## Clonar un tipo
+
+Clonar un tipo crea, dentro del mismo espacio, una copia con todos sus campos y sus validaciones. Es útil para partir de una estructura ya probada sin rehacerla campo por campo. Para clonar un tipo:
+
+1. Desde el menú principal, haz click en **Contenido**.
+2. Selecciona el espacio donde está el tipo.
+3. Haz click en **Tipos**.
+4. En la columna **Acciones** de la fila del tipo, haz click en **Clonar**.
+5. En la ventana **Clonar tipo**, confirma haciendo click en **Clonar tipo**.
+
+El clon toma el nombre del original precedido de "Copia de" y el identificador precedido de "copia-de-". Si ya existe un tipo con ese nombre o identificador, se le añade un número al final para no repetirlo. Solo se copia la estructura: las entradas del tipo original no se duplican.
+
+:::tip Tip
+El clonado se ejecuta en segundo plano y puede tardar: mientras se completa, la ventana muestra "Esto demorará un tiempo, el tipo está siendo clonado.". Al terminar verás "Tipo clonado correctamente" y el nuevo tipo aparecerá en el listado.
 :::

--- a/docs/es/platform/content/types.md
+++ b/docs/es/platform/content/types.md
@@ -68,7 +68,7 @@ Para más información ve a la [referencia de la API](/es/platform/content/publi
 
 Todos los campos que puedes añadir a un tipo comparten tres propiedades, que se configuran en la pestaña **Campo** del panel derecho:
 
-- **Nombre**: Identifica al campo y es la clave con la que accedes a su valor desde Liquid, los SDK y la API. Es obligatorio, admite hasta 255 caracteres, y no puede empezar con guion bajo (`_`), contener puntos, ni incluir los caracteres `<`, `>` y `;`. Si escribes un carácter no permitido, el panel descarta lo que escribiste y muestra "Los nombres de campos no pueden empezar con guión ni contener puntos".
+- **Nombre**: Identifica al campo y es la clave con la que accedes a su valor desde Liquid, los SDK y la API. Es obligatorio, admite hasta 255 caracteres, y no puede empezar con guion bajo (`_`) ni contener puntos. Si escribes un carácter no permitido, el panel descarta lo que escribiste y muestra el aviso "Los nombres de campos no pueden empezar con guión ni contener puntos". Ese aviso dice "guión", pero lo que la plataforma rechaza es el guion bajo inicial: un nombre que empiece con guion medio se guarda sin problema.
 - **Indicación**: Texto de ayuda opcional. Se muestra bajo el campo al crear o modificar una entrada, para orientar a quien la completa.
 - **Requerido**: Al crear o modificar una entrada, se debe proporcionar un valor para ese campo. De lo contrario, no podrás guardar los cambios realizados.
 
@@ -84,7 +84,7 @@ Eliminar un campo de un tipo borra el valor de ese campo en todas las entradas d
 
 ### Texto de una línea
 
-Este campo te permite ingresar textos de una sola linea, con un tope de 255 caracteres. Si necesitas guardar un texto más largo, usa [Texto de múltiples líneas](#texto-de-multiples-lineas). Cuenta con las siguientes restricciones:
+Este campo te permite ingresar textos de una sola línea, con un tope de 255 caracteres. Si necesitas guardar un texto más largo, usa [Texto de múltiples líneas](#texto-de-multiples-lineas). Cuenta con las siguientes restricciones:
 
 - **Largo mínimo**: Permite exigir un mínimo de caracteres para el texto ingresado.
 - **Largo máximo**: Permite  limitar la cantidad máxima de caracteres para el texto ingresado.


### PR DESCRIPTION
## Cambios propuestos

### `docs/{es,en}/platform/content/types.md` y `content/spaces.md`

Las propiedades que comparten todos los campos de un tipo, los límites del tipo y sus campos, el clonado, y —lo más importante— **qué pasa al eliminar un campo**: destruye el valor de ese campo en todas las entradas del tipo, de forma irreversible. Era la única pérdida de datos irreversible de este bloque y no estaba advertida en ninguna parte.

## Un gap saltado, con evidencia

La ficha pedía documentar «la acción de reindexación completa del espacio». **En master no existe tal acción independiente**: la clave de traducción que la ficha citaba se usa en un solo lugar y no corresponde a una acción propia. Es una ficha del plan que quedó desactualizada.

Closes #1078

Gaps: `CONTENT-15`, `CONTENT-17`, `CONTENT-20`, `CONTENT-26`

🤖 Generated with [Claude Code](https://claude.com/claude-code)